### PR TITLE
DT-523

### DIFF
--- a/auth-service/README.md
+++ b/auth-service/README.md
@@ -11,7 +11,7 @@
 
 ## Run
 
-* Start with `./gradlew run`
+* Start with `./gradlew run` (to run locally with AWS metrics run through aws-vault as `aws-vault exec <profile> -- .\gradlew.bat run`)
 
 Alternatively open in IntelliJ, add this folder as a Gradle module, then create a new Ktor run configuration
 with `uk.gov.communities.delta.auth.ApplicationKt` as the main class and environment variables set from `.env`. (See below image for an example)

--- a/auth-service/README.md
+++ b/auth-service/README.md
@@ -11,7 +11,7 @@
 
 ## Run
 
-* Start with `./gradlew run` (to run locally with AWS metrics run through aws-vault as `aws-vault exec <profile> -- .\gradlew.bat run`)
+* Start with `./gradlew run` (to run locally with AWS metrics run through aws-vault as `aws-vault exec <profile> -- .\gradlew.bat run` and set environment variable AUTH_METRICS_NAMESPACE to e.g. "localYourName/AuthService")
 
 Alternatively open in IntelliJ, add this folder as a Gradle module, then create a new Ktor run configuration
 with `uk.gov.communities.delta.auth.ApplicationKt` as the main class and environment variables set from `.env`. (See below image for an example)

--- a/auth-service/build.gradle.kts
+++ b/auth-service/build.gradle.kts
@@ -51,6 +51,10 @@ dependencies {
     implementation("io.ktor:ktor-server-rate-limit:$ktorVersion")
     implementation("io.ktor:ktor-server-forwarded-header:$ktorVersion")
 
+    // Metrics
+    implementation("io.ktor:ktor-server-metrics-micrometer:$ktorVersion")
+    implementation("io.micrometer:micrometer-registry-cloudwatch2:1.11.2")
+
     // Logging
     implementation("ch.qos.logback:logback-classic:1.4.8")
     implementation("net.logstash.logback:logstash-logback-encoder:7.4") // Structured log encoder

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Application.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Application.kt
@@ -42,7 +42,7 @@ fun Application.appModule() {
 
     configureRateLimiting(Injection.instance.deltaConfig.rateLimit, Injection.instance.rateLimitCounter)
     configureSecurity(Injection.instance)
-    configureMonitoring(Injection.instance.cloudWatchMeterRegistry)
+    configureMonitoring(Injection.instance.meterRegistry)
     configureSerialization()
     configureTemplating(developmentMode)
     configureRouting(Injection.instance)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Application.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Application.kt
@@ -40,9 +40,9 @@ fun Application.appModule() {
         Injection.instance.dbPool.eagerInit()
     }
 
-    configureRateLimiting(Injection.instance.deltaConfig.rateLimit)
+    configureRateLimiting(Injection.instance.deltaConfig.rateLimit, Injection.instance.rateLimitCounter)
     configureSecurity(Injection.instance)
-    configureMonitoring()
+    configureMonitoring(Injection.instance.cloudWatchMeterRegistry)
     configureSerialization()
     configureTemplating(developmentMode)
     configureRouting(Injection.instance)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -80,7 +80,7 @@ class Injection (
     val ssoLoginStateService = SSOLoginSessionStateService()
     val ssoOAuthClientProviderLookupService = SSOOAuthClientProviderLookupService(azureADSSOConfig, ssoLoginStateService)
     val microsoftGraphService = MicrosoftGraphService()
-    val meterRegistry = if (authServiceConfig.metricsNamespace == "") SimpleMeterRegistry() else CloudWatchMeterRegistry(
+    val meterRegistry = if (authServiceConfig.metricsNamespace.isNullOrEmpty()) SimpleMeterRegistry() else CloudWatchMeterRegistry(
         object : CloudWatchConfig {
             private val configuration = mapOf(
                 "cloudwatch.namespace" to authServiceConfig.metricsNamespace,

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/AuthServiceConfig.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/AuthServiceConfig.kt
@@ -2,14 +2,15 @@ package uk.gov.communities.delta.auth.config
 
 import org.slf4j.spi.LoggingEventBuilder
 
-class AuthServiceConfig(val serviceUrl: String) {
+class AuthServiceConfig(val serviceUrl: String, val metricsNamespace: String) {
     companion object {
         fun fromEnv() = AuthServiceConfig(
             serviceUrl = Env.getRequiredOrDevFallback("SERVICE_URL", "http://localhost:8088"),
+            metricsNamespace = Env.getRequiredOrDevFallback("AUTH_METRICS_NAMESPACE", "local/AuthService")
         )
     }
 
     fun log(logger: LoggingEventBuilder) {
-        logger.addKeyValue("SERVICE_URL", serviceUrl).log("Service config")
+        logger.addKeyValue("SERVICE_URL", serviceUrl).addKeyValue("AUTH_METRICS_NAMESPACE", metricsNamespace).log("Service config")
     }
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/AuthServiceConfig.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/AuthServiceConfig.kt
@@ -2,11 +2,11 @@ package uk.gov.communities.delta.auth.config
 
 import org.slf4j.spi.LoggingEventBuilder
 
-class AuthServiceConfig(val serviceUrl: String, val metricsNamespace: String) {
+class AuthServiceConfig(val serviceUrl: String, val metricsNamespace: String?) {
     companion object {
         fun fromEnv() = AuthServiceConfig(
             serviceUrl = Env.getRequiredOrDevFallback("SERVICE_URL", "http://localhost:8088"),
-            metricsNamespace = Env.getRequiredOrDevFallback("AUTH_METRICS_NAMESPACE", "local/AuthService")
+            metricsNamespace = Env.getRequiredOrNullDevFallback("AUTH_METRICS_NAMESPACE")
         )
     }
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/Env.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/Env.kt
@@ -8,6 +8,12 @@ class Env {
 
         fun getRequiredOrDevFallback(name: String, fallback: String) = getRequiredOrDevFallback(name) { fallback }
 
+        fun getRequiredOrNullDevFallback(name: String): String? {
+            val env = getEnv(name)
+            if (!env.isNullOrEmpty()) return env
+            return if (devFallbackEnabled) null else throw MissingRequiredEnvironmentException(name)
+        }
+
         fun getRequiredOrDevFallback(name: String, fallback: () -> String): String {
             val env = getEnv(name)
             if (!env.isNullOrEmpty()) return env

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/Monitoring.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/Monitoring.kt
@@ -6,9 +6,9 @@ import io.ktor.server.metrics.micrometer.*
 import io.ktor.server.plugins.*
 import io.ktor.server.plugins.callid.*
 import io.ktor.server.plugins.callloging.*
-import io.micrometer.cloudwatch2.CloudWatchMeterRegistry
 import io.micrometer.core.instrument.config.MeterFilter
 import io.ktor.server.request.*
+import io.micrometer.core.instrument.MeterRegistry
 import kotlinx.coroutines.slf4j.MDCContext
 import kotlinx.coroutines.withContext
 import org.slf4j.MDC
@@ -19,7 +19,7 @@ import uk.gov.communities.delta.auth.security.DELTA_AD_LDAP_SERVICE_USERS_AUTH_N
 import uk.gov.communities.delta.auth.security.DeltaLdapPrincipal
 import uk.gov.communities.delta.auth.services.OAuthSession
 
-fun Application.configureMonitoring(cloudWatchMeterRegistry: CloudWatchMeterRegistry) {
+fun Application.configureMonitoring(meterRegistry: MeterRegistry) {
     install(CallLogging) {
         level = Level.INFO
         callIdMdc("requestId")
@@ -36,7 +36,7 @@ fun Application.configureMonitoring(cloudWatchMeterRegistry: CloudWatchMeterRegi
         }
     }
     install(MicrometerMetrics) {
-        registry = cloudWatchMeterRegistry
+        registry = meterRegistry
         registry.config()
             .meterFilter(MeterFilter.acceptNameStartsWith("login"))
             .meterFilter(MeterFilter.deny()) // Currently don't want any other metrics

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/ApplicationTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/ApplicationTest.kt
@@ -39,7 +39,7 @@ class ApplicationTest {
                 ClientConfig.fromEnv(deltaConfig),
                 deltaConfig,
                 AzureADSSOConfig(emptyList()),
-                AuthServiceConfig.fromEnv(),
+                AuthServiceConfig("testInvalidServiceUrl", ""),
             )
             testApp = TestApplication {
                 application {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/ApplicationTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/ApplicationTest.kt
@@ -39,7 +39,7 @@ class ApplicationTest {
                 ClientConfig.fromEnv(deltaConfig),
                 deltaConfig,
                 AzureADSSOConfig(emptyList()),
-                AuthServiceConfig("testInvalidServiceUrl", ""),
+                AuthServiceConfig("testInvalidServiceUrl", null),
             )
             testApp = TestApplication {
                 application {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthLoginTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthLoginTest.kt
@@ -239,7 +239,7 @@ class OAuthLoginTest {
     companion object {
         private lateinit var testApp: TestApplication
         private val deltaConfig = DeltaConfig.fromEnv()
-        private val serviceConfig = AuthServiceConfig("testServiceUrl", "")
+        private val serviceConfig = AuthServiceConfig("testServiceUrl", null)
         private val serviceClient = testServiceClient()
         private val ssoClient = AzureADSSOClient(
             "test",
@@ -303,7 +303,7 @@ class OAuthLoginTest {
                 install(CallId) { generate(4) }
                 install(Authentication) {
                     azureAdSingleSignOn(
-                        AuthServiceConfig("http://auth-service", ""),
+                        AuthServiceConfig("http://auth-service", null),
                         HttpClient(mockOAuthTokenRequestHttpEngine),
                         oauthClientProviderLookupService,
                     )

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthLoginTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthLoginTest.kt
@@ -239,7 +239,7 @@ class OAuthLoginTest {
     companion object {
         private lateinit var testApp: TestApplication
         private val deltaConfig = DeltaConfig.fromEnv()
-        private val serviceConfig = AuthServiceConfig.fromEnv()
+        private val serviceConfig = AuthServiceConfig("testServiceUrl", "")
         private val serviceClient = testServiceClient()
         private val ssoClient = AzureADSSOClient(
             "test",

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthLoginTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthLoginTest.kt
@@ -13,6 +13,7 @@ import io.ktor.server.testing.*
 import io.ktor.test.dispatcher.*
 import io.ktor.util.*
 import io.ktor.utils.io.*
+import io.micrometer.core.instrument.Metrics.counter
 import io.mockk.*
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.CoreMatchers
@@ -268,7 +269,9 @@ class OAuthLoginTest {
                 ssoConfig,
                 deltaConfig,
                 mockk(),
-                authorizationCodeServiceMock
+                authorizationCodeServiceMock,
+                counter("failedLoginNoopCounter"),
+                counter("successfulLoginNoopCounter")
             )
             val oauthController = DeltaSSOLoginController(
                 deltaConfig,
@@ -300,14 +303,14 @@ class OAuthLoginTest {
                 install(CallId) { generate(4) }
                 install(Authentication) {
                     azureAdSingleSignOn(
-                        AuthServiceConfig("http://auth-service"),
+                        AuthServiceConfig("http://auth-service", ""),
                         HttpClient(mockOAuthTokenRequestHttpEngine),
                         oauthClientProviderLookupService,
                     )
                 }
                 application {
                     configureTemplating(false)
-                    configureRateLimiting(10)
+                    configureRateLimiting(10, counter("rateLimitingNoopCounter"))
                     routing {
                         route("/delta") {
                             deltaLoginRoutes(serviceConfig, loginPageController, oauthController)

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/RateLimitingTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/RateLimitingTest.kt
@@ -10,7 +10,13 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import io.ktor.test.dispatcher.*
+import io.micrometer.core.instrument.Counter
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.AfterClass
+import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
 import uk.gov.communities.delta.auth.config.AzureADSSOConfig
@@ -57,6 +63,7 @@ class RateLimitingTest {
             assertSuccessfulGetRequest(forwardedFor)
         }
         assertBlockedGetRequest(forwardedFor)
+        verify(exactly=1) { rateLimitLoginCounter.increment(1.0) }
     }
 
     @Test
@@ -69,6 +76,13 @@ class RateLimitingTest {
         }
         assertBlockedGetRequest(forwardFor1)
         assertSuccessfulGetRequest(forwardFor2)
+        verify(exactly=1) { rateLimitLoginCounter.increment(1.0) }
+    }
+
+    @Before
+    fun resetCounter() {
+        clearAllMocks()
+        every { rateLimitLoginCounter.increment(1.0) } returns Unit
     }
 
     companion object {
@@ -76,6 +90,7 @@ class RateLimitingTest {
         private lateinit var testClient: HttpClient
         val client = testServiceClient()
         private const val rateLimitValue = 2
+        val rateLimitLoginCounter = mockk<Counter>()
 
         @BeforeClass
         @JvmStatic
@@ -83,7 +98,7 @@ class RateLimitingTest {
             testApp = TestApplication {
                 application {
                     configureTemplating(false)
-                    configureRateLimiting(rateLimitValue)
+                    configureRateLimiting(rateLimitValue, rateLimitLoginCounter)
                     configureStatusPages("test.url", AzureADSSOConfig(emptyList()))
                     routing {
                         rateLimit(RateLimitName(loginRateLimitName)) {

--- a/terraform/modules/auth_service/iam_roles.tf
+++ b/terraform/modules/auth_service/iam_roles.tf
@@ -1,0 +1,45 @@
+resource "aws_iam_role" "auth_service_task_role" {
+  name = "${var.environment}-auth-service-metrics-role"
+
+  assume_role_policy = jsonencode(
+    {
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect = "Allow"
+          Action = "sts:AssumeRole"
+          "Condition" : {
+            "ArnLike" : {
+              "aws:SourceArn" : "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+            }
+          }
+          Sid = ""
+          Principal = {
+            Service = "ecs-tasks.amazonaws.com"
+          }
+        }
+      ]
+    }
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "auth_service_metrics_role_policy_attachment" {
+  role       = aws_iam_role.auth_service_task_role.name
+  policy_arn = aws_iam_policy.auth_service_metrics_access.arn
+}
+
+resource "aws_iam_policy" "auth_service_metrics_access" {
+  name   = "${var.environment}-auth-service-metrics-access"
+  policy = data.aws_iam_policy_document.auth_service_metrics_access.json
+}
+
+# tfsec:ignore:aws-iam-no-policy-wildcards
+data "aws_iam_policy_document" "auth_service_metrics_access" {
+  statement {
+    actions = ["cloudwatch:PutMetricData"]
+    effect  = "Allow"
+    resources = [
+      "*"
+    ]
+  }
+}

--- a/terraform/modules/auth_service/main.tf
+++ b/terraform/modules/auth_service/main.tf
@@ -23,6 +23,8 @@ module "fargate" {
   memory                             = var.ecs.memory
   ecs_cloudwatch_log_expiration_days = var.cloudwatch_log_expiration_days
   alarms_sns_topic_arn               = var.alarms_sns_topic_arn
+  auth_metrics_namespace             = var.auth_metrics_namespace
+  task_role_arn                      = aws_iam_role.auth_service_task_role.arn
   target_groups = [
     {
       tg_arn        = aws_lb_target_group.internal.arn
@@ -75,6 +77,10 @@ module "fargate" {
     {
       name  = "DISABLE_DEVELOPMENT_FALLBACK"
       value = "true"
+    },
+    {
+      name  = "AUTH_METRICS_NAMESPACE"
+      value = var.auth_metrics_namespace
     },
     {
       name  = "SERVICE_URL"

--- a/terraform/modules/auth_service/main.tf
+++ b/terraform/modules/auth_service/main.tf
@@ -23,7 +23,6 @@ module "fargate" {
   memory                             = var.ecs.memory
   ecs_cloudwatch_log_expiration_days = var.cloudwatch_log_expiration_days
   alarms_sns_topic_arn               = var.alarms_sns_topic_arn
-  auth_metrics_namespace             = var.auth_metrics_namespace
   task_role_arn                      = aws_iam_role.auth_service_task_role.arn
   target_groups = [
     {

--- a/terraform/modules/auth_service/monitoring.tf
+++ b/terraform/modules/auth_service/monitoring.tf
@@ -1,0 +1,47 @@
+resource "aws_cloudwatch_metric_alarm" "fail_rate_high_login" {
+  alarm_name          = "auth-${var.environment}-login-fail-rate-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "login.failedLogins.count"
+  namespace           = var.auth_metrics_namespace
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 20 //Highest in last month (10/08) is 10
+  treat_missing_data  = "notBreaching"
+
+  alarm_description = "There are more failed logins than expected"
+  alarm_actions     = [var.alarms_sns_topic_arn]
+  ok_actions        = [var.alarms_sns_topic_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "success_rate_high_login" {
+  alarm_name          = "auth-${var.environment}-login-success-rate-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "login.successfulLogins.count"
+  namespace           = var.auth_metrics_namespace
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 30 // Highest in last month (10/08) is 23
+  treat_missing_data  = "notBreaching"
+
+  alarm_description = "There are more successful logins than expected"
+  alarm_actions     = [var.alarms_sns_topic_arn]
+  ok_actions        = [var.alarms_sns_topic_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "auth_rate_limit_reached" {
+  alarm_name          = "auth-${var.environment}-rate-limit-reached"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "login.rateLimitedRequests.count"
+  namespace           = var.auth_metrics_namespace
+  period              = 120
+  statistic           = "Sum"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+
+  alarm_description = "An IP address has reached the rate limit on the login page"
+  alarm_actions     = [var.alarms_sns_topic_arn]
+  ok_actions        = [var.alarms_sns_topic_arn]
+}

--- a/terraform/modules/auth_service/variables.tf
+++ b/terraform/modules/auth_service/variables.tf
@@ -1,3 +1,7 @@
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
 variable "environment" {
   type = string
 }
@@ -104,4 +108,9 @@ variable "delta_website_local_dev_client_secret_arn" {
   type        = string
   default     = null
   description = "Client secret for a client that redirects to localhost, for use only on the test environment"
+}
+
+variable "auth_metrics_namespace" {
+  description = "Namespace for auth metrics"
+  type        = string
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -48,6 +48,7 @@ module "auth_service" {
   bastion_security_group_id      = data.terraform_remote_state.common_infra.outputs.bastion_sg_id
   db_backup_retention_days       = 14
   private_dns                    = data.terraform_remote_state.common_infra.outputs.private_dns
+  auth_metrics_namespace         = "production/AuthService"
 
   ldap_config = {
     CA_S3_URL                   = "https://data-collection-service-ldaps-crl-production.s3.amazonaws.com/CASRVPRODUCTION/CASRVproduction.dluhcdata.local_CASRVproduction.crt"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -47,6 +47,7 @@ module "auth_service" {
   delta_hostname                 = data.terraform_remote_state.common_infra.outputs.public_albs.delta.primary_hostname
   bastion_security_group_id      = data.terraform_remote_state.common_infra.outputs.bastion_sg_id
   private_dns                    = data.terraform_remote_state.common_infra.outputs.private_dns
+  auth_metrics_namespace         = "staging/AuthService"
 
   ldap_config = {
     CA_S3_URL                   = "https://data-collection-service-ldaps-crl-staging.s3.amazonaws.com/CASRVSTAGING/CASRVstaging.dluhcdata.local_CASRVstaging.crt"

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -69,6 +69,7 @@ module "auth_service" {
   delta_hostname                 = data.terraform_remote_state.common_infra.outputs.public_albs.delta.primary_hostname
   bastion_security_group_id      = data.terraform_remote_state.common_infra.outputs.bastion_sg_id
   private_dns                    = data.terraform_remote_state.common_infra.outputs.private_dns
+  auth_metrics_namespace         = "test/AuthService"
 
   ldap_config = {
     CA_S3_URL                   = "https://data-collection-service-ldaps-crl-test.s3.amazonaws.com/CASRVTEST/CASRVtest.dluhctest.local_CASRVtest.crt"


### PR DESCRIPTION
Adding metrics and alarms for the auth service

Testing: Metrics tested by adding to the tests (all tests pass locally), tested alarms locally but will want further testing on test/staging once deployed (permissions for the role etc have not been tested)
Risks: Incorrectly set up alarms could mean that we aren't notified to login being spammed
Documentation: This PR, [the ticket](https://dluhcdigital.atlassian.net/browse/DT-523), will update the runbook with where to find the logs/metrics once deployed