### PR TITLE
DT-522 LDAP login endpoint

### DIFF
--- a/auth-service/build.gradle.kts
+++ b/auth-service/build.gradle.kts
@@ -37,7 +37,6 @@ dependencies {
     implementation("io.ktor:ktor-serialization-kotlinx-json-jvm:$ktor_version")
     implementation("io.ktor:ktor-server-netty-jvm:$ktor_version")
     implementation("io.ktor:ktor-network-tls-certificates:$ktor_version")
-    implementation("io.ktor:ktor-server-auth-ldap:$ktor_version")
     implementation("io.ktor:ktor-server-thymeleaf:$ktor_version")
     implementation("io.ktor:ktor-server-thymeleaf-jvm:$ktor_version")
     implementation("ch.qos.logback:logback-classic:$logback_version")

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Application.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Application.kt
@@ -34,6 +34,6 @@ fun Application.module() {
     configureSecurity()
     configureMonitoring()
     configureSerialization()
-    configureTemplating()
+    configureTemplating(developmentMode)
     configureRouting()
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -1,9 +1,11 @@
 package uk.gov.communities.delta.auth
 
+import uk.gov.communities.delta.auth.config.LDAPConfig
 import uk.gov.communities.delta.auth.config.SAMLConfig
 import uk.gov.communities.delta.auth.controllers.GenerateSAMLTokenController
 import uk.gov.communities.delta.auth.controllers.PublicDeltaLoginController
 import uk.gov.communities.delta.auth.saml.SAMLTokenService
+import uk.gov.communities.delta.auth.security.ADLdapLoginService
 import uk.gov.communities.delta.auth.security.LdapAuthenticationService
 
 class Injection {
@@ -13,8 +15,15 @@ class Injection {
             return SAMLTokenService(signingCredentials)
         }
 
-        fun ldapAuthenticationService(): LdapAuthenticationService {
-            return LdapAuthenticationService()
+        fun ldapServiceUserAuthenticationService(): LdapAuthenticationService {
+            val ldapService = ADLdapLoginService(
+                ADLdapLoginService.Configuration(
+                    LDAPConfig.DELTA_LDAP_URL,
+                    LDAPConfig.LDAP_SERVICE_USER_DN_FORMAT,
+                    LDAPConfig.LDAP_GROUP_DN_FORMAT
+                )
+            )
+            return LdapAuthenticationService(ldapService, LDAPConfig.SERVICE_USER_GROUP_CN)
         }
 
         fun generateSAMLTokenController(): GenerateSAMLTokenController {
@@ -22,7 +31,14 @@ class Injection {
         }
 
         fun publicDeltaLoginController(): PublicDeltaLoginController {
-            return PublicDeltaLoginController()
+            val ldapService = ADLdapLoginService(
+                ADLdapLoginService.Configuration(
+                    LDAPConfig.DELTA_LDAP_URL,
+                    LDAPConfig.LDAP_DELTA_USER_DN_FORMAT,
+                    LDAPConfig.LDAP_GROUP_DN_FORMAT
+                )
+            )
+            return PublicDeltaLoginController(ldapService)
         }
     }
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -2,52 +2,57 @@ package uk.gov.communities.delta.auth
 
 import uk.gov.communities.delta.auth.config.LDAPConfig
 import uk.gov.communities.delta.auth.config.SAMLConfig
-import uk.gov.communities.delta.auth.controllers.internal.GenerateSAMLTokenController
 import uk.gov.communities.delta.auth.controllers.external.DeltaLoginController
+import uk.gov.communities.delta.auth.controllers.internal.GenerateSAMLTokenController
 import uk.gov.communities.delta.auth.controllers.internal.OAuthTokenController
 import uk.gov.communities.delta.auth.saml.SAMLTokenService
-import uk.gov.communities.delta.auth.security.ADLdapLoginServiceImpl
+import uk.gov.communities.delta.auth.security.ADLdapLoginService
 import uk.gov.communities.delta.auth.security.LdapAuthenticationService
 import uk.gov.communities.delta.auth.services.AuthorizationCodeService
+import uk.gov.communities.delta.auth.services.LdapService
+import uk.gov.communities.delta.auth.services.UserLookupService
 
 class Injection {
     companion object {
-
         private val authorizationCodeService = AuthorizationCodeService()
-
-        private fun samlTokenService(): SAMLTokenService {
-            val signingCredentials = SAMLConfig.getSAMLSigningCredentials()
-            return SAMLTokenService(signingCredentials)
-        }
+        private val samlTokenService = SAMLTokenService(SAMLConfig.getSAMLSigningCredentials())
+        private val ldapService = LdapService(
+            LdapService.Configuration(
+                ldapUrl = LDAPConfig.DELTA_LDAP_URL,
+                groupDnFormat = LDAPConfig.LDAP_GROUP_DN_FORMAT
+            )
+        )
+        private val userLookupService = UserLookupService(
+            UserLookupService.Configuration(
+                LDAPConfig.LDAP_DELTA_USER_DN_FORMAT,
+                LDAPConfig.ldapAuthServiceUserDn,
+                LDAPConfig.LDAP_AUTH_SERVICE_USER_PASSWORD,
+            ),
+            ldapService
+        )
 
         fun ldapServiceUserAuthenticationService(): LdapAuthenticationService {
-            val ldapService = ADLdapLoginServiceImpl(
-                ADLdapLoginServiceImpl.Configuration(
-                    LDAPConfig.DELTA_LDAP_URL,
-                    LDAPConfig.LDAP_SERVICE_USER_DN_FORMAT,
-                    LDAPConfig.LDAP_GROUP_DN_FORMAT
-                )
+            val adLoginService = ADLdapLoginService(
+                ADLdapLoginService.Configuration(LDAPConfig.LDAP_SERVICE_USER_DN_FORMAT),
+                ldapService
             )
-            return LdapAuthenticationService(ldapService, LDAPConfig.SERVICE_USER_GROUP_CN)
+            return LdapAuthenticationService(adLoginService, LDAPConfig.SERVICE_USER_GROUP_CN)
         }
 
-        fun generateSAMLTokenController(): GenerateSAMLTokenController {
-            return GenerateSAMLTokenController(samlTokenService())
-        }
+        fun generateSAMLTokenController() = GenerateSAMLTokenController(samlTokenService)
 
         fun externalDeltaLoginController(): DeltaLoginController {
-            val ldapService = ADLdapLoginServiceImpl(
-                ADLdapLoginServiceImpl.Configuration(
-                    LDAPConfig.DELTA_LDAP_URL,
-                    LDAPConfig.LDAP_DELTA_USER_DN_FORMAT,
-                    LDAPConfig.LDAP_GROUP_DN_FORMAT
-                )
+            val adLoginService = ADLdapLoginService(
+                ADLdapLoginService.Configuration(LDAPConfig.LDAP_DELTA_USER_DN_FORMAT),
+                ldapService
             )
-            return DeltaLoginController(ldapService, authorizationCodeService)
+            return DeltaLoginController(adLoginService, authorizationCodeService)
         }
 
-        fun internalOAuthTokenController(): OAuthTokenController {
-            return OAuthTokenController(authorizationCodeService)
-        }
+        fun internalOAuthTokenController() = OAuthTokenController(
+            authorizationCodeService,
+            userLookupService,
+            samlTokenService,
+        )
     }
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -5,7 +5,7 @@ import uk.gov.communities.delta.auth.config.SAMLConfig
 import uk.gov.communities.delta.auth.controllers.GenerateSAMLTokenController
 import uk.gov.communities.delta.auth.controllers.PublicDeltaLoginController
 import uk.gov.communities.delta.auth.saml.SAMLTokenService
-import uk.gov.communities.delta.auth.security.ADLdapLoginService
+import uk.gov.communities.delta.auth.security.ADLdapLoginServiceImpl
 import uk.gov.communities.delta.auth.security.LdapAuthenticationService
 
 class Injection {
@@ -16,8 +16,8 @@ class Injection {
         }
 
         fun ldapServiceUserAuthenticationService(): LdapAuthenticationService {
-            val ldapService = ADLdapLoginService(
-                ADLdapLoginService.Configuration(
+            val ldapService = ADLdapLoginServiceImpl(
+                ADLdapLoginServiceImpl.Configuration(
                     LDAPConfig.DELTA_LDAP_URL,
                     LDAPConfig.LDAP_SERVICE_USER_DN_FORMAT,
                     LDAPConfig.LDAP_GROUP_DN_FORMAT
@@ -31,8 +31,8 @@ class Injection {
         }
 
         fun publicDeltaLoginController(): PublicDeltaLoginController {
-            val ldapService = ADLdapLoginService(
-                ADLdapLoginService.Configuration(
+            val ldapService = ADLdapLoginServiceImpl(
+                ADLdapLoginServiceImpl.Configuration(
                     LDAPConfig.DELTA_LDAP_URL,
                     LDAPConfig.LDAP_DELTA_USER_DN_FORMAT,
                     LDAPConfig.LDAP_GROUP_DN_FORMAT

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
@@ -5,7 +5,6 @@ import io.ktor.server.auth.*
 import io.ktor.server.http.content.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import uk.gov.communities.delta.auth.controllers.PublicDeltaLoginController
 import uk.gov.communities.delta.auth.plugins.addUsernameToMdc
 import uk.gov.communities.delta.auth.security.CLIENT_AUTH_NAME
 import uk.gov.communities.delta.auth.security.DELTA_AD_LDAP_SERVICE_USERS_AUTH_NAME
@@ -38,7 +37,10 @@ fun Route.externalRoutes() {
         route("/delta") {
             route("/login") {
                 get {
-                    publicDeltaLoginController.getLoginPage(call)
+                    publicDeltaLoginController.loginGet(call)
+                }
+                post {
+                    publicDeltaLoginController.loginPost(call)
                 }
             }
         }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
@@ -51,8 +51,8 @@ fun Route.externalRoutes() {
 fun Route.internalRoutes() {
     val generateSAMLTokenController = Injection.generateSAMLTokenController()
 
-    authenticate(CLIENT_AUTH_NAME, strategy = AuthenticationStrategy.Required) {
-        route("/auth-internal") {
+    route("/auth-internal") {
+        authenticate(CLIENT_AUTH_NAME, strategy = AuthenticationStrategy.Required) {
             authenticate(DELTA_AD_LDAP_SERVICE_USERS_AUTH_NAME, strategy = AuthenticationStrategy.Required) {
                 install(addUsernameToMdc)
                 route("/service-user") {
@@ -65,6 +65,16 @@ fun Route.internalRoutes() {
                     }
                 }
             }
+        }
+        post("/token") {
+            // TODO
+            // Should no-cache
+            call.respond(mapOf(
+                "access_token" to "my_access_token",
+                "token_type" to "bearer",
+                "expires_in" to "43200",
+                "delta_user" to "delta.admin",
+            ))
         }
     }
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
@@ -30,7 +30,7 @@ fun Route.healthcheckRoute() {
 }
 
 fun Route.externalRoutes() {
-    val publicDeltaLoginController = Injection.publicDeltaLoginController()
+    val publicDeltaLoginController = Injection.externalDeltaLoginController()
 
     route("/auth-external") {
         staticResources("/static", "static")
@@ -50,6 +50,7 @@ fun Route.externalRoutes() {
 // "Internal" to the VPC, this is enforced by load balancer rules
 fun Route.internalRoutes() {
     val generateSAMLTokenController = Injection.generateSAMLTokenController()
+    val oAuthTokenController = Injection.internalOAuthTokenController()
 
     route("/auth-internal") {
         authenticate(CLIENT_AUTH_NAME, strategy = AuthenticationStrategy.Required) {
@@ -69,12 +70,7 @@ fun Route.internalRoutes() {
         post("/token") {
             // TODO
             // Should no-cache
-            call.respond(mapOf(
-                "access_token" to "my_access_token",
-                "token_type" to "bearer",
-                "expires_in" to "43200",
-                "delta_user" to "delta.admin",
-            ))
+            oAuthTokenController.getToken(call)
         }
     }
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/ClientConfig.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/ClientConfig.kt
@@ -3,5 +3,6 @@ package uk.gov.communities.delta.auth.config
 class ClientConfig {
     companion object {
         val CLIENT_SECRET_MARKLOGIC = System.getenv("CLIENT_SECRET_MARKLOGIC") ?: "dev-marklogic-client-secret"
+        val CLIENT_SECRET_DELTA_WEBSITE = System.getenv("CLIENT_SECRET_DELTA_WEBSITE") ?: "dev-delta-website-client-secret"
     }
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/DeltaConfig.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/DeltaConfig.kt
@@ -5,6 +5,7 @@ import org.slf4j.spi.LoggingEventBuilder
 class DeltaConfig {
     companion object {
         val DELTA_WEBSITE_URL = System.getenv("DELTA_WEBSITE_URL") ?: "http://localhost:8080"
+        const val REQUIRED_GROUP_CN = "datamart-delta-user"
 
         fun log(logger: LoggingEventBuilder) {
             logger

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/LDAPConfig.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/LDAPConfig.kt
@@ -7,13 +7,18 @@ class LDAPConfig {
         val DELTA_LDAP_URL = System.getenv("DELTA_LDAP_URL") ?: "ldap://localhost:2389"
         val LDAP_SERVICE_USER_DN_FORMAT =
             System.getenv("LDAP_SERVICE_USER_DN_FORMAT") ?: "CN=%s,OU=Users,OU=dluhctest,DC=dluhctest,DC=local"
+        val LDAP_DELTA_USER_DN_FORMAT =
+            System.getenv("LDAP_DELTA_USER_DN_FORMAT")
+                ?: "CN=%s,CN=Datamart,OU=Users,OU=dluhctest,DC=dluhctest,DC=local"
         val LDAP_GROUP_DN_FORMAT =
             System.getenv("LDAP_GROUP_DN_FORMAT") ?: "CN=%s,OU=Groups,OU=dluhctest,DC=dluhctest,DC=local"
+        const val SERVICE_USER_GROUP_CN = "dluhc-service-users"
 
         fun log(logger: LoggingEventBuilder) {
             logger
                 .addKeyValue("DELTA_LDAP_URL", DELTA_LDAP_URL)
                 .addKeyValue("LDAP_SERVICE_USER_DN_FORMAT", LDAP_SERVICE_USER_DN_FORMAT)
+                .addKeyValue("LDAP_DELTA_USER_DN_FORMAT", LDAP_DELTA_USER_DN_FORMAT)
                 .addKeyValue("LDAP_GROUP_DN_FORMAT", LDAP_GROUP_DN_FORMAT)
                 .log("LDAP config")
         }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/LDAPConfig.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/LDAPConfig.kt
@@ -13,6 +13,11 @@ class LDAPConfig {
         val LDAP_GROUP_DN_FORMAT =
             System.getenv("LDAP_GROUP_DN_FORMAT") ?: "CN=%s,OU=Groups,OU=dluhctest,DC=dluhctest,DC=local"
         const val SERVICE_USER_GROUP_CN = "dluhc-service-users"
+        private val LDAP_AUTH_SERVICE_USER = System.getenv("LDAP_AUTH_SERVICE_USER") ?: "delta.app"
+        val ldapAuthServiceUserDn = LDAP_SERVICE_USER_DN_FORMAT.format(LDAP_AUTH_SERVICE_USER)
+        val LDAP_AUTH_SERVICE_USER_PASSWORD = System.getenv("LDAP_AUTH_SERVICE_USER_PASSWORD") ?: throw Exception("Environment variable LDAP_AUTH_SERVICE_USER_PASSWORD is required")
+
+        val VALID_USERNAME_REGEX = Regex("^[\\w-.!]+$")
 
         fun log(logger: LoggingEventBuilder) {
             logger
@@ -20,6 +25,7 @@ class LDAPConfig {
                 .addKeyValue("LDAP_SERVICE_USER_DN_FORMAT", LDAP_SERVICE_USER_DN_FORMAT)
                 .addKeyValue("LDAP_DELTA_USER_DN_FORMAT", LDAP_DELTA_USER_DN_FORMAT)
                 .addKeyValue("LDAP_GROUP_DN_FORMAT", LDAP_GROUP_DN_FORMAT)
+                .addKeyValue("LDAP_AUTH_SERVICE_USER", LDAP_AUTH_SERVICE_USER)
                 .log("LDAP config")
         }
     }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/PublicDeltaLoginController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/PublicDeltaLoginController.kt
@@ -1,18 +1,118 @@
 package uk.gov.communities.delta.auth.controllers
 
 import io.ktor.server.application.*
+import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.thymeleaf.*
+import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.config.DeltaConfig
+import uk.gov.communities.delta.auth.security.ADLdapLoginService
+import uk.gov.communities.delta.auth.security.LdapUser
 
-class PublicDeltaLoginController {
-    suspend fun getLoginPage(call: ApplicationCall) {
-        call.respond(
-            ThymeleafContent(
-                "delta-login", mapOf(
-                    "deltaUrl" to DeltaConfig.DELTA_WEBSITE_URL
-                )
+
+class PublicDeltaLoginController(private val ldapService: ADLdapLoginService) {
+    private val logger = LoggerFactory.getLogger(this.javaClass)
+
+    suspend fun loginGet(call: ApplicationCall) {
+        call.respondLoginPage()
+    }
+
+    private suspend fun ApplicationCall.respondLoginPage(
+        errorMessage: String = "", errorLink: String = "#", username: String = "", password: String = ""
+    ) = respond(
+        ThymeleafContent(
+            "delta-login",
+            mapOf(
+                "deltaUrl" to DeltaConfig.DELTA_WEBSITE_URL,
+                "errorMessage" to errorMessage,
+                "errorLink" to errorLink,
+                "username" to username,
+                "password" to password,
             )
         )
+    )
+
+    suspend fun loginPost(call: ApplicationCall) {
+        val formParameters = call.receiveParameters()
+        val formUsername = formParameters["username"]
+        val password = formParameters["password"]
+
+        if (formUsername.isNullOrEmpty()) return call.respondLoginPage(
+            errorMessage = "Username is required", errorLink = "#username"
+        )
+        if (password.isNullOrEmpty()) return call.respondLoginPage(
+            errorMessage = "Password is required",
+            errorLink = "#password",
+            username = formUsername,
+        )
+
+        val cn = formUsername.replace('@', '!')
+        when (val loginResult = ldapService.ldapLogin(cn, password)) {
+            is ADLdapLoginService.LdapLoginSuccess -> {
+                if (!loginResult.user.isMemberOfDeltaGroup()) {
+                    logger.atInfo().addKeyValue("username", cn).addKeyValue("loginFailureType", "NotDeltaUser")
+                        .log("Login failed")
+                    call.respondLoginPage(
+                        errorMessage = "Your account exists but is not set up to access Delta. Please contact the Service Desk.",
+                        errorLink = DeltaConfig.DELTA_WEBSITE_URL + "/contact-us",
+                        username = formUsername,
+                        password = password,
+                    )
+                }
+
+                logger.atInfo().addKeyValue("username", cn).log("Successful login")
+                call.respondText("Successful login $cn")
+            }
+
+            is ADLdapLoginService.LdapLoginFailure -> {
+                // There's a risk of logging passwords accidentally typed into the username box,
+                // but we're accepting that here for the convenience of being able to see failed logins
+                logger.atInfo().addKeyValue("username", cn)
+                    .addKeyValue("loginFailureType", loginResult.javaClass.simpleName).log("Login failed")
+                val userVisibleError = userVisibleError(loginResult)
+                call.respondLoginPage(
+                    errorMessage = userVisibleError.errorMessage,
+                    errorLink = userVisibleError.link ?: "#",
+                    username = formUsername,
+                    password = password
+                )
+            }
+        }
+    }
+
+    private data class LoginError(val errorMessage: String, val link: String?)
+
+    private fun userVisibleError(ldapError: ADLdapLoginService.LdapLoginFailure): LoginError {
+        return when (ldapError) {
+            is ADLdapLoginService.DisabledAccount -> LoginError(
+                "Your account has been disabled. Please contact the Service Desk",
+                DeltaConfig.DELTA_WEBSITE_URL + "/contact-us"
+
+            )
+
+            is ADLdapLoginService.ExpiredPassword -> LoginError(
+                "Your password has expired. Please reset your password.",
+                DeltaConfig.DELTA_WEBSITE_URL + "/forgot-password"
+            )
+
+            is ADLdapLoginService.PasswordNeedsReset -> LoginError(
+                "Your password has expired. Please reset your password.",
+                DeltaConfig.DELTA_WEBSITE_URL + "/forgot-password"
+            )
+
+            is ADLdapLoginService.BadConnection -> LoginError(
+                "Error connecting to LDAP server. If this persists please contact the Service Desk",
+                DeltaConfig.DELTA_WEBSITE_URL + "/contact-us"
+            )
+
+            else -> LoginError(INVALID_LOGIN_MESSAGE, null)
+        }
+    }
+
+    private fun LdapUser.isMemberOfDeltaGroup() = memberOfCNs.contains(DeltaConfig.REQUIRED_GROUP_CN)
+
+    companion object {
+        const val INVALID_LOGIN_MESSAGE =
+            "Your username or password are incorrect. Please try again or reset your password. Five incorrect login attempts will lock your account for 30 minutes, you may have to try later."
     }
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/PublicDeltaLoginController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/PublicDeltaLoginController.kt
@@ -105,14 +105,12 @@ class PublicDeltaLoginController(private val ldapService: ADLdapLoginService) {
                 DeltaConfig.DELTA_WEBSITE_URL + "/contact-us"
             )
 
-            else -> LoginError(INVALID_LOGIN_MESSAGE, null)
+            else -> LoginError(
+                "Your username or password are incorrect. Please try again or reset your password. Five incorrect login attempts will lock your account for 30 minutes, you may have to try later.",
+                null
+            )
         }
     }
 
     private fun LdapUser.isMemberOfDeltaGroup() = memberOfCNs.contains(DeltaConfig.REQUIRED_GROUP_CN)
-
-    companion object {
-        const val INVALID_LOGIN_MESSAGE =
-            "Your username or password are incorrect. Please try again or reset your password. Five incorrect login attempts will lock your account for 30 minutes, you may have to try later."
-    }
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaLoginController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaLoginController.kt
@@ -63,6 +63,7 @@ class DeltaLoginController(
         val formParameters = call.receiveParameters()
         val formUsername = formParameters["username"]
         val password = formParameters["password"]
+        val state = call.request.queryParameters["state"]!!
 
         if (formUsername.isNullOrEmpty()) return call.respondLoginPage(
             errorMessage = "Username is required", errorLink = "#username"
@@ -101,10 +102,9 @@ class DeltaLoginController(
                     )
                 }
 
-                logger.atInfo().addKeyValue("username", cn).log("Successful login")
-
-                val state = call.request.queryParameters["state"]!!
                 val authCode = authenticationCodeService.generateAndStore(loginResult.user.cn)
+
+                logger.atInfo().addKeyValue("username", cn).log("Successful login")
                 call.respondRedirect(DeltaConfig.DELTA_WEBSITE_URL + "/login/oauth2/redirect?code=${authCode}&state=${state.encodeURLQueryComponent()}")
             }
         }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/GenerateSAMLTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/GenerateSAMLTokenController.kt
@@ -23,12 +23,12 @@ class GenerateSAMLTokenController(private val samlTokenService: SAMLTokenService
         val validTo = validFrom.plus(SAMLConfig.SAML_TOKEN_EXPIRY_HOURS.toLong(), ChronoUnit.HOURS)
             .truncatedTo(ChronoUnit.SECONDS)
 
-        val token = samlTokenService.generate(user, validFrom, validTo)
+        val token = samlTokenService.generate(user.ldapUser, validFrom, validTo)
         val encodedToken = base64Encode(token)
 
         call.respond(
             GenerateSAMLTokenResponse(
-                username = user.cn,
+                username = user.ldapUser.cn,
                 token = encodedToken,
                 expiry = DateTimeFormatter.ISO_INSTANT.format(validTo),
             )

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/GenerateSAMLTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/GenerateSAMLTokenController.kt
@@ -1,4 +1,4 @@
-package uk.gov.communities.delta.auth.controllers
+package uk.gov.communities.delta.auth.controllers.internal
 
 import io.ktor.server.application.*
 import io.ktor.server.auth.*

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/OAuthTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/OAuthTokenController.kt
@@ -5,16 +5,26 @@ import io.ktor.server.plugins.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.util.*
+import kotlinx.serialization.Serializable
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.config.ClientConfig
+import uk.gov.communities.delta.auth.saml.SAMLTokenService
 import uk.gov.communities.delta.auth.services.IAuthorizationCodeService
+import uk.gov.communities.delta.auth.services.LdapUser
+import uk.gov.communities.delta.auth.services.UserLookupService
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
+import java.time.Instant
 
 class OAuthTokenController(
-    private val authorizationCodeService: IAuthorizationCodeService
+    private val authorizationCodeService: IAuthorizationCodeService,
+    private val userLookupService: UserLookupService,
+    private val samlTokenService: SAMLTokenService,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
+    companion object {
+        private const val TOKEN_EXPIRY_SECONDS = 43200L
+    }
 
     suspend fun getToken(call: ApplicationCall) {
         val params = call.receiveParameters()
@@ -32,20 +42,41 @@ class OAuthTokenController(
         }
 
         val authCode = authorizationCodeService.lookupAndInvalidate(code) ?: throw BadRequestException("Invalid code")
+        val user = userLookupService.lookupUserByCn(authCode.userCn)
+        val samlToken = samlToken(user)
+
+        logger.atInfo().addKeyValue("username", user.cn).log("Successful token request")
 
         call.respond(
-            mapOf(
-                "access_token" to "unused_for_now",
-                "token_type" to "bearer",
-                "expires_in" to "43200",
-                "delta_user" to authCode.userCn,
+            AccessTokenResponse(
+                access_token = "unused_for_now",
+                delta_ldap_user = user,
+                saml_token = samlToken,
             )
         )
     }
+
+    @Suppress("PropertyName")
+    @Serializable
+    data class AccessTokenResponse(
+        val access_token: String,
+        val delta_ldap_user: LdapUser,
+        val saml_token: String,
+        // TODO remove
+        val delta_user: String = delta_ldap_user.cn,
+        val token_type: String = "bearer",
+        val expires_in: String = TOKEN_EXPIRY_SECONDS.toString(),
+    )
 
     private fun compareClientSecret(req: String, correct: String): Boolean {
         val requestClientSecretBytes = req.toByteArray(StandardCharsets.UTF_8)
         val correctSecretBytes = correct.toByteArray(StandardCharsets.UTF_8)
         return MessageDigest.isEqual(requestClientSecretBytes, correctSecretBytes)
+    }
+
+    private fun samlToken(user: LdapUser): String {
+        val now = Instant.now()
+        val expiry = now.plusSeconds(TOKEN_EXPIRY_SECONDS)
+        return samlTokenService.generate(user, now, expiry)
     }
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/OAuthTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/OAuthTokenController.kt
@@ -1,0 +1,51 @@
+package uk.gov.communities.delta.auth.controllers.internal
+
+import io.ktor.server.application.*
+import io.ktor.server.plugins.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.util.*
+import org.slf4j.LoggerFactory
+import uk.gov.communities.delta.auth.config.ClientConfig
+import uk.gov.communities.delta.auth.services.IAuthorizationCodeService
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+class OAuthTokenController(
+    private val authorizationCodeService: IAuthorizationCodeService
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    suspend fun getToken(call: ApplicationCall) {
+        val params = call.receiveParameters()
+        val code = params.getOrFail("code")
+        val clientId = params.getOrFail("client_id")
+        val clientSecret = params.getOrFail("client_secret")
+
+        if (clientId != "delta-website") {
+            logger.error("Client id mismatch {}", clientId)
+            throw BadRequestException("Invalid client id")
+        }
+        if (!compareClientSecret(clientSecret, ClientConfig.CLIENT_SECRET_DELTA_WEBSITE)) {
+            logger.error("Invalid client secret for {}", clientId)
+            throw BadRequestException("Invalid client secret")
+        }
+
+        val authCode = authorizationCodeService.lookupAndInvalidate(code) ?: throw BadRequestException("Invalid code")
+
+        call.respond(
+            mapOf(
+                "access_token" to "unused_for_now",
+                "token_type" to "bearer",
+                "expires_in" to "43200",
+                "delta_user" to authCode.userCn,
+            )
+        )
+    }
+
+    private fun compareClientSecret(req: String, correct: String): Boolean {
+        val requestClientSecretBytes = req.toByteArray(StandardCharsets.UTF_8)
+        val correctSecretBytes = correct.toByteArray(StandardCharsets.UTF_8)
+        return MessageDigest.isEqual(requestClientSecretBytes, correctSecretBytes)
+    }
+}

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/Monitoring.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/Monitoring.kt
@@ -15,7 +15,7 @@ fun Application.configureMonitoring() {
     install(CallLogging) {
         level = Level.INFO
         callIdMdc("requestId")
-        mdc("username") { it.principal<DeltaLdapPrincipal>(DELTA_AD_LDAP_SERVICE_USERS_AUTH_NAME)?.cn }
+        mdc("username") { it.principal<DeltaLdapPrincipal>(DELTA_AD_LDAP_SERVICE_USERS_AUTH_NAME)?.username }
         disableDefaultColors()
     }
     install(CallId) {
@@ -41,7 +41,7 @@ internal object BeforeCall : Hook<suspend (ApplicationCall, suspend () -> Unit) 
 // The call logging plugin doesn't update the MDC after the authentication phase by default, so add as an extra step
 val addUsernameToMdc = createRouteScopedPlugin("AddUsernameToMdc") {
     on(BeforeCall) { call, proceed ->
-        val username = call.principal<DeltaLdapPrincipal>(DELTA_AD_LDAP_SERVICE_USERS_AUTH_NAME)!!.cn
+        val username = call.principal<DeltaLdapPrincipal>(DELTA_AD_LDAP_SERVICE_USERS_AUTH_NAME)!!.username
         val mdcContextMap = MDC.getCopyOfContextMap() ?: mutableMapOf()
         mdcContextMap["username"] = username
         withContext(MDCContext(mdcContextMap)) {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/Templating.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/Templating.kt
@@ -5,9 +5,9 @@ import io.ktor.server.thymeleaf.*
 import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver
 import org.thymeleaf.templateresolver.FileTemplateResolver
 
-fun Application.configureTemplating() {
+fun Application.configureTemplating(devMode: Boolean) {
     install(Thymeleaf) {
-        setTemplateResolver((if (developmentMode) {
+        setTemplateResolver((if (devMode) {
             log.info("Development mode, using templates from src/ folder")
             FileTemplateResolver().apply {
                 cacheManager = null

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/saml/SAMLTokenService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/saml/SAMLTokenService.kt
@@ -11,6 +11,7 @@ import org.opensaml.saml.saml2.core.impl.*
 import org.opensaml.security.x509.BasicX509Credential
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.security.DeltaLdapPrincipal
+import uk.gov.communities.delta.auth.services.LdapUser
 import java.io.StringWriter
 import java.time.Instant
 import java.util.*
@@ -30,13 +31,13 @@ class SAMLTokenService(basicCredentials: BasicX509Credential) {
         samlAssertionSigner = SAMLAssertionSigner(basicCredentials)
     }
 
-    fun generate(user: DeltaLdapPrincipal, validFrom: Instant, validTo: Instant): String {
+    fun generate(user: LdapUser, validFrom: Instant, validTo: Instant): String {
         if (!initialised.get()) {
             // Lazily initialise the OpenSAML library as it takes a second or so to start
             initialiseOpenSaml()
         }
         return try {
-            val roles = user.memberOfGroupCNs.filter { it.startsWith("datamart-delta-") }
+            val roles = user.memberOfCNs.filter { it.startsWith("datamart-delta-") }
             logger.debug("Generating SAML token for user {} with {} roles", user.cn, roles.size)
             val assertion = makeAssertionElement(user.cn, roles, validFrom, validTo)
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/ADLdapLoginService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/ADLdapLoginService.kt
@@ -1,0 +1,129 @@
+package uk.gov.communities.delta.auth.security
+
+import org.slf4j.LoggerFactory
+import java.util.*
+import javax.naming.AuthenticationException
+import javax.naming.CommunicationException
+import javax.naming.Context
+import javax.naming.NamingException
+import javax.naming.directory.Attributes
+import javax.naming.directory.InitialDirContext
+
+data class LdapUser(val cn: String, val memberOfCNs: List<String>)
+
+class ADLdapLoginService(private val config: Configuration) {
+
+    data class Configuration(val ldapUrl: String, val userDnFormat: String, val groupDnFormat: String)
+
+    private val logger = LoggerFactory.getLogger(this.javaClass)
+    private val groupCnRegex = Regex(config.groupDnFormat.replace("%s", "([\\w-]+)"))
+
+    fun ldapLogin(username: String, password: String): LdapLoginResult {
+        if (!username.matches(VALID_USERNAME_REGEX)) {
+            logger.warn("Invalid username '{}'", username)
+            return InvalidUsername
+        }
+
+        val userDn = config.userDnFormat.format(username)
+
+        return ldapBind(userDn, password)
+    }
+
+    private fun ldapBind(userDn: String, password: String): LdapLoginResult {
+        val env = Hashtable<String, Any?>()
+        env[Context.INITIAL_CONTEXT_FACTORY] = "com.sun.jndi.ldap.LdapCtxFactory"
+        env[Context.PROVIDER_URL] = config.ldapUrl
+        env[Context.SECURITY_AUTHENTICATION] = "simple"
+        env[Context.SECURITY_PRINCIPAL] = userDn
+        env[Context.SECURITY_CREDENTIALS] = password
+
+        return try {
+            val context = InitialDirContext(env)
+            logger.debug("Successful bind for DN {}", userDn)
+            val user = mapContextToUser(context)
+            context.close()
+            LdapLoginSuccess(user)
+        } catch (e: NamingException) {
+            logger.debug("LDAP login failed for user $userDn", e)
+            handleLdapException(e)
+        }
+    }
+
+    private fun mapContextToUser(ctx: InitialDirContext): LdapUser {
+        val userDn = ctx.environment[Context.SECURITY_PRINCIPAL] as String
+        val attributes = ctx.getAttributes(userDn, arrayOf("cn", "memberOf"))
+
+        val cn = attributes.get("cn").get() as String
+        val memberOfGroupDNs = attributes.getMemberOfList()
+
+        val memberOfGroupCNs = memberOfGroupDNs.mapNotNull {
+            val match = groupCnRegex.matchEntire(it)
+            match?.groups?.get(1)?.value
+        }
+        return LdapUser(cn, memberOfGroupCNs)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun Attributes.getMemberOfList(): List<String> {
+        return get("memberOf").all.asSequence().toList() as List<String>
+    }
+
+    private fun handleLdapException(e: NamingException): LdapLoginFailure {
+        when (e) {
+            is AuthenticationException -> {
+                val subErrorCodeMatch = ACTIVE_DIRECTORY_SUB_ERROR_CODE_ERROR_MESSAGE_REGEX.find(e.message!!)
+                if (subErrorCodeMatch != null) {
+                    val subErrorCode = subErrorCodeMatch.groupValues[1]
+                    return activeDirectoryErrorCodes.getOrElse(subErrorCode) {
+                        logger.warn("Unknown AD sub error code $subErrorCode", e)
+                        UnknownAdSubErrorCode
+                    }
+                }
+                logger.warn("Authentication failure, no AD sub error code found", e)
+                return UnknownAuthenticationFailure
+            }
+
+            is CommunicationException -> {
+                logger.error("Failed to connect to LDAP server", e)
+                return BadConnection
+            }
+
+            else -> {
+                logger.warn("Unknown authentication failure", e)
+                return UnknownNamingException
+            }
+        }
+    }
+
+    sealed interface LdapLoginResult
+    class LdapLoginSuccess(val user: LdapUser) : LdapLoginResult
+    sealed class LdapLoginFailure() : LdapLoginResult
+
+    object BadConnection : LdapLoginFailure()
+    object UnknownNamingException : LdapLoginFailure()
+
+    object UnknownAuthenticationFailure : LdapLoginFailure()
+    object InvalidUsername : LdapLoginFailure()
+
+    open class ActiveDirectoryBindError(val code: String) : LdapLoginFailure()
+
+    object DisabledAccount : ActiveDirectoryBindError("533")
+    object AccountLocked : ActiveDirectoryBindError("775")
+    object ExpiredPassword : ActiveDirectoryBindError("532")
+    object PasswordNeedsReset : ActiveDirectoryBindError("773")
+    object InvalidUsernameOrPassword : ActiveDirectoryBindError("52e")
+    object UnknownAdSubErrorCode : ActiveDirectoryBindError("UNKNOWN")
+
+    private val activeDirectoryErrorCodes = listOf(
+        DisabledAccount,
+        AccountLocked,
+        ExpiredPassword,
+        PasswordNeedsReset,
+        InvalidUsernameOrPassword,
+    ).associateBy { it.code }
+
+    companion object {
+        private val VALID_USERNAME_REGEX = Regex("^[\\w-.!]+$")
+        private val ACTIVE_DIRECTORY_SUB_ERROR_CODE_ERROR_MESSAGE_REGEX = Regex(".*data\\s([0-9a-f]{3,4}).*")
+    }
+}

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/LdapAuthenticationService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/LdapAuthenticationService.kt
@@ -1,71 +1,42 @@
 package uk.gov.communities.delta.auth.security
 
 import io.ktor.server.auth.*
-import io.ktor.server.auth.ldap.*
 import kotlinx.serialization.Serializable
 import org.slf4j.LoggerFactory
-import uk.gov.communities.delta.auth.config.LDAPConfig
-import javax.naming.Context
-import javax.naming.directory.DirContext
 
 @Serializable
 data class DeltaLdapPrincipal(
     val cn: String,
-    val memberOfGroupDNs: List<String>,
-) : Principal {
-    val memberOfGroupCNs = memberOfGroupDNs.mapNotNull {
-        val match = LdapAuthenticationService.groupCnRegex.matchEntire(it)
-        match?.groups?.get(1)?.value
-    }
-}
+    val memberOfGroupCNs: List<String>,
+) : Principal
 
-class LdapAuthenticationService {
-    companion object {
-        val usernameRegex = Regex("^[\\w-.!]+$")
-        val groupCnRegex = Regex(LDAPConfig.LDAP_GROUP_DN_FORMAT.replace("%s", "([\\w-]+)"))
-    }
+class LdapAuthenticationService(private val ldapService: ADLdapLoginService, private val requiredGroupCN: String) {
 
     private val logger = LoggerFactory.getLogger(LdapAuthenticationService::class.java)
 
     fun authenticate(credential: UserPasswordCredential): DeltaLdapPrincipal? {
-        if (!credential.name.matches(usernameRegex)) {
-            logger.warn("Invalid username {}", credential.name)
-            return null
-        }
-
         logger.debug("Authenticating LDAP service user '{}'", credential.name)
-        val principal = ldapAuthenticate(
-            credential,
-            LDAPConfig.DELTA_LDAP_URL,
-            { env ->
-                env[Context.SECURITY_AUTHENTICATION] = "simple"
-                env[Context.SECURITY_PRINCIPAL] = LDAPConfig.LDAP_SERVICE_USER_DN_FORMAT.format(credential.name)
-                env[Context.SECURITY_CREDENTIALS] = credential.password
-            }
-        ) {
-            val userDn = environment["java.naming.security.principal"] as String
-            val memberOf = getMemberOfList(userDn)
 
-            if (memberOf.contains(LDAPConfig.LDAP_GROUP_DN_FORMAT.format("dluhc-service-users"))) {
-                logger.info("Authenticated user {}", it.name)
-                DeltaLdapPrincipal(it.name, memberOf)
-            } else {
-                logger.warn(
-                    "Authenticated user {}, but not member of dluhc-service-users", it.name
-                )
-                null
+        when (val loginResult = ldapService.ldapLogin(credential.name, credential.password)) {
+            is ADLdapLoginService.LdapLoginSuccess -> {
+                val user = loginResult.user
+                if (!user.memberOfCNs.contains(requiredGroupCN)) {
+                    logger.atWarn().addKeyValue("username", credential.name)
+                        .log("Authentication failed, user not member of required group {}", requiredGroupCN)
+                    return null
+                }
+
+                logger.atInfo().addKeyValue("username", credential.name).log("LDAP authentication success")
+                return DeltaLdapPrincipal(user.cn, user.memberOfCNs)
+            }
+
+            is ADLdapLoginService.LdapLoginFailure -> {
+                logger.atInfo()
+                    .addKeyValue("username", credential.name)
+                    .addKeyValue("loginFailureType", loginResult.javaClass.simpleName)
+                    .log("LDAP authentication failed")
+                return null
             }
         }
-        if (principal == null) {
-            logger.info("LDAP authentication failed for user '{}'", credential.name)
-        }
-        return principal
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun DirContext.getMemberOfList(userDn: String): List<String> {
-        return getAttributes(
-            userDn, arrayOf("memberOf")
-        ).get("memberOf").all.asSequence().toList() as List<String>
     }
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/Security.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/Security.kt
@@ -9,7 +9,7 @@ const val CLIENT_AUTH_NAME = "delta-client-header-auth"
 const val DELTA_AD_LDAP_SERVICE_USERS_AUTH_NAME = "delta-ldap-service-users-basic"
 
 fun Application.configureSecurity() {
-    val ldapAuthenticationService = Injection.ldapAuthenticationService()
+    val ldapAuthenticationService = Injection.ldapServiceUserAuthenticationService()
 
     authentication {
         basic(DELTA_AD_LDAP_SERVICE_USERS_AUTH_NAME) {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/AuthorizationCodeService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/AuthorizationCodeService.kt
@@ -21,7 +21,7 @@ data class AuthCode(val code: String, val userCn: String, val createdAt: Instant
 class AuthorizationCodeService : IAuthorizationCodeService {
     // TODO Should be stored in a database, and expired ones automatically deleted
     private val authCodes = ConcurrentHashMap<String, AuthCode>()
-    private val sr = SecureRandom()
+    private val sr: SecureRandom by lazy { SecureRandom() }
     private val logger = LoggerFactory.getLogger(javaClass)
 
     companion object {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/AuthorizationCodeService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/AuthorizationCodeService.kt
@@ -1,0 +1,58 @@
+package uk.gov.communities.delta.auth.services
+
+import net.logstash.logback.argument.StructuredArguments
+import org.slf4j.LoggerFactory
+import java.security.SecureRandom
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+interface IAuthorizationCodeService {
+    fun generateAndStore(userCn: String): String
+    fun lookupAndInvalidate(code: String): AuthCode?
+}
+
+// Assume we only have one client (delta-website)
+data class AuthCode(val code: String, val userCn: String, val createdAt: Instant) {
+    fun expired() = createdAt.plusSeconds(AuthorizationCodeService.AUTH_CODE_VALID_DURATION_SECONDS) < Instant.now()
+}
+
+class AuthorizationCodeService : IAuthorizationCodeService {
+    // TODO Should be stored in a database, and expired ones automatically deleted
+    private val authCodes = ConcurrentHashMap<String, AuthCode>()
+    private val sr = SecureRandom()
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    companion object {
+        const val AUTH_CODE_VALID_DURATION_SECONDS = 30L
+        const val AUTH_CODE_LENGTH_BYTES = 24
+    }
+
+    override fun generateAndStore(userCn: String): String {
+        val code = randomBase64()
+        val now = Instant.now()
+        val authCode = AuthCode(code, userCn, now)
+
+        authCodes[code] = authCode
+
+        logger.info("Generated auth code for user {} at {}", StructuredArguments.keyValue("username", userCn), now)
+        return code
+    }
+
+    @OptIn(ExperimentalEncodingApi::class)
+    private fun randomBase64(): String {
+        val bytes = ByteArray(AUTH_CODE_LENGTH_BYTES)
+        sr.nextBytes(bytes)
+        return Base64.UrlSafe.encode(bytes)
+    }
+
+    override fun lookupAndInvalidate(code: String): AuthCode? {
+        val entry = authCodes.remove(code) ?: return null
+        if (entry.expired()) {
+            logger.warn("Expired auth code {} for user {}", code, entry.userCn)
+            return null
+        }
+        return entry
+    }
+}

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserLookupService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserLookupService.kt
@@ -1,0 +1,22 @@
+package uk.gov.communities.delta.auth.services
+
+class UserLookupService(
+    private val config: Configuration,
+    private val ldapService: LdapService,
+) {
+    data class Configuration(
+        val userDnFormat: String,
+        val bindUserDn: String,
+        val bindUserPassword: String,
+    )
+
+    fun lookupUserByCn(cn: String): LdapUser {
+        val dn = config.userDnFormat.format(cn)
+        val ctx = ldapService.bind(config.bindUserDn, config.bindUserPassword, poolConnection = true)
+        try {
+            return ldapService.mapUserFromContext(ctx, dn)
+        } finally {
+            ctx.close()
+        }
+    }
+}

--- a/auth-service/src/main/resources/templates/thymeleaf/delta-login.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/delta-login.html
@@ -55,10 +55,29 @@
 </header>
 
 <!--/*@thymesVar id="deltaUrl" type="java.lang.String" */-->
+<!--/*@thymesVar id="errorMessage" type="java.lang.String" */-->
+<!--/*@thymesVar id="errorLink" type="java.lang.String" */-->
+<!--/*@thymesVar id="username" type="java.lang.String" */-->
+<!--/*@thymesVar id="password" type="java.lang.String" */-->
 
 <div class="govuk-width-container ">
     <main class="govuk-main-wrapper " id="main-content" role="main">
         <h1 class="govuk-heading-xl">Sign in to DELTA</h1>
+        <div th:if="${not #strings.isEmpty(errorMessage)}" class="govuk-error-summary"
+             data-module="govuk-error-summary">
+            <div role="alert">
+                <h2 class="govuk-error-summary__title">
+                    There is a problem
+                </h2>
+                <div class="govuk-error-summary__body">
+                    <ul class="govuk-list govuk-error-summary__list">
+                        <li>
+                            <a th:text="${errorMessage}" th:href="${errorLink}" href="#">Error message</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
                 <form action="/auth-external/delta/login" method="POST">
@@ -66,14 +85,15 @@
                         <label class="govuk-label" for="username">
                             Username
                         </label>
-                        <input class="govuk-input govuk-!-width-two-thirds" id="username" name="username" type="text">
+                        <input th:value="${username}" class="govuk-input govuk-!-width-two-thirds" id="username"
+                               name="username" type="text">
                     </div>
                     <div class="govuk-form-group">
                         <label class="govuk-label" for="password">
                             Password
                         </label>
-                        <input class="govuk-input govuk-!-width-two-thirds" id="password" name="event-name"
-                               type="password">
+                        <input th:value="${password}" class="govuk-input govuk-!-width-two-thirds" id="password"
+                               name="password" type="password">
                     </div>
                     <p>
                         You can <a th:href="${deltaUrl} + '/forgot-password'">reset your password here</a>

--- a/auth-service/src/main/resources/templates/thymeleaf/delta-login.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/delta-login.html
@@ -86,14 +86,14 @@
                             Username
                         </label>
                         <input th:value="${username}" class="govuk-input govuk-!-width-two-thirds" id="username"
-                               name="username" type="text">
+                               name="username" type="text" autocomplete="username">
                     </div>
                     <div class="govuk-form-group">
                         <label class="govuk-label" for="password">
                             Password
                         </label>
                         <input th:value="${password}" class="govuk-input govuk-!-width-two-thirds" id="password"
-                               name="password" type="password">
+                               name="password" type="password" autocomplete="current-password">
                     </div>
                     <p>
                         You can <a th:href="${deltaUrl} + '/forgot-password'">reset your password here</a>

--- a/auth-service/src/main/resources/templates/thymeleaf/delta-login.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/delta-login.html
@@ -80,7 +80,7 @@
         </div>
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-                <form action="/auth-external/delta/login" method="POST">
+                <form method="POST">
                     <div class="govuk-form-group">
                         <label class="govuk-label" for="username">
                             Username

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaLoginControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaLoginControllerTest.kt
@@ -14,10 +14,10 @@ import org.junit.Test
 import uk.gov.communities.delta.auth.config.DeltaConfig
 import uk.gov.communities.delta.auth.controllers.external.DeltaLoginController
 import uk.gov.communities.delta.auth.plugins.configureTemplating
-import uk.gov.communities.delta.auth.security.ADLdapLoginService
-import uk.gov.communities.delta.auth.security.LdapUser
+import uk.gov.communities.delta.auth.security.IADLdapLoginService
 import uk.gov.communities.delta.auth.services.AuthCode
 import uk.gov.communities.delta.auth.services.IAuthorizationCodeService
+import uk.gov.communities.delta.auth.services.LdapUser
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
@@ -34,7 +34,7 @@ class DeltaLoginControllerTest {
 
     @Test
     fun testLoginPostAccountDisabled() = testSuspend {
-        loginResult = ADLdapLoginService.DisabledAccount
+        loginResult = IADLdapLoginService.DisabledAccount
         testApp.client.submitForm(
             url = "/login",
             formParameters = parameters {
@@ -49,7 +49,7 @@ class DeltaLoginControllerTest {
 
     @Test
     fun testLoginPostNotInGroup() = testSuspend {
-        loginResult = ADLdapLoginService.LdapLoginSuccess(LdapUser("username", listOf()))
+        loginResult = IADLdapLoginService.LdapLoginSuccess(LdapUser("username", listOf()))
         testApp.client.submitForm(
             url = "/login",
             formParameters = parameters {
@@ -64,7 +64,7 @@ class DeltaLoginControllerTest {
 
     @Test
     fun testLoginPostSuccess() = testSuspend {
-        loginResult = ADLdapLoginService.LdapLoginSuccess(LdapUser("username", listOf(DeltaConfig.REQUIRED_GROUP_CN)))
+        loginResult = IADLdapLoginService.LdapLoginSuccess(LdapUser("username", listOf(DeltaConfig.REQUIRED_GROUP_CN)))
         testApp.client.submitForm(
             url = "/login",
             formParameters = parameters {
@@ -80,14 +80,14 @@ class DeltaLoginControllerTest {
 
     companion object {
         private lateinit var testApp: TestApplication
-        private lateinit var loginResult: ADLdapLoginService.LdapLoginResult
+        private lateinit var loginResult: IADLdapLoginService.LdapLoginResult
 
         @BeforeClass
         @JvmStatic
         fun setup() {
             val controller = DeltaLoginController(
-                object : ADLdapLoginService {
-                    override fun ldapLogin(username: String, password: String): ADLdapLoginService.LdapLoginResult {
+                object : IADLdapLoginService {
+                    override fun ldapLogin(username: String, password: String): IADLdapLoginService.LdapLoginResult {
                         return loginResult
                     }
                 },

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/PublicDeltaLoginControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/PublicDeltaLoginControllerTest.kt
@@ -1,0 +1,111 @@
+package uk.gov.communities.delta.controllers
+
+import io.ktor.client.request.*
+import io.ktor.client.request.forms.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import io.ktor.test.dispatcher.*
+import org.junit.AfterClass
+import org.junit.BeforeClass
+import org.junit.Test
+import uk.gov.communities.delta.auth.config.DeltaConfig
+import uk.gov.communities.delta.auth.controllers.PublicDeltaLoginController
+import uk.gov.communities.delta.auth.plugins.configureTemplating
+import uk.gov.communities.delta.auth.security.ADLdapLoginService
+import uk.gov.communities.delta.auth.security.LdapUser
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+
+
+class PublicDeltaLoginControllerTest {
+
+    @Test
+    fun testLoginPage() = testSuspend {
+        testApp.client.get("/login").apply {
+            assertEquals(HttpStatusCode.OK, status)
+            assertContains(bodyAsText(), "Sign in to DELTA")
+        }
+    }
+
+    @Test
+    fun testLoginPostAccountDisabled() = testSuspend {
+        loginResult = ADLdapLoginService.DisabledAccount
+        testApp.client.submitForm(
+            url = "/login",
+            formParameters = parameters {
+                append("username", "user")
+                append("password", "pass")
+            }
+        ).apply {
+            assertEquals(HttpStatusCode.OK, status)
+            assertContains(bodyAsText(), "Your account has been disabled")
+        }
+    }
+
+    @Test
+    fun testLoginPostNotInGroup() = testSuspend {
+        loginResult = ADLdapLoginService.LdapLoginSuccess(LdapUser("username", listOf()))
+        testApp.client.submitForm(
+            url = "/login",
+            formParameters = parameters {
+                append("username", "user")
+                append("password", "pass")
+            }
+        ).apply {
+            assertEquals(HttpStatusCode.OK, status)
+            assertContains(bodyAsText(), "Your account exists but is not set up to access Delta.")
+        }
+    }
+
+    @Test
+    fun testLoginPostSuccess() = testSuspend {
+        loginResult = ADLdapLoginService.LdapLoginSuccess(LdapUser("username", listOf(DeltaConfig.REQUIRED_GROUP_CN)))
+        testApp.client.submitForm(
+            url = "/login",
+            formParameters = parameters {
+                append("username", "user")
+                append("password", "pass")
+            }
+        ).apply {
+            // TODO DT-525 Clearly not the final behaviour!
+            assertEquals(HttpStatusCode.OK, status)
+            assertEquals(bodyAsText(), "Successful login user")
+        }
+    }
+
+    companion object {
+        private lateinit var testApp: TestApplication
+        private lateinit var loginResult: ADLdapLoginService.LdapLoginResult
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            val controller = PublicDeltaLoginController(object : ADLdapLoginService {
+                override fun ldapLogin(username: String, password: String): ADLdapLoginService.LdapLoginResult {
+                    return loginResult
+                }
+
+            })
+            testApp = TestApplication {
+                application {
+                    configureTemplating(false)
+                    routing {
+                        route("/login") {
+                            get { controller.loginGet(call) }
+                            post { controller.loginPost(call) }
+                        }
+                    }
+                }
+            }
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDown() {
+            testApp.stop()
+        }
+    }
+}

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/ClientHeaderAuthProviderTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/ClientHeaderAuthProviderTest.kt
@@ -1,7 +1,5 @@
 package uk.gov.communities.delta.security
 
-import io.ktor.client.*
-import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
@@ -14,7 +12,6 @@ import io.ktor.test.dispatcher.*
 import org.junit.AfterClass
 import org.junit.BeforeClass
 import org.junit.Test
-import uk.gov.communities.delta.auth.plugins.configureSerialization
 import uk.gov.communities.delta.auth.security.ClientHeaderAuthProvider
 import uk.gov.communities.delta.auth.security.clientHeaderAuth
 import kotlin.test.assertContains

--- a/terraform/modules/auth_service/main.tf
+++ b/terraform/modules/auth_service/main.tf
@@ -35,6 +35,10 @@ module "fargate" {
       value = var.ldap_config.LDAP_SERVICE_USER_DN_FORMAT
     },
     {
+      name  = "LDAP_DELTA_USER_DN_FORMAT"
+      value = var.ldap_config.LDAP_DELTA_USER_DN_FORMAT
+    },
+    {
       name  = "CA_S3_URL"
       value = var.ldap_config.CA_S3_URL
     },

--- a/terraform/modules/auth_service/main.tf
+++ b/terraform/modules/auth_service/main.tf
@@ -60,6 +60,10 @@ module "fargate" {
       name      = "CLIENT_SECRET_MARKLOGIC"
       valueFrom = aws_secretsmanager_secret.ml_client_secret.arn
     },
+    {
+      name      = "CLIENT_SECRET_DELTA_WEBSITE"
+      valueFrom = aws_secretsmanager_secret.delta_website_client_secret.arn
+    },
   ]
   secret_kms_key_arns = compact([var.ml_secret_kms_key_arn, data.aws_secretsmanager_secret.saml_certificate.kms_key_id])
 }

--- a/terraform/modules/auth_service/secrets.tf
+++ b/terraform/modules/auth_service/secrets.tf
@@ -27,3 +27,25 @@ resource "aws_secretsmanager_secret_version" "ml_client_secret" {
   secret_id     = aws_secretsmanager_secret.ml_client_secret.id
   secret_string = random_password.ml_client_secret.result
 }
+
+resource "random_password" "delta_website_client_secret" {
+  length  = 32
+  special = false
+}
+
+# No CMK, secret is shared between multiple services
+# tfsec:ignore:aws-ssm-secret-use-customer-key
+resource "aws_secretsmanager_secret" "delta_website_client_secret" {
+  name                    = "tf-${var.environment}-auth-delta-website-client-secret"
+  description             = "Shared secret for Delta Website -> auth service for internal API calls"
+  recovery_window_in_days = 0
+
+  tags = {
+    "delta-marklogic-deploy-read" : var.environment
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "delta_website_client_secret" {
+  secret_id     = aws_secretsmanager_secret.delta_website_client_secret.id
+  secret_string = random_password.delta_website_client_secret.result
+}

--- a/terraform/modules/auth_service/variables.tf
+++ b/terraform/modules/auth_service/variables.tf
@@ -44,6 +44,7 @@ variable "ldap_config" {
   type = object({
     DELTA_LDAP_URL              = string
     LDAP_SERVICE_USER_DN_FORMAT = string
+    LDAP_DELTA_USER_DN_FORMAT   = string
     LDAP_GROUP_DN_FORMAT        = string
     CA_S3_URL                   = string
   })

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -49,6 +49,7 @@ module "auth_service" {
     CA_S3_URL                   = "https://data-collection-service-ldaps-crl-production.s3.amazonaws.com/CASRVPRODUCTION/CASRVproduction.dluhcdata.local_CASRVproduction.crt"
     DELTA_LDAP_URL              = "ldaps://dluhcdata.local:636"
     LDAP_SERVICE_USER_DN_FORMAT = "CN=%s,OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"
+    LDAP_DELTA_USER_DN_FORMAT   = "CN=%s,CN=Datamart,OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"
     LDAP_GROUP_DN_FORMAT        = "CN=%s,OU=Groups,OU=dluhcdata,DC=dluhcdata,DC=local"
   }
   ecs = {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -49,6 +49,7 @@ module "auth_service" {
     CA_S3_URL                   = "https://data-collection-service-ldaps-crl-staging.s3.amazonaws.com/CASRVSTAGING/CASRVstaging.dluhcdata.local_CASRVstaging.crt"
     DELTA_LDAP_URL              = "ldaps://dluhcdata.local:636"
     LDAP_SERVICE_USER_DN_FORMAT = "CN=%s,OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"
+    LDAP_DELTA_USER_DN_FORMAT   = "CN=%s,CN=Datamart,OU=Users,OU=dluhcdata,DC=dluhcdata,DC=local"
     LDAP_GROUP_DN_FORMAT        = "CN=%s,OU=Groups,OU=dluhcdata,DC=dluhcdata,DC=local"
   }
   ecs = {

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -49,6 +49,7 @@ module "auth_service" {
     CA_S3_URL                   = "https://data-collection-service-ldaps-crl-test.s3.amazonaws.com/CASRVTEST/CASRVtest.dluhctest.local_CASRVtest.crt"
     DELTA_LDAP_URL              = "ldaps://dluhctest.local:636"
     LDAP_SERVICE_USER_DN_FORMAT = "CN=%s,OU=Users,OU=dluhctest,DC=dluhctest,DC=local"
+    LDAP_DELTA_USER_DN_FORMAT   = "CN=%s,CN=Datamart,OU=Users,OU=dluhctest,DC=dluhctest,DC=local"
     LDAP_GROUP_DN_FORMAT        = "CN=%s,OU=Groups,OU=dluhctest,DC=dluhctest,DC=local"
   }
 }


### PR DESCRIPTION
Implement a login endpoint. Required copying `ldapAuthenticate` from Ktor and adding some AD-specific error handling which I've copied from Delta's `MyActiveDirectoryLdapAuthenticationProvider` and tested some, but not all of the cases.