### PR TITLE
Skip logging healthchecks

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
@@ -14,6 +14,7 @@ import uk.gov.communities.delta.auth.plugins.addBearerSessionInfoToMDC
 import uk.gov.communities.delta.auth.plugins.addClientIdToMDC
 import uk.gov.communities.delta.auth.plugins.addServiceUserUsernameToMDC
 import uk.gov.communities.delta.auth.security.*
+import java.io.File
 
 fun Application.configureRouting(injection: Injection) {
     routing {
@@ -32,6 +33,11 @@ fun Route.healthcheckRoute() {
 fun Route.externalRoutes(deltaLoginController: DeltaLoginController) {
 
     staticResources("/static", "static")
+    // We override the link in our HTML, but this saves us some spurious 404s when browsers request it anyway
+    get("/favicon.ico") {
+        call.respondFile(File(javaClass.classLoader.getResource("static/assets/images/favicon.ico")!!.toURI()))
+    }
+
     rateLimit(RateLimitName(loginRateLimitName)) {
         route("/delta/login") {
             deltaLoginController.loginRoutes(this)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/Monitoring.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/Monitoring.kt
@@ -1,10 +1,12 @@
 package uk.gov.communities.delta.auth.plugins
 
+import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.plugins.*
 import io.ktor.server.plugins.callid.*
 import io.ktor.server.plugins.callloging.*
+import io.ktor.server.request.*
 import kotlinx.coroutines.slf4j.MDCContext
 import kotlinx.coroutines.withContext
 import org.slf4j.MDC
@@ -19,6 +21,7 @@ fun Application.configureMonitoring() {
     install(CallLogging) {
         level = Level.INFO
         callIdMdc("requestId")
+        filter { it.request.path() != "/health" }
         mdc("username") { it.principal<DeltaLdapPrincipal>(DELTA_AD_LDAP_SERVICE_USERS_AUTH_NAME)?.username }
         mdc("IPAddress") { it.request.origin.remoteHost }
         disableDefaultColors()


### PR DESCRIPTION
They're very noisy in the logs at the moment.

Plus add a path for /favicon.ico to get rid of some 404s