### PR TITLE
Switch from Mockito to mockk

### DIFF
--- a/auth-service/build.gradle.kts
+++ b/auth-service/build.gradle.kts
@@ -65,7 +65,7 @@ dependencies {
 
     testImplementation("io.ktor:ktor-server-tests-jvm:$ktorVersion")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion")
-    testImplementation("org.mockito.kotlin:mockito-kotlin:5.0.0")
+    testImplementation("io.mockk:mockk:1.13.5")
 }
 
 // Migrations are run by the application on startup, or on first use of the database in Development mode.

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/helper/TestClient.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/helper/TestClient.kt
@@ -1,8 +1,8 @@
 package uk.gov.communities.delta.helper
 
-import org.mockito.Mockito
+import io.mockk.mockk
 import uk.gov.communities.delta.auth.config.OAuthClient
 
 fun testServiceClient(clientId: String = "delta-website"): OAuthClient {
-    return OAuthClient(clientId, "client-secret", Mockito.mock(), "https://delta/redirect")
+    return OAuthClient(clientId, "client-secret", mockk(), "https://delta/redirect")
 }


### PR DESCRIPTION
I wanted to be consistent, but Mockito struggles with suspending functions and non-nullable parameters, so switching to <https://mockk.io/>.