### PR TITLE
Use IO dispatcher for blocking calls

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Application.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Application.kt
@@ -23,7 +23,7 @@ fun main() {
             port = 8443
         }
         module {
-            Injection.startupInitFromEnvironment()
+            Injection.startupInitFromEnvironment().registerShutdownHook()
             appModule()
         }
     }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Application.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Application.kt
@@ -18,8 +18,8 @@ fun main() {
         }
         sslConnector(keyStore = keyStore,
             keyAlias = "auth-service",
-            keyStorePassword = { SelfSignedSSLCertKeystore.keyStorePassword.toCharArray() },
-            privateKeyPassword = { SelfSignedSSLCertKeystore.keyStorePassword.toCharArray() }) {
+            keyStorePassword = { SelfSignedSSLCertKeystore.KEY_STORE_PASSWORD.toCharArray() },
+            privateKeyPassword = { SelfSignedSSLCertKeystore.KEY_STORE_PASSWORD.toCharArray() }) {
             port = 8443
         }
         module {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -68,6 +68,10 @@ class Injection(
         dbPool.close()
     }
 
+    fun registerShutdownHook() {
+        Runtime.getRuntime().addShutdownHook(Thread { close() })
+    }
+
     private val samlTokenService = SAMLTokenService()
     private val ldapService = LdapService(
         LdapService.Configuration(

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/SelfSignedSSLCertKeystore.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/SelfSignedSSLCertKeystore.kt
@@ -11,22 +11,22 @@ import java.security.KeyStore
 */
 class SelfSignedSSLCertKeystore {
     companion object {
-        const val keyStorePassword = ""
+        const val KEY_STORE_PASSWORD = ""
         private val logger = LoggerFactory.getLogger(SelfSignedSSLCertKeystore::class.java)
 
         fun getKeystore(): KeyStore {
             val keyStoreFile = File("sslKeystore.jks")
             if (keyStoreFile.exists()) {
-                return KeyStore.getInstance(keyStoreFile, keyStorePassword.toCharArray())
+                return KeyStore.getInstance(keyStoreFile, KEY_STORE_PASSWORD.toCharArray())
             }
             logger.info("Generating a new SSL Keystore")
             val keyStore = buildKeyStore {
                 certificate("auth-service") {
-                    password = keyStorePassword
+                    password = KEY_STORE_PASSWORD
                     domains = listOf("localhost")
                 }
             }
-            keyStore.saveToFile(keyStoreFile, keyStorePassword)
+            keyStore.saveToFile(keyStoreFile, KEY_STORE_PASSWORD)
             return keyStore
         }
     }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/ClientConfig.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/ClientConfig.kt
@@ -9,7 +9,7 @@ open class Client(val clientId: String, val clientSecret: String, val samlCreden
     }
 }
 
-class OAuthClient(
+class DeltaLoginEnabledClient(
     clientId: String,
     clientSecret: String,
     samlCredential: BasicX509Credential,
@@ -36,7 +36,7 @@ class ClientConfig(val clients: List<Client>) {
             val marklogic =
                 Client("marklogic", marklogicSecret, samlCredentials)
             val deltaWebsite = deltaWebsiteSecret?.let {
-                OAuthClient(
+                DeltaLoginEnabledClient(
                     "delta-website",
                     deltaWebsiteSecret,
                     samlCredentials,
@@ -44,7 +44,7 @@ class ClientConfig(val clients: List<Client>) {
                 )
             }
             val devDeltaWebsite = devDeltaWebsiteSecret?.let {
-                OAuthClient(
+                DeltaLoginEnabledClient(
                     "delta-website-dev",
                     devDeltaWebsiteSecret,
                     SAMLConfig.insecureHardcodedCredentials(),
@@ -55,7 +55,7 @@ class ClientConfig(val clients: List<Client>) {
         }
     }
 
-    val oauthClients = clients.filterIsInstance<OAuthClient>()
+    val oauthClients = clients.filterIsInstance<DeltaLoginEnabledClient>()
 
     fun log(logger: LoggingEventBuilder) {
         logger.log("Enabled clients {}", clients)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaLoginController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaLoginController.kt
@@ -9,8 +9,6 @@ import io.ktor.server.routing.*
 import io.ktor.server.sessions.*
 import io.ktor.server.thymeleaf.*
 import io.micrometer.core.instrument.Counter
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.LoginSessionCookie
 import uk.gov.communities.delta.auth.config.AuthServiceConfig
@@ -30,7 +28,7 @@ class DeltaLoginController(
     private val ssoConfig: AzureADSSOConfig,
     private val deltaConfig: DeltaConfig,
     private val ldapService: IADLdapLoginService,
-    private val authenticationCodeService: AuthorizationCodeService,
+    private val authorizationCodeService: AuthorizationCodeService,
     private val failedLoginCounter: Counter,
     private val successfulLoginCounter: Counter,
 ) {
@@ -167,11 +165,9 @@ class DeltaLoginController(
                     )
                 }
 
-                val authCode = withContext(Dispatchers.IO) {
-                    authenticationCodeService.generateAndStore(
-                        userCn = loginResult.user.cn, client = client, traceId = call.callId!!
-                    )
-                }
+                val authCode = authorizationCodeService.generateAndStore(
+                    userCn = loginResult.user.cn, client = client, traceId = call.callId!!
+                )
 
                 logger.atInfo().withAuthCode(authCode).log("Successful login")
                 successfulLoginCounter.increment(1.0)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaLoginController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaLoginController.kt
@@ -14,7 +14,7 @@ import uk.gov.communities.delta.auth.LoginSessionCookie
 import uk.gov.communities.delta.auth.config.AuthServiceConfig
 import uk.gov.communities.delta.auth.config.AzureADSSOConfig
 import uk.gov.communities.delta.auth.config.DeltaConfig
-import uk.gov.communities.delta.auth.config.OAuthClient
+import uk.gov.communities.delta.auth.config.DeltaLoginEnabledClient
 import uk.gov.communities.delta.auth.oauthClientLoginRoute
 import uk.gov.communities.delta.auth.security.IADLdapLoginService
 import uk.gov.communities.delta.auth.services.IAuthorizationCodeService
@@ -24,7 +24,7 @@ import uk.gov.communities.delta.auth.services.withAuthCode
 
 class DeltaLoginController(
     private val authServiceConfig: AuthServiceConfig,
-    private val clients: List<OAuthClient>,
+    private val clients: List<DeltaLoginEnabledClient>,
     private val ssoConfig: AzureADSSOConfig,
     private val deltaConfig: DeltaConfig,
     private val ldapService: IADLdapLoginService,
@@ -55,7 +55,7 @@ class DeltaLoginController(
         call.respondLoginPage(client)
     }
 
-    private class LoginQueryParams(val client: OAuthClient, val state: String)
+    private class LoginQueryParams(val client: DeltaLoginEnabledClient, val state: String)
 
     private fun ApplicationCall.getLoginQueryParams(): LoginQueryParams? {
         val responseType = request.queryParameters["response_type"]
@@ -79,7 +79,7 @@ class DeltaLoginController(
     }
 
     private suspend fun ApplicationCall.respondLoginPage(
-        client: OAuthClient,
+        client: DeltaLoginEnabledClient,
         errorMessage: String = "",
         errorLink: String = "#",
         username: String = "",

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/OAuthTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/OAuthTokenController.kt
@@ -8,14 +8,14 @@ import io.ktor.server.routing.*
 import io.ktor.server.util.*
 import kotlinx.serialization.Serializable
 import org.slf4j.LoggerFactory
-import uk.gov.communities.delta.auth.config.OAuthClient
+import uk.gov.communities.delta.auth.config.DeltaLoginEnabledClient
 import uk.gov.communities.delta.auth.saml.SAMLTokenService
 import uk.gov.communities.delta.auth.security.ClientSecretCheck
 import uk.gov.communities.delta.auth.services.*
 import java.time.Instant
 
 class OAuthTokenController(
-    private val clients: List<OAuthClient>,
+    private val clients: List<DeltaLoginEnabledClient>,
     private val authorizationCodeService: IAuthorizationCodeService,
     private val userLookupService: UserLookupService,
     private val samlTokenService: SAMLTokenService,

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/Monitoring.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/Monitoring.kt
@@ -18,7 +18,6 @@ import uk.gov.communities.delta.auth.security.ClientPrincipal
 import uk.gov.communities.delta.auth.security.DELTA_AD_LDAP_SERVICE_USERS_AUTH_NAME
 import uk.gov.communities.delta.auth.security.DeltaLdapPrincipal
 import uk.gov.communities.delta.auth.services.OAuthSession
-import kotlin.collections.mutableMapOf
 import kotlin.collections.set
 
 fun Application.configureMonitoring(meterRegistry: MeterRegistry) {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/ADLdapLoginService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/ADLdapLoginService.kt
@@ -1,5 +1,8 @@
 package uk.gov.communities.delta.auth.security
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jetbrains.annotations.Blocking
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.config.LDAPConfig
 import uk.gov.communities.delta.auth.services.LdapService
@@ -14,7 +17,7 @@ import javax.naming.directory.InitialDirContext
  * LDAP binds with Active Directory specific error handling
  */
 interface IADLdapLoginService {
-    fun ldapLogin(username: String, password: String): LdapLoginResult
+    suspend fun ldapLogin(username: String, password: String): LdapLoginResult
 
 
     sealed interface LdapLoginResult
@@ -45,7 +48,7 @@ class ADLdapLoginService(
 
     private val logger = LoggerFactory.getLogger(this.javaClass)
 
-    override fun ldapLogin(username: String, password: String): IADLdapLoginService.LdapLoginResult {
+    override suspend fun ldapLogin(username: String, password: String): IADLdapLoginService.LdapLoginResult {
         if (!username.matches(LDAPConfig.VALID_USERNAME_REGEX)) {
             logger.warn("Invalid username '{}'", username)
             return IADLdapLoginService.InvalidUsername
@@ -53,9 +56,12 @@ class ADLdapLoginService(
 
         val userDn = config.userDnFormat.format(username)
 
-        return ldapBind(userDn, password)
+        return withContext(Dispatchers.IO) {
+            ldapBind(userDn, password)
+        }
     }
 
+    @Blocking
     private fun ldapBind(userDn: String, password: String): IADLdapLoginService.LdapLoginResult {
         var context: InitialDirContext? = null
         return try {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/LdapAuthenticationService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/LdapAuthenticationService.kt
@@ -16,7 +16,7 @@ class LdapAuthenticationService(private val ldapService: IADLdapLoginService, pr
 
     private val logger = LoggerFactory.getLogger(LdapAuthenticationService::class.java)
 
-    fun authenticate(credential: UserPasswordCredential): DeltaLdapPrincipal? {
+    suspend fun authenticate(credential: UserPasswordCredential): DeltaLdapPrincipal? {
         logger.debug("Authenticating LDAP service user '{}'", credential.name)
 
         when (val loginResult = ldapService.ldapLogin(credential.name, credential.password)) {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/Security.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/Security.kt
@@ -11,7 +11,7 @@ import io.ktor.server.request.*
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.Injection
 import uk.gov.communities.delta.auth.config.AuthServiceConfig
-import uk.gov.communities.delta.auth.config.OAuthClient
+import uk.gov.communities.delta.auth.config.DeltaLoginEnabledClient
 import uk.gov.communities.delta.auth.oauthClientCallbackRoute
 import uk.gov.communities.delta.auth.services.sso.SSOOAuthClientProviderLookupService
 import kotlin.time.Duration.Companion.seconds
@@ -65,7 +65,7 @@ fun Application.configureSecurity(injection: Injection) {
                     logger.warn("OAuth Bearer token authentication, rejecting due to missing client authentication")
                     return@authenticate null
                 }
-                oauthSessionService.retrieveFomAuthToken(it.token, clientPrincipal.client as OAuthClient)
+                oauthSessionService.retrieveFomAuthToken(it.token, clientPrincipal.client as DeltaLoginEnabledClient)
             }
         }
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/AuthorizationCodeService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/AuthorizationCodeService.kt
@@ -1,16 +1,12 @@
 package uk.gov.communities.delta.auth.services
 
+import org.jetbrains.annotations.Blocking
 import org.slf4j.LoggerFactory
 import org.slf4j.spi.LoggingEventBuilder
 import uk.gov.communities.delta.auth.config.Client
 import uk.gov.communities.delta.auth.utils.TimeSource
 import java.sql.Timestamp
 import java.time.Instant
-
-interface IAuthorizationCodeService {
-    fun generateAndStore(userCn: String, client: Client, traceId: String): AuthCode
-    fun lookupAndInvalidate(code: String, client: Client): AuthCode?
-}
 
 // The authorization code is the value we include in the URL when we redirect back to the Delta website
 // It's a short-lived code that can be exchanged using the token endpoint for user details and a longer lived access token
@@ -25,8 +21,7 @@ data class AuthCode(
         createdAt.plusSeconds(AuthorizationCodeService.AUTH_CODE_VALID_DURATION_SECONDS) < timeSource.now()
 }
 
-class AuthorizationCodeService(private val dbPool: DbPool, private val timeSource: TimeSource) :
-    IAuthorizationCodeService {
+class AuthorizationCodeService(private val dbPool: DbPool, private val timeSource: TimeSource) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
     companion object {
@@ -34,7 +29,8 @@ class AuthorizationCodeService(private val dbPool: DbPool, private val timeSourc
         const val AUTH_CODE_LENGTH_BYTES = 24
     }
 
-    override fun generateAndStore(userCn: String, client: Client, traceId: String): AuthCode {
+    @Blocking
+    fun generateAndStore(userCn: String, client: Client, traceId: String): AuthCode {
         val code = randomBase64(AUTH_CODE_LENGTH_BYTES)
         val now = timeSource.now()
         val authCode = AuthCode(code, userCn, client, now, traceId)
@@ -44,7 +40,8 @@ class AuthorizationCodeService(private val dbPool: DbPool, private val timeSourc
         return authCode
     }
 
-    override fun lookupAndInvalidate(code: String, client: Client): AuthCode? {
+    @Blocking
+    fun lookupAndInvalidate(code: String, client: Client): AuthCode? {
         val entry = deleteReturning(code, client) ?: return null
         if (entry.expired(timeSource)) {
             logger.atWarn().withAuthCode(entry).log("Expired auth code '{}'", code)
@@ -54,7 +51,7 @@ class AuthorizationCodeService(private val dbPool: DbPool, private val timeSourc
     }
 
     private fun insert(authCode: AuthCode) {
-        dbPool.connection().use {
+        dbPool.useConnection {
             val stmt = it.prepareStatement(
                 "INSERT INTO authorization_code (username, client_id, code_hash, created_at, trace_id) " +
                         "VALUES (?, ?, ?, ?, ?)"
@@ -101,5 +98,5 @@ class AuthorizationCodeService(private val dbPool: DbPool, private val timeSourc
     }
 }
 
-fun LoggingEventBuilder.withAuthCode(authCode: AuthCode) =
+fun LoggingEventBuilder.withAuthCode(authCode: AuthCode): LoggingEventBuilder =
     addKeyValue("username", authCode.code).addKeyValue("trace", authCode.traceId)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/DbPool.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/DbPool.kt
@@ -62,7 +62,9 @@ class DbPool(private val config: DatabaseConfig) : Closeable {
     })
 
     override fun close() {
-        connectionPool.close()
+        if (connectionPoolDelegate.isInitialized()) {
+            connectionPool.close()
+        }
     }
 }
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/DbPool.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/DbPool.kt
@@ -4,6 +4,7 @@ import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import io.ktor.utils.io.core.*
 import org.flywaydb.core.Flyway
+import org.jetbrains.annotations.Blocking
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.config.DatabaseConfig
 import java.sql.Connection
@@ -18,10 +19,12 @@ class DbPool(private val config: DatabaseConfig) : Closeable {
     private val connectionPoolDelegate = lazy(::createPoolAndMigrate)
     private val connectionPool: HikariDataSource by connectionPoolDelegate
 
+    @Blocking
     fun connection(): Connection {
-        return connectionPool.connection
+        return connectionPool.getConnection()
     }
 
+    @Blocking
     @OptIn(ExperimentalContracts::class)
     inline fun <R> useConnection(block: (Connection) -> R): R {
         contract {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/LdapService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/LdapService.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.delta.auth.services
 
 import kotlinx.serialization.Serializable
+import org.jetbrains.annotations.Blocking
 import org.slf4j.LoggerFactory
 import java.lang.Integer.parseInt
 import java.util.*
@@ -16,6 +17,7 @@ class LdapService(private val config: Configuration) {
     private val logger = LoggerFactory.getLogger(javaClass)
     private val groupDnToCnRegex = Regex(config.groupDnFormat.replace("%s", "([\\w-]+)"))
 
+    @Blocking
     fun bind(userDn: String, password: String, poolConnection: Boolean = false): InitialDirContext {
         val env = Hashtable<String, String>()
         env[Context.INITIAL_CONTEXT_FACTORY] = "com.sun.jndi.ldap.LdapCtxFactory"
@@ -40,6 +42,7 @@ class LdapService(private val config: Configuration) {
         }
     }
 
+    @Blocking
     fun mapUserFromContext(ctx: InitialDirContext, userDn: String): LdapUser {
         val attributes =
             ctx.getAttributes(

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OAuthSessionService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OAuthSessionService.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.delta.auth.services
 
 import io.ktor.server.auth.*
+import org.jetbrains.annotations.Blocking
 import org.slf4j.LoggerFactory
 import org.slf4j.spi.LoggingEventBuilder
 import uk.gov.communities.delta.auth.config.DeltaLoginEnabledClient
@@ -34,6 +35,7 @@ class OAuthSessionService(private val dbPool: DbPool, private val timeSource: Ti
         const val TOKEN_LENGTH_BYTES = 24
     }
 
+    @Blocking
     override fun create(authCode: AuthCode, client: DeltaLoginEnabledClient): OAuthSession {
         val token = randomBase64(TOKEN_LENGTH_BYTES)
         val now = timeSource.now()
@@ -43,6 +45,7 @@ class OAuthSessionService(private val dbPool: DbPool, private val timeSource: Ti
         return deltaSession
     }
 
+    @Blocking
     override fun retrieveFomAuthToken(authToken: String, client: DeltaLoginEnabledClient): OAuthSession? {
         val session = select(authToken, client) ?: return null
         if (session.expired(timeSource)) {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OAuthSessionService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OAuthSessionService.kt
@@ -3,7 +3,7 @@ package uk.gov.communities.delta.auth.services
 import io.ktor.server.auth.*
 import org.slf4j.LoggerFactory
 import org.slf4j.spi.LoggingEventBuilder
-import uk.gov.communities.delta.auth.config.OAuthClient
+import uk.gov.communities.delta.auth.config.DeltaLoginEnabledClient
 import uk.gov.communities.delta.auth.utils.TimeSource
 import java.sql.Timestamp
 import java.time.Instant
@@ -12,7 +12,7 @@ import kotlin.time.Duration.Companion.hours
 data class OAuthSession(
     val id: Int, // Our internal database id, no relation to the value of the SESSIONID cookie in Delta, or sessionId from Delta's logs
     val userCn: String,
-    val client: OAuthClient,
+    val client: DeltaLoginEnabledClient,
     val authToken: String,
     val createdAt: Instant,
     val traceId: String,
@@ -22,8 +22,8 @@ data class OAuthSession(
 }
 
 interface IOAuthSessionService {
-    fun create(authCode: AuthCode, client: OAuthClient): OAuthSession
-    fun retrieveFomAuthToken(authToken: String, client: OAuthClient): OAuthSession?
+    fun create(authCode: AuthCode, client: DeltaLoginEnabledClient): OAuthSession
+    fun retrieveFomAuthToken(authToken: String, client: DeltaLoginEnabledClient): OAuthSession?
 }
 
 class OAuthSessionService(private val dbPool: DbPool, private val timeSource: TimeSource) : IOAuthSessionService {
@@ -34,7 +34,7 @@ class OAuthSessionService(private val dbPool: DbPool, private val timeSource: Ti
         const val TOKEN_LENGTH_BYTES = 24
     }
 
-    override fun create(authCode: AuthCode, client: OAuthClient): OAuthSession {
+    override fun create(authCode: AuthCode, client: DeltaLoginEnabledClient): OAuthSession {
         val token = randomBase64(TOKEN_LENGTH_BYTES)
         val now = timeSource.now()
         val deltaSession = insert(authCode, client, token, now)
@@ -43,7 +43,7 @@ class OAuthSessionService(private val dbPool: DbPool, private val timeSource: Ti
         return deltaSession
     }
 
-    override fun retrieveFomAuthToken(authToken: String, client: OAuthClient): OAuthSession? {
+    override fun retrieveFomAuthToken(authToken: String, client: DeltaLoginEnabledClient): OAuthSession? {
         val session = select(authToken, client) ?: return null
         if (session.expired(timeSource)) {
             logger.atInfo().withSession(session).log("Session expired. Crated at {}", session.createdAt)
@@ -53,7 +53,7 @@ class OAuthSessionService(private val dbPool: DbPool, private val timeSource: Ti
         return session
     }
 
-    private fun insert(authCode: AuthCode, client: OAuthClient, token: String, now: Instant): OAuthSession {
+    private fun insert(authCode: AuthCode, client: DeltaLoginEnabledClient, token: String, now: Instant): OAuthSession {
         return dbPool.useConnection {
             val stmt = it.prepareStatement(
                 "INSERT INTO delta_session (username, client_id, auth_token_hash, created_at, trace_id) " +
@@ -79,7 +79,7 @@ class OAuthSessionService(private val dbPool: DbPool, private val timeSource: Ti
         }
     }
 
-    private fun select(authToken: String, client: OAuthClient): OAuthSession? {
+    private fun select(authToken: String, client: DeltaLoginEnabledClient): OAuthSession? {
         return dbPool.useConnection {
             val stmt =
                 it.prepareStatement(

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/tasks/DeleteOldAuthCodes.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/tasks/DeleteOldAuthCodes.kt
@@ -9,6 +9,8 @@ import java.time.temporal.ChronoUnit
 class DeleteOldAuthCodes(private val db: DbPool) : AuthServiceTask("DeleteOldAuthCodes") {
     private val logger = LoggerFactory.getLogger(javaClass)
 
+    // Tasks are run separately anyway
+    @Suppress("BlockingMethodInNonBlockingContext")
     override suspend fun execute() {
         db.useConnection {
             val stmt = it.prepareStatement(

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/tasks/DeleteOldDeltaSessions.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/tasks/DeleteOldDeltaSessions.kt
@@ -10,6 +10,8 @@ class DeleteOldDeltaSessions(private val db: DbPool) :
     AuthServiceTask("DeleteOldDeltaSessions") {
     private val logger = LoggerFactory.getLogger(javaClass)
 
+    // Tasks are run separately anyway
+    @Suppress("BlockingMethodInNonBlockingContext")
     override suspend fun execute() {
         db.useConnection {
             val stmt = it.prepareStatement(

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaLoginControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaLoginControllerTest.kt
@@ -12,10 +12,7 @@ import io.ktor.server.sessions.*
 import io.ktor.server.testing.*
 import io.ktor.test.dispatcher.*
 import io.micrometer.core.instrument.Counter
-import io.mockk.clearAllMocks
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
+import io.mockk.*
 import kotlinx.coroutines.runBlocking
 import org.junit.*
 import uk.gov.communities.delta.auth.LoginSessionCookie
@@ -168,7 +165,7 @@ class DeltaLoginControllerTest {
         clearAllMocks()
         every { failedLoginCounter.increment(1.0) } returns Unit
         every { successfulLoginCounter.increment(1.0) } returns Unit
-        every { authorizationCodeService.generateAndStore(any(), any(), any()) } answers {
+        coEvery { authorizationCodeService.generateAndStore(any(), any(), any()) } answers {
             AuthCode("test-auth-code", "user", client, Instant.now(), "trace")
         }
     }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/OAuthTokenControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/OAuthTokenControllerTest.kt
@@ -7,6 +7,7 @@ import io.ktor.http.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import io.ktor.test.dispatcher.*
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.serialization.json.Json
@@ -96,7 +97,7 @@ class OAuthTokenControllerTest {
             every { authorizationCodeService.lookupAndInvalidate(any(), client) } answers { null }
             every { authorizationCodeService.lookupAndInvalidate(authCode.code, client) } answers { authCode }
             every { oauthSessionService.create(authCode, client) } answers { session }
-            every { userLookupService.lookupUserByCn(authCode.userCn) } answers { user }
+            coEvery { userLookupService.lookupUserByCn(authCode.userCn) }.returns(user)
             every {
                 samlTokenService.generate(
                     client.samlCredential,

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/OAuthTokenControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/OAuthTokenControllerTest.kt
@@ -94,9 +94,9 @@ class OAuthTokenControllerTest {
         @BeforeClass
         @JvmStatic
         fun setup() {
-            every { authorizationCodeService.lookupAndInvalidate(any(), client) } answers { null }
-            every { authorizationCodeService.lookupAndInvalidate(authCode.code, client) } answers { authCode }
-            every { oauthSessionService.create(authCode, client) } answers { session }
+            coEvery { authorizationCodeService.lookupAndInvalidate(any(), client) } answers { null }
+            coEvery { authorizationCodeService.lookupAndInvalidate(authCode.code, client) } answers { authCode }
+            coEvery { oauthSessionService.create(authCode, client) } answers { session }
             coEvery { userLookupService.lookupUserByCn(authCode.userCn) }.returns(user)
             every {
                 samlTokenService.generate(

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/RefreshUserInfoControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/RefreshUserInfoControllerTest.kt
@@ -8,6 +8,7 @@ import io.ktor.server.auth.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import io.ktor.test.dispatcher.*
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.serialization.json.Json
@@ -76,7 +77,7 @@ class RefreshUserInfoControllerTest {
         @BeforeClass
         @JvmStatic
         fun setup() {
-            every { userLookupService.lookupUserByCn(session.userCn) } answers { user }
+            coEvery { userLookupService.lookupUserByCn(session.userCn) } answers { user }
             every {
                 samlTokenService.generate(
                     client.samlCredential,

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/RefreshUserInfoControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/RefreshUserInfoControllerTest.kt
@@ -86,8 +86,8 @@ class RefreshUserInfoControllerTest {
                     any()
                 )
             } answers { "SAML Token" }
-            every { oauthSessionService.retrieveFomAuthToken(any(), client) } answers { null }
-            every { oauthSessionService.retrieveFomAuthToken(session.authToken, client) } answers { session }
+            coEvery { oauthSessionService.retrieveFomAuthToken(any(), client) } answers { null }
+            coEvery { oauthSessionService.retrieveFomAuthToken(session.authToken, client) } answers { session }
 
             controller = RefreshUserInfoController(userLookupService, samlTokenService)
             testApp = TestApplication {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/AuthorizationCodeServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/AuthorizationCodeServiceTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.delta.dbintegration
 
+import io.ktor.test.dispatcher.*
 import org.junit.BeforeClass
 import org.junit.Test
 import uk.gov.communities.delta.auth.services.AuthorizationCodeService
@@ -12,20 +13,20 @@ import kotlin.test.assertNull
 class AuthorizationCodeServiceTest {
 
     @Test
-    fun testLookupInvalidCodeFails() {
+    fun testLookupInvalidCodeFails() = testSuspend {
         val result = service.lookupAndInvalidate("invalid_code", client)
         assertNull(result)
     }
 
     @Test
-    fun testLookupCodeWrongClientFails() {
+    fun testLookupCodeWrongClientFails() = testSuspend {
         val code = service.generateAndStore("some.user", client, "traceId")
         val result = service.lookupAndInvalidate(code.code, testServiceClient("wrong-client"))
         assertNull(result)
     }
 
     @Test
-    fun testRetrieveValidCode() {
+    fun testRetrieveValidCode() = testSuspend {
         val code = service.generateAndStore("some.user", client, "traceId")
         val result = service.lookupAndInvalidate(code.code, client)
         assertNotNull(result)

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/OAuthSessionServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/OAuthSessionServiceTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.delta.dbintegration
 
+import io.ktor.test.dispatcher.*
 import org.junit.BeforeClass
 import org.junit.Test
 import uk.gov.communities.delta.auth.services.AuthCode
@@ -13,13 +14,13 @@ import kotlin.test.assertNull
 
 class OAuthSessionServiceTest {
     @Test
-    fun testLookupInvalidTokenFails() {
+    fun testLookupInvalidTokenFails() = testSuspend {
         val result = service.retrieveFomAuthToken("invalidToken", client)
         assertNull(result)
     }
 
     @Test
-    fun testLookupInvalidClientFails() {
+    fun testLookupInvalidClientFails() = testSuspend {
         val authCode = AuthCode("code", "userCn", client, Instant.now(), "trace")
         val createResult = service.create(authCode, client)
 
@@ -28,7 +29,7 @@ class OAuthSessionServiceTest {
     }
 
     @Test
-    fun testCreateAndRetrieveSession() {
+    fun testCreateAndRetrieveSession() = testSuspend {
         val authCode = AuthCode("code", "userCn", client, Instant.now(), "trace")
         val createResult = service.create(authCode, client)
 

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/helper/TestClient.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/helper/TestClient.kt
@@ -1,8 +1,8 @@
 package uk.gov.communities.delta.helper
 
 import io.mockk.mockk
-import uk.gov.communities.delta.auth.config.OAuthClient
+import uk.gov.communities.delta.auth.config.DeltaLoginEnabledClient
 
-fun testServiceClient(clientId: String = "delta-website"): OAuthClient {
-    return OAuthClient(clientId, "client-secret", mockk(), "https://delta")
+fun testServiceClient(clientId: String = "delta-website"): DeltaLoginEnabledClient {
+    return DeltaLoginEnabledClient(clientId, "client-secret", mockk(), "https://delta")
 }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthLoginTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthLoginTest.kt
@@ -16,8 +16,6 @@ import io.ktor.utils.io.*
 import io.micrometer.core.instrument.Metrics.counter
 import io.mockk.*
 import kotlinx.coroutines.runBlocking
-import org.hamcrest.CoreMatchers
-import org.hamcrest.MatcherAssert
 import org.junit.*
 import uk.gov.communities.delta.auth.config.*
 import uk.gov.communities.delta.auth.controllers.external.DeltaLoginController
@@ -125,7 +123,7 @@ class OAuthLoginTest {
 
     @Test
     fun `Callback redirects to Delta create user page if no ldap user`() = testSuspend {
-        every { ldapUserLookupServiceMock.lookupUserByCn("user!example.com") } throws (NameNotFoundException())
+        coEvery { ldapUserLookupServiceMock.lookupUserByCn("user!example.com") } throws (NameNotFoundException())
         testClient(loginState.cookie).get("/delta/oauth/test/callback?code=auth-code&state=${loginState.state}")
             .apply {
                 assertEquals(HttpStatusCode.Found, status)
@@ -135,7 +133,7 @@ class OAuthLoginTest {
 
     @Test
     fun `Callback returns error if user is disabled`()  {
-        every { ldapUserLookupServiceMock.lookupUserByCn("user!example.com") } answers {
+        coEvery { ldapUserLookupServiceMock.lookupUserByCn("user!example.com") } answers {
             testLdapUser(memberOfCNs = listOf(deltaConfig.requiredGroupCn), accountEnabled = false)
         }
         Assert.assertThrows(DeltaSSOLoginController.OAuthLoginException::class.java) {
@@ -147,7 +145,7 @@ class OAuthLoginTest {
 
     @Test
     fun `Callback returns error if user has no email`()  {
-        every { ldapUserLookupServiceMock.lookupUserByCn("user!example.com") } answers {
+        coEvery { ldapUserLookupServiceMock.lookupUserByCn("user!example.com") } answers {
             testLdapUser(memberOfCNs = listOf(deltaConfig.requiredGroupCn), email = null)
         }
         Assert.assertThrows(DeltaSSOLoginController.OAuthLoginException::class.java) {
@@ -159,7 +157,7 @@ class OAuthLoginTest {
 
     @Test
     fun `Callback returns error if user is not in Delta users group`()  {
-        every { ldapUserLookupServiceMock.lookupUserByCn("user!example.com") } answers {
+        coEvery { ldapUserLookupServiceMock.lookupUserByCn("user!example.com") } answers {
             testLdapUser(memberOfCNs = listOf("some-other-group"))
         }
         Assert.assertThrows(DeltaSSOLoginController.OAuthLoginException::class.java) {
@@ -181,7 +179,7 @@ class OAuthLoginTest {
     }
 
     private fun mockAdminUser() {
-        every { ldapUserLookupServiceMock.lookupUserByCn("user!example.com") } answers {
+        coEvery { ldapUserLookupServiceMock.lookupUserByCn("user!example.com") } answers {
             testLdapUser(memberOfCNs = listOf(deltaConfig.requiredGroupCn, "datamart-delta-admin"))
         }
     }
@@ -223,7 +221,7 @@ class OAuthLoginTest {
     @Before
     fun setupMocks() {
         clearAllMocks()
-        every { ldapUserLookupServiceMock.lookupUserByCn("user!example.com") } answers {
+        coEvery { ldapUserLookupServiceMock.lookupUserByCn("user!example.com") } answers {
             testLdapUser(memberOfCNs = listOf(deltaConfig.requiredGroupCn))
         }
         every { authorizationCodeServiceMock.generateAndStore("cn", serviceClient, any()) } answers {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthLoginTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthLoginTest.kt
@@ -73,7 +73,7 @@ class OAuthLoginTest {
             // Which should redirect us back to Delta with an Authorisation code
             assertEquals(HttpStatusCode.Found, status)
             assertEquals("https://delta/login/oauth2/redirect?code=code&state=delta-state", headers["Location"])
-            verify { authorizationCodeServiceMock.generateAndStore("cn", serviceClient, any()) }
+            coVerify { authorizationCodeServiceMock.generateAndStore("cn", serviceClient, any()) }
             assertEquals("", setCookie()[0].value) // Session should be cleared
         }
     }
@@ -108,7 +108,7 @@ class OAuthLoginTest {
             .apply {
                 assertEquals(HttpStatusCode.Found, status)
                 assertTrue(headers["Location"]!!.startsWith("${deltaConfig.deltaWebsiteUrl}/login?error=delta_sso_failed&sso_error=some_azure_error"))
-                verify(exactly = 0) { authorizationCodeServiceMock.generateAndStore("cn", serviceClient, any()) }
+                coVerify(exactly = 0) { authorizationCodeServiceMock.generateAndStore("cn", serviceClient, any()) }
             }
     }
 
@@ -224,7 +224,7 @@ class OAuthLoginTest {
         coEvery { ldapUserLookupServiceMock.lookupUserByCn("user!example.com") } answers {
             testLdapUser(memberOfCNs = listOf(deltaConfig.requiredGroupCn))
         }
-        every { authorizationCodeServiceMock.generateAndStore("cn", serviceClient, any()) } answers {
+        coEvery { authorizationCodeServiceMock.generateAndStore("cn", serviceClient, any()) } answers {
             AuthCode("code", "cn", serviceClient, Instant.MIN, "trace")
         }
         coEvery {


### PR DESCRIPTION
Plus a couple of refactors (review commit by commit).

Something I've been lazy about and am coming back to now. From some reading and experimenting:

* Ktor uses Dispatchers.Default for handling requests, which will be 2 threads on prod (it's `max(cpu_cores, 2)`)
* JDBC and Java's LDAP implementation are blocking, so send those off to Dispatchers.IO (which is a bigger thread pool)
* HttpClient (for talking to Microsoft in the OAuth flow) is non-blocking, so don't need to worry about that

I haven't done any load testing as I expect we've got plenty of headroom even without this change.