### PR TITLE
DT-553 Map user roles from AD

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -89,6 +89,7 @@ class Injection(
     )
     private val emailService = EmailService(emailConfig)
     private val userService = UserService(ldapService)
+    private val accessGroupsService = AccessGroupsService(ldapService, ldapConfig)
 
     val dbPool = DbPool(databaseConfig)
 
@@ -192,6 +193,9 @@ class Injection(
         userLookupService,
         samlTokenService,
         oauthSessionService,
+        accessGroupsService,
+        organisationService,
+        ::MemberOfToDeltaRolesMapper
     )
 
     fun refreshUserInfoController() = RefreshUserInfoController(userLookupService, samlTokenService)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/LDAPConfig.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/LDAPConfig.kt
@@ -8,6 +8,8 @@ data class LDAPConfig(
     val deltaUserDnFormat: String,
     val groupDnFormat: String,
     val serviceUserRequiredGroupCn: String,
+    // Container with an empty group for each access group and system role
+    val accessGroupContainerDn: String,
     val authServiceUserCn: String,
     val authServiceUserPassword: String,
     val domainRealm: String,
@@ -28,6 +30,10 @@ data class LDAPConfig(
                 "CN=%s,OU=Groups,OU=dluhctest,DC=dluhctest,DC=local"
             ),
             serviceUserRequiredGroupCn = "dluhc-service-users",
+            accessGroupContainerDn = Env.getRequiredOrDevFallback(
+                "ACCESS_GROUP_CONTAINER_DN",
+                "CN=datamart-delta,OU=Groups,OU=dluhctest,DC=dluhctest,DC=local"
+            ),
             authServiceUserCn = Env.getEnv("LDAP_AUTH_SERVICE_USER") ?: "auth-service.app",
             authServiceUserPassword = Env.getRequired("LDAP_AUTH_SERVICE_USER_PASSWORD"),
             domainRealm = Env.getRequiredOrDevFallback("LDAP_DOMAIN_REALM", "dluhctest.local"),

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/Monitoring.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/Monitoring.kt
@@ -26,7 +26,7 @@ fun Application.configureMonitoring(meterRegistry: MeterRegistry) {
         callIdMdc("requestId")
         filter { it.request.path() != "/health" }
         mdc("username") { it.principal<DeltaLdapPrincipal>(DELTA_AD_LDAP_SERVICE_USERS_AUTH_NAME)?.username }
-        mdc("IPAddress") { it.request.origin.remoteHost }
+        mdc("IPAddress") { it.request.origin.remoteAddress }
         disableDefaultColors()
     }
     install(CallId) {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/AccessGroupsService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/AccessGroupsService.kt
@@ -1,0 +1,91 @@
+package uk.gov.communities.delta.auth.services
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
+import uk.gov.communities.delta.auth.config.LDAPConfig
+import javax.naming.directory.Attributes
+import javax.naming.directory.SearchControls
+import kotlin.time.Duration.Companion.seconds
+
+
+@Serializable
+data class AccessGroup(
+    val name: String,
+    val classification: String?,
+    val registrationDisplayName: String?,
+    val enableOnlineRegistration: Boolean,
+    val enableInternalUser: Boolean,
+)
+
+
+class AccessGroupsService(private val ldapService: LdapService, val config: LDAPConfig) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    companion object {
+        private const val PAGE_SIZE = 200
+    }
+
+    suspend fun getAllAccessGroups(): List<AccessGroup> {
+        val startTime = System.currentTimeMillis()
+
+        return ldapService.useServiceUserBind { ctx ->
+            val accessGroups =
+                ctx.searchPaged(config.accessGroupContainerDn, "(objectClass=group)", searchControls(), PAGE_SIZE) {
+                    val cn = it.get("cn").get() as String
+
+                    if (DELTA_SYSTEM_ROLES.contains(cn) || DELTA_EXTERNAL_ROLES.contains(cn)) {
+                        null
+                    } else {
+                        val info = it.getInfo()
+                        AccessGroup(
+                            cn,
+                            it.getClassification(),
+                            info.registrationDisplayName,
+                            info.enableOnlineRegistration,
+                            info.enableInternalUser
+                        )
+                    }
+                }
+
+            logger.atInfo().addKeyValue("accessGroupCount", accessGroups.size)
+                .addKeyValue("durationMs", System.currentTimeMillis() - startTime)
+                .log("Retrieved Access Groups from AD")
+            return@useServiceUserBind accessGroups
+        }
+    }
+
+    private fun searchControls(): SearchControls {
+        val searchControls = SearchControls()
+        searchControls.searchScope = SearchControls.ONELEVEL_SCOPE
+        searchControls.timeLimit = 30.seconds.inWholeMilliseconds.toInt()
+        searchControls.returningAttributes = arrayOf("cn", "description", "info")
+        return searchControls
+    }
+
+    private val validClassifications = listOf("statistics", "grants", "other")
+    private fun Attributes.getClassification(): String? {
+        val description = get("description")?.get() as String? ?: return null
+        return if (validClassifications.contains(description)) description else null
+    }
+
+    @Serializable
+    data class AccessGroupInfo(
+        val registrationDisplayName: String? = null,
+        val enableOnlineRegistration: Boolean = false,
+        val enableInternalUser: Boolean = false,
+    )
+
+    private fun Attributes.getInfo(): AccessGroupInfo {
+        val cn = get("cn").get() as String
+        val info = (get("info")?.get() as? String)?.let {
+            try {
+                Json.decodeFromString<AccessGroupInfo>(it)
+            } catch (e: Exception) {
+                logger.error("Failed to parse info attribute for access group, ignoring {} {}", cn, it, e)
+                null
+            }
+        }
+        return info ?: AccessGroupInfo()
+    }
+}

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/LdapService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/LdapService.kt
@@ -1,6 +1,5 @@
 package uk.gov.communities.delta.auth.services
 
-import io.ktor.util.reflect.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
@@ -11,14 +10,19 @@ import java.lang.Integer.parseInt
 import java.util.*
 import javax.naming.Context
 import javax.naming.NamingException
-import javax.naming.directory.*
+import javax.naming.directory.Attributes
+import javax.naming.directory.InitialDirContext
+import javax.naming.directory.SearchControls
+import javax.naming.ldap.Control
 import javax.naming.ldap.InitialLdapContext
+import javax.naming.ldap.PagedResultsControl
+import javax.naming.ldap.PagedResultsResponseControl
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
 class LdapService(
-    private val ldapConfig: LDAPConfig
+    private val ldapConfig: LDAPConfig,
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -69,7 +73,22 @@ class LdapService(
         val attributes =
             ctx.getAttributes(
                 userDn,
-                arrayOf("cn", "memberOf", "mail", "unixHomeDirectory", "givenName", "sn", "userAccountControl")
+                arrayOf(
+                    "cn",
+                    "memberOf",
+                    "mail",
+                    "unixHomeDirectory", // Delta TOTP secret
+                    "givenName",
+                    "sn",
+                    "userAccountControl",
+                    "objectGUID",
+                    "imported-guid",
+                    "telephoneNumber",
+                    "mobile",
+                    "title", // Delta "Position in organisation"
+                    "description", // Delta "Reason for access"
+                    "comment",
+                )
             )
 
         val cn = attributes.get("cn")?.get() as String? ?: throw InvalidLdapUserException("No value for attribute cn")
@@ -77,15 +96,37 @@ class LdapService(
         val totpSecret = attributes.get("unixHomeDirectory")?.get() as String?
         val firstName = attributes.get("givenName")?.get() as String? ?: ""
         val surname = attributes.get("sn")?.get() as String? ?: ""
-        val name = "$firstName $surname"
+        val fullName = "$firstName $surname"
+        val telephone = attributes.get("telephoneNumber")?.get() as String?
+        val mobile = attributes.get("mobile")?.get() as String?
+        val positionInOrganisation = attributes.get("title")?.get() as String?
+        val reasonForAccess = attributes.get("description")?.get() as String?
+        val comment = attributes.get("comment")?.get() as String?
         val memberOfGroupDNs = attributes.getMemberOfList()
         val accountEnabled = attributes.getAccountEnabled()
+        val deltaGuid = attributes.getMangledDeltaObjectGUID()
 
         val memberOfGroupCNs = memberOfGroupDNs.mapNotNull {
             val match = groupDnToCnRegex.matchEntire(it)
             match?.groups?.get(1)?.value
         }
-        return LdapUser(userDn, cn, memberOfGroupCNs, email, totpSecret, name, firstName, accountEnabled)
+        return LdapUser(
+            dn = userDn,
+            cn = cn,
+            memberOfCNs = memberOfGroupCNs,
+            email = email,
+            deltaTOTPSecret = totpSecret,
+            firstName = firstName,
+            lastName = surname,
+            fullName = fullName,
+            accountEnabled = accountEnabled,
+            mangledDeltaObjectGuid = deltaGuid,
+            telephone = telephone,
+            mobile = mobile,
+            positionInOrganisation = positionInOrganisation,
+            reasonForAccess = reasonForAccess,
+            comment = comment,
+        )
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -99,6 +140,19 @@ class LdapService(
         // https://learn.microsoft.com/en-us/troubleshoot/windows-server/identity/useraccountcontrol-manipulate-account-properties
         return userAccountControl and (1 shl 1) == 0
     }
+
+    @OptIn(ExperimentalStdlibApi::class)
+    private fun Attributes.getMangledDeltaObjectGUID(): String {
+        // These attributes should be treated as binary i.e.
+        // env.["java.naming.ldap.attributes.binary"] = "objectGUID imported-guid"
+        // but Delta doesn't do that and instead attempts to use them as strings, which discards much of the value.
+        // These ids are scattered through the Delta database now though, so we keep them for compatibility
+        val importedGuid = get("imported-guid")?.get() as String?
+        if (importedGuid != null) {
+            return importedGuid.toByteArray().toHexString()
+        }
+        return (get("objectGUID").get() as String).toByteArray().toHexString()
+    }
 }
 
 @Serializable
@@ -108,9 +162,42 @@ data class LdapUser(
     val memberOfCNs: List<String>,
     val email: String?,
     val deltaTOTPSecret: String?,
-    val fullName: String,
     val firstName: String,
+    val lastName: String,
+    val fullName: String,
     val accountEnabled: Boolean,
+    val mangledDeltaObjectGuid: String,
+    val telephone: String?,
+    val mobile: String?,
+    val positionInOrganisation: String?,
+    val reasonForAccess: String?,
+    val comment: String?,
 )
 
 class InvalidLdapUserException(message: String) : Exception(message)
+
+@Blocking
+fun <T> InitialLdapContext.searchPaged(
+    dn: String, filter: String, searchControls: SearchControls,
+    pageSize: Int, mapper: (Attributes) -> T?,
+): List<T> {
+    val accumulatedResults = mutableListOf<T>()
+    var pagedResultsCookie: ByteArray?
+    requestControls = arrayOf(
+        PagedResultsControl(pageSize, Control.CRITICAL)
+    )
+
+    do {
+        val searchResult = search(dn, filter, searchControls)
+
+        do {
+            searchResult.next().attributes.let(mapper)?.let { accumulatedResults.add(it) }
+        } while (searchResult.hasMore())
+
+        pagedResultsCookie = responseControls?.filterIsInstance(PagedResultsResponseControl::class.java)
+            ?.firstOrNull()?.cookie
+        requestControls = arrayOf(PagedResultsControl(pageSize, pagedResultsCookie, Control.CRITICAL))
+    } while (pagedResultsCookie != null)
+
+    return accumulatedResults
+}

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/MemberOfToDeltaRolesMapper.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/MemberOfToDeltaRolesMapper.kt
@@ -170,4 +170,8 @@ val DELTA_SYSTEM_ROLES = hashSetOf(
     "stats-data-certifiers",
 )
 
+/*
+ * Name is copied from Delta, "External" in that it's managed by MarkLogic rather than Delta's Java layer.
+ * We should be able to get rid of this distinction at some point, but for now Delta expects it.
+ */
 val DELTA_EXTERNAL_ROLES = hashSetOf("section-151-officers")

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/MemberOfToDeltaRolesMapper.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/MemberOfToDeltaRolesMapper.kt
@@ -1,0 +1,173 @@
+package uk.gov.communities.delta.auth.services
+
+import kotlinx.serialization.Serializable
+import org.slf4j.LoggerFactory
+
+typealias MemberOfToDeltaRolesMapperFactory = (
+    username: String,
+    allOrganisationIds: List<String>,
+    allAccessGroups: List<AccessGroup>,
+) -> MemberOfToDeltaRolesMapper
+
+class MemberOfToDeltaRolesMapper(
+    private val username: String,
+    allOrganisationIds: List<String>,
+    allAccessGroups: List<AccessGroup>,
+) {
+    companion object {
+        const val DATAMART_DELTA_PREFIX = "datamart-delta-"
+        private val logger = LoggerFactory.getLogger(MemberOfToDeltaRolesMapper::class.java)
+    }
+
+    @Serializable
+    data class AccessGroupRole(val name: String, val classification: String?, val organisationIds: List<String>)
+
+    @Serializable
+    data class SystemRole(val name: String, val organisationIds: List<String>)
+
+    @Serializable
+    data class ExternalRole(val name: String, val organisationIds: List<String>)
+
+    @Serializable
+    data class Roles(
+        val systemRoles: List<SystemRole>,
+        val externalRoles: List<ExternalRole>,
+        val accessGroups: List<AccessGroupRole>,
+        val organisationIds: List<String>,
+    )
+
+    private val organisationIdSuffixes = allOrganisationIds.map { "-$it" }.sortedByDescending { it.length }.toList()
+    private val allAccessGroupsMap = allAccessGroups.associateBy { it.name }
+
+    fun map(memberOf: List<String>): Roles {
+        val roles = memberOf
+            .mapNotNull(::removeDatamartDeltaPrefix)
+            .mapNotNull(::parseToRoleAndOrg)
+
+        val organisationIds = roles.filter { it.role == "user" }.mapNotNull { it.orgId }.toHashSet()
+        val roleOrgIdsMap = mapOf<RoleType, MutableMap<String, MutableList<String>>>(
+            RoleType.SYSTEM to mutableMapOf(),
+            RoleType.EXTERNAL to mutableMapOf(),
+            RoleType.ACCESS_GROUP to mutableMapOf(),
+        )
+
+        // Set the non-organisation specific roles first
+        for (role in roles.filter { it.orgId == null }) {
+            roleOrgIdsMap[role.type]!![role.role] = mutableListOf()
+        }
+
+        // Then go through the organisation specific ones and add the organisation ids to the role
+        for (role in roles) {
+            if (role.orgId == null) continue
+            if (!organisationIds.contains(role.orgId)) {
+                logger.atWarn().addKeyValue("username", username).addKeyValue("group", role.originalGroup)
+                    .addKeyValue("role", role.role).addKeyValue("orgId", role.orgId)
+                    .log("User is member of datamart-delta-<role>-<orgId> group, but not part of the organisation, i.e. not a member of datamart-delta-user-<orgId> group, discarding group")
+                continue
+            }
+
+            val orgListForRole = roleOrgIdsMap[role.type]!![role.role]
+            if (orgListForRole == null) {
+                logger.atWarn().addKeyValue("username", username).addKeyValue("group", role.originalGroup)
+                    .addKeyValue("role", role.role).addKeyValue("orgId", role.orgId)
+                    .log("User is member of datamart-delta-<role>-<orgId> group, but not member of datamart-delta-<role> group, discarding group")
+                continue
+            }
+            orgListForRole.add(role.orgId)
+        }
+
+        return Roles(
+            roleOrgIdsMap[RoleType.SYSTEM]!!.entries.map { SystemRole(it.key, it.value) },
+            roleOrgIdsMap[RoleType.EXTERNAL]!!.entries.map { ExternalRole(it.key, it.value) },
+            roleOrgIdsMap[RoleType.ACCESS_GROUP]!!.entries.map {
+                AccessGroupRole(
+                    it.key,
+                    allAccessGroupsMap[it.key]!!.classification,
+                    it.value
+                )
+            },
+            organisationIds.toList(),
+        )
+    }
+
+    private enum class RoleType {
+        SYSTEM,
+        EXTERNAL,
+        ACCESS_GROUP,
+    }
+
+    private class ParsedRole(val role: String, val orgId: String?, val type: RoleType, val originalGroup: String)
+
+
+    private fun removeDatamartDeltaPrefix(group: String): String? {
+        return if (group.startsWith(DATAMART_DELTA_PREFIX)) {
+            group.substring(DATAMART_DELTA_PREFIX.length, group.length)
+        } else {
+            logger.atWarn().addKeyValue("username", username).addKeyValue("group", group)
+                .log("Ignoring group as CN does not start with $DATAMART_DELTA_PREFIX")
+            null
+        }
+    }
+
+    private fun parseToRoleAndOrg(groupWithoutPrefix: String): ParsedRole? {
+        /*
+         * Group names take the form datamart-delta-<role name>[-<orgId>], e.g.
+         * datamart-delta-data-provider-dclg
+         * ______________-_____________-____
+         *  ^prefix        ^role         ^organisation id
+         * Where role can be a system role (like "data-provider"), or an access group (like "homelessness-research")
+         * The organisation id is optional and indicates the user has that role in that organisation.
+         * Role and organisation ids can both have hyphens in.
+         */
+        val orgId = organisationIdSuffixes.firstOrNull { groupWithoutPrefix.endsWith(it) }?.substring(1)
+        val roleStr =
+            if (orgId == null) groupWithoutPrefix
+            else groupWithoutPrefix.substring(0, groupWithoutPrefix.length - (orgId.length + 1))
+
+        val roleType = determineRoleType(roleStr)
+        return if (roleType == null) {
+            logger.atWarn().addKeyValue("username", username).addKeyValue("role", roleStr)
+                .addKeyValue("orgId", orgId).addKeyValue("group", DATAMART_DELTA_PREFIX + groupWithoutPrefix)
+                .log("Ignoring group as unable to find matching system role or access group")
+            null
+        } else {
+            ParsedRole(roleStr, orgId, roleType, DATAMART_DELTA_PREFIX + groupWithoutPrefix)
+        }
+    }
+
+    private fun determineRoleType(role: String): RoleType? {
+        return if (DELTA_SYSTEM_ROLES.contains(role)) RoleType.SYSTEM
+        else if (DELTA_EXTERNAL_ROLES.contains(role)) RoleType.EXTERNAL
+        else if (allAccessGroupsMap.contains(role)) RoleType.ACCESS_GROUP
+        else null
+    }
+}
+
+val DELTA_SYSTEM_ROLES = hashSetOf(
+    "admin",
+    "read-only-admin",
+    "testers",
+    "data-providers",
+    "data-certifiers",
+    "data-auditors",
+    "billing-data-approvers",
+    "warehouse-users",
+    "dataset-admins",
+    "form-designers",
+    "lead-testers",
+    "user",
+    "data-entry-clerks",
+    "payments-approvers",
+    "payments-reviewers",
+    "sap-team-members",
+    "local-admins",
+    "abatements-approvers",
+    "suspensions-approvers",
+    "write-offs-approvers",
+    "setup-managers",
+    "report-users",
+    "personal-data-owners",
+    "stats-data-certifiers",
+)
+
+val DELTA_EXTERNAL_ROLES = hashSetOf("section-151-officers")

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OrganisationService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OrganisationService.kt
@@ -22,8 +22,8 @@ class OrganisationSearchResponse(@SerialName("organisation-results") val organis
 @Serializable
 class Organisation(
     @SerialName("code") val code: String,
-    @SerialName("retirement-date") val retirementDate: String? = null,
     @SerialName("name") val name: String,
+    @SerialName("retirement-date") val retirementDate: String? = null,
 ) {
     val retired = retirementDate != null && LocalDate.parse(retirementDate.substring(IntRange(0, 9))) < LocalDate.now()
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OrganisationService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OrganisationService.kt
@@ -11,6 +11,7 @@ import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.config.DeltaConfig
 import java.time.LocalDate
 import kotlin.time.Duration.Companion.seconds
@@ -21,15 +22,46 @@ class OrganisationSearchResponse(@SerialName("organisation-results") val organis
 @Serializable
 class Organisation(
     @SerialName("code") val code: String,
-    @SerialName("retirement-date") val retirementDate: String? = null
+    @SerialName("retirement-date") val retirementDate: String? = null,
+    @SerialName("name") val name: String,
 ) {
     val retired = retirementDate != null && LocalDate.parse(retirementDate.substring(IntRange(0, 9))) < LocalDate.now()
 }
 
+@Serializable
+class OrganisationNameAndCode(
+    @SerialName("code") val code: String,
+    @SerialName("name") val name: String,
+)
+
 class OrganisationService(private val httpClient: HttpClient, private val deltaConfig: DeltaConfig) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
     suspend fun findAllByDomain(domain: String): List<Organisation> {
-        return httpClient.get(deltaConfig.masterStoreBaseNoAuth + "organisation/search?domain=${domain.encodeURLParameter()}")
-            .body<OrganisationSearchResponse>().organisations
+        return timed("Fetched organisations for domain {}", domain) {
+            httpClient.get(deltaConfig.masterStoreBaseNoAuth + "organisation/search?domain=${domain.encodeURLParameter()}")
+                .body<OrganisationSearchResponse>().organisations
+        }
+    }
+
+    suspend fun findAllNamesAndCodes(): List<OrganisationNameAndCode> {
+        return timed("Fetched all organisation names and codes") {
+            httpClient.get(deltaConfig.masterStoreBaseNoAuth + "organisation/all-names-and-codes")
+                .body<List<OrganisationNameAndCode>>()
+        }
+    }
+
+    private suspend fun <T> timed(
+        message: String,
+        vararg logParams: String,
+        block: suspend () -> List<T>,
+    ): List<T> {
+        val startTime = System.currentTimeMillis()
+        val result = block()
+        logger.atInfo().addKeyValue("organisationCount", result.size)
+            .addKeyValue("durationMs", System.currentTimeMillis() - startTime)
+            .log(message, *logParams)
+        return result
     }
 
     companion object {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/ApplicationTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/ApplicationTest.kt
@@ -35,7 +35,7 @@ class ApplicationTest {
         fun setup() {
             val deltaConfig = DeltaConfig.fromEnv()
             Injection.instance = Injection(
-                LDAPConfig("testInvalidUrl", "", "", "", "", "", "", ""),
+                LDAPConfig("testInvalidUrl", "", "", "", "", "", "", "", ""),
                 DatabaseConfig("testInvalidUrl", "", ""),
                 ClientConfig.fromEnv(deltaConfig),
                 deltaConfig,

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaSetPasswordControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaSetPasswordControllerTest.kt
@@ -234,7 +234,7 @@ class DeltaSetPasswordControllerTest {
         private const val deltaUserDnFormat = "CN=%s"
         private val userDN = String.format(deltaUserDnFormat, userCN)
         private val deltaConfig = DeltaConfig.fromEnv()
-        private val ldapConfig = LDAPConfig("testInvalidUrl", "", deltaUserDnFormat, "", "", "", "", "")
+        private val ldapConfig = LDAPConfig("testInvalidUrl", "", deltaUserDnFormat, "", "", "", "", "", "")
         private val authenticator: Authenticator = object : Authenticator() {
             override fun getPasswordAuthentication(): PasswordAuthentication {
                 return PasswordAuthentication("", "")

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaUserRegistrationControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaUserRegistrationControllerTest.kt
@@ -194,7 +194,7 @@ class DeltaUserRegistrationControllerTest {
 
     @Test
     fun testRegistrationOfStandardUserInRetiredOrg() = testSuspend {
-        coEvery { organisationService.findAllByDomain(any()) } returns listOf(Organisation(orgCode, "2023-09-30Z"))
+        coEvery { organisationService.findAllByDomain(any()) } returns listOf(Organisation(orgCode, "2023-09-30Z", "Test org"))
         testClient.submitForm(
             url = "/register",
             formParameters = correctFormParameters(emailStart + notRequiredDomain)
@@ -242,7 +242,7 @@ class DeltaUserRegistrationControllerTest {
     @Before
     fun resetMocks() {
         clearAllMocks()
-        coEvery { organisationService.findAllByDomain(any()) } returns listOf(Organisation(orgCode))
+        coEvery { organisationService.findAllByDomain(any()) } returns listOf(Organisation(orgCode, name = "Test org"))
         coEvery { userService.createUser(any()) } just runs
         coEvery { groupService.addUserToGroup(any(), any()) } just runs
         coEvery { setPasswordTokenService.createToken(any()) } returns "token"
@@ -274,7 +274,7 @@ class DeltaUserRegistrationControllerTest {
             val registrationService = RegistrationService(
                 deltaConfig,
                 EmailConfig.fromEnv(),
-                LDAPConfig("testInvalidUrl", "", "", "", "", "", "", ""),
+                LDAPConfig("testInvalidUrl", "", "", "", "", "", "", "", ""),
                 authServiceConfig,
                 setPasswordTokenService,
                 emailService,

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaUserRegistrationControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaUserRegistrationControllerTest.kt
@@ -194,7 +194,11 @@ class DeltaUserRegistrationControllerTest {
 
     @Test
     fun testRegistrationOfStandardUserInRetiredOrg() = testSuspend {
-        coEvery { organisationService.findAllByDomain(any()) } returns listOf(Organisation(orgCode, "2023-09-30Z", "Test org"))
+        coEvery { organisationService.findAllByDomain(any()) } returns listOf(Organisation(
+            orgCode,
+            "Test org",
+            "2023-09-30Z"
+        ))
         testClient.submitForm(
             url = "/register",
             formParameters = correctFormParameters(emailStart + notRequiredDomain)
@@ -242,7 +246,7 @@ class DeltaUserRegistrationControllerTest {
     @Before
     fun resetMocks() {
         clearAllMocks()
-        coEvery { organisationService.findAllByDomain(any()) } returns listOf(Organisation(orgCode, name = "Test org"))
+        coEvery { organisationService.findAllByDomain(any()) } returns listOf(Organisation(orgCode, "Test org"))
         coEvery { userService.createUser(any()) } just runs
         coEvery { groupService.addUserToGroup(any(), any()) } just runs
         coEvery { setPasswordTokenService.createToken(any()) } returns "token"

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/helper/TestLdapUser.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/helper/TestLdapUser.kt
@@ -8,7 +8,17 @@ fun testLdapUser(
     memberOfCNs: List<String> = emptyList(),
     email: String? = "email",
     deltaTOTPSecret: String? = null,
-    name: String = "Test User",
     firstName: String = "Test",
+    lastName: String = "Surname",
+    fullName: String = "Test Surname",
     accountEnabled: Boolean = true,
-) = LdapUser(dn, cn, memberOfCNs, email, deltaTOTPSecret, name, firstName, accountEnabled)
+    mangledDeltaObjectGuid: String = "mangled-id",
+    telephone: String? = null,
+    mobile: String? = null,
+    positionInOrganisation: String? = null,
+    reasonForAccess: String? = null,
+    comment: String? = null,
+) = LdapUser(
+    dn, cn, memberOfCNs, email, deltaTOTPSecret, firstName, lastName, fullName, accountEnabled,
+    mangledDeltaObjectGuid, telephone, mobile, positionInOrganisation, reasonForAccess, comment
+)

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/GroupServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/GroupServiceTest.kt
@@ -23,7 +23,7 @@ class GroupServiceTest {
     private val groupCN = "datamart-delta-group"
     private val groupDnFormat = "CN=%s"
     private val groupDN = String.format(groupDnFormat, groupCN)
-    private val ldapConfig = LDAPConfig("testInvalidUrl", "", "", groupDnFormat, "", "", "", "")
+    private val ldapConfig = LDAPConfig("testInvalidUrl", "", "", groupDnFormat, "", "", "", "", "")
     private val groupService = GroupService(ldapService, ldapConfig)
     private val container = slot<Attributes>()
     private val modificationItems = slot<Array<ModificationItem>>()

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthSSOLoginTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthSSOLoginTest.kt
@@ -137,7 +137,7 @@ class OAuthSSOLoginTest {
         coEvery { ldapUserLookupServiceMock.lookupUserByCn(userCN) } throws (NameNotFoundException()) andThen testLdapUser(
             memberOfCNs = listOf(deltaConfig.datamartDeltaUser)
         )
-        val organisations = listOf(Organisation("E1234"))
+        val organisations = listOf(Organisation("E1234", null, "Test Organisation"))
         coEvery { organisationService.findAllByDomain("example.com") } returns organisations
         val registration = Registration("Example", "User", "user@example.com")
         coEvery { registrationService.register(any(), any(), true) } returns RegistrationService.SSOUserCreated
@@ -156,7 +156,7 @@ class OAuthSSOLoginTest {
         coEvery { ldapUserLookupServiceMock.lookupUserByCn(userCN) } throws (NameNotFoundException()) andThen testLdapUser(
             memberOfCNs = listOf(deltaConfig.datamartDeltaUser)
         )
-        val organisations = listOf(Organisation("E1234"))
+        val organisations = listOf(Organisation("E1234", null, "Test Organisation"))
         coEvery { organisationService.findAllByDomain("example.com") } returns organisations
         val registration = Registration("Example", "User", "user@example.com")
         coEvery { registrationService.register(any(), any(), true) } returns RegistrationService.SSOUserCreated

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthSSOLoginTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthSSOLoginTest.kt
@@ -137,7 +137,7 @@ class OAuthSSOLoginTest {
         coEvery { ldapUserLookupServiceMock.lookupUserByCn(userCN) } throws (NameNotFoundException()) andThen testLdapUser(
             memberOfCNs = listOf(deltaConfig.datamartDeltaUser)
         )
-        val organisations = listOf(Organisation("E1234", null, "Test Organisation"))
+        val organisations = listOf(Organisation("E1234", "Test Organisation"))
         coEvery { organisationService.findAllByDomain("example.com") } returns organisations
         val registration = Registration("Example", "User", "user@example.com")
         coEvery { registrationService.register(any(), any(), true) } returns RegistrationService.SSOUserCreated
@@ -156,7 +156,7 @@ class OAuthSSOLoginTest {
         coEvery { ldapUserLookupServiceMock.lookupUserByCn(userCN) } throws (NameNotFoundException()) andThen testLdapUser(
             memberOfCNs = listOf(deltaConfig.datamartDeltaUser)
         )
-        val organisations = listOf(Organisation("E1234", null, "Test Organisation"))
+        val organisations = listOf(Organisation("E1234", "Test Organisation"))
         coEvery { organisationService.findAllByDomain("example.com") } returns organisations
         val registration = Registration("Example", "User", "user@example.com")
         coEvery { registrationService.register(any(), any(), true) } returns RegistrationService.SSOUserCreated

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/RegistrationServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/RegistrationServiceTest.kt
@@ -22,7 +22,7 @@ class RegistrationServiceTest {
     private val orgCode = "E12345"
     private val userCN = "user!example.com"
     private val anotherOrgCode = orgCode + "2"
-    private val retiredOrganisation = Organisation(orgCode, "2023-09-30Z", "Test org")
+    private val retiredOrganisation = Organisation(orgCode, "Test org", "2023-09-30Z")
 
     private val registrationService = RegistrationService(
         deltaConfig,
@@ -48,7 +48,7 @@ class RegistrationServiceTest {
     fun testRegisteringNewStandardUser() = testSuspend {
         val registrationResult = registrationService.register(
             Registration("Test", "User", "user@example.com"),
-            listOf(Organisation(orgCode, name = "Test org")),
+            listOf(Organisation(orgCode, "Test org")),
         )
         coVerify(exactly = 1) { userService.createUser(any()) }
         coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaReportUsers) }
@@ -63,7 +63,7 @@ class RegistrationServiceTest {
     fun testSSOUserRegistration() = testSuspend {
         val registrationResult = registrationService.register(
             Registration("Test", "User", "user@example.com"),
-            listOf(Organisation(orgCode, name = "Test org")),
+            listOf(Organisation(orgCode, "Test org")),
             true
         )
         coVerify(exactly = 1) { userService.createUser(any()) }
@@ -80,7 +80,7 @@ class RegistrationServiceTest {
         coEvery { userLookupService.userExists(userCN) } returns true
         val registrationResult = registrationService.register(
             Registration("Test", "User", "user@example.com"),
-            listOf(Organisation(orgCode, name = "Test org")),
+            listOf(Organisation(orgCode, "Test org")),
             true
         )
         assertTrue(registrationResult is RegistrationService.UserAlreadyExists)
@@ -93,7 +93,7 @@ class RegistrationServiceTest {
     fun testStandardUserInMultipleOrg() = testSuspend {
         val registrationResult = registrationService.register(
             Registration("Test", "User", "user@example.com"),
-            listOf(Organisation(orgCode, name = "Test org"), Organisation(anotherOrgCode, name = "Another org")),
+            listOf(Organisation(orgCode, "Test org"), Organisation(anotherOrgCode, name = "Another org")),
         )
         coVerify(exactly = 1) { userService.createUser(any()) }
         coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaReportUsers) }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/RegistrationServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/RegistrationServiceTest.kt
@@ -22,12 +22,12 @@ class RegistrationServiceTest {
     private val orgCode = "E12345"
     private val userCN = "user!example.com"
     private val anotherOrgCode = orgCode + "2"
-    private val retiredOrganisation = Organisation(orgCode, "2023-09-30Z")
+    private val retiredOrganisation = Organisation(orgCode, "2023-09-30Z", "Test org")
 
     private val registrationService = RegistrationService(
         deltaConfig,
         EmailConfig.fromEnv(),
-        LDAPConfig("testInvalidUrl", "", "", "", "", "", "", ""),
+        LDAPConfig("testInvalidUrl", "", "", "", "", "", "", "", ""),
         authServiceConfig,
         setPasswordTokenService,
         emailService,
@@ -48,7 +48,7 @@ class RegistrationServiceTest {
     fun testRegisteringNewStandardUser() = testSuspend {
         val registrationResult = registrationService.register(
             Registration("Test", "User", "user@example.com"),
-            listOf(Organisation(orgCode)),
+            listOf(Organisation(orgCode, name = "Test org")),
         )
         coVerify(exactly = 1) { userService.createUser(any()) }
         coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaReportUsers) }
@@ -63,7 +63,7 @@ class RegistrationServiceTest {
     fun testSSOUserRegistration() = testSuspend {
         val registrationResult = registrationService.register(
             Registration("Test", "User", "user@example.com"),
-            listOf(Organisation(orgCode)),
+            listOf(Organisation(orgCode, name = "Test org")),
             true
         )
         coVerify(exactly = 1) { userService.createUser(any()) }
@@ -80,7 +80,7 @@ class RegistrationServiceTest {
         coEvery { userLookupService.userExists(userCN) } returns true
         val registrationResult = registrationService.register(
             Registration("Test", "User", "user@example.com"),
-            listOf(Organisation(orgCode)),
+            listOf(Organisation(orgCode, name = "Test org")),
             true
         )
         assertTrue(registrationResult is RegistrationService.UserAlreadyExists)
@@ -93,7 +93,7 @@ class RegistrationServiceTest {
     fun testStandardUserInMultipleOrg() = testSuspend {
         val registrationResult = registrationService.register(
             Registration("Test", "User", "user@example.com"),
-            listOf(Organisation(orgCode), Organisation(anotherOrgCode)),
+            listOf(Organisation(orgCode, name = "Test org"), Organisation(anotherOrgCode, name = "Another org")),
         )
         coVerify(exactly = 1) { userService.createUser(any()) }
         coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaReportUsers) }
@@ -109,7 +109,7 @@ class RegistrationServiceTest {
     fun testStandardUserInRetiredAndNotRetiredOrg() = testSuspend {
         val registrationResult = registrationService.register(
             Registration("Test", "User", "user@example.com"),
-            listOf(retiredOrganisation, Organisation(anotherOrgCode)),
+            listOf(retiredOrganisation, Organisation(anotherOrgCode, name = "Another org")),
         )
         coVerify(exactly = 1) { userService.createUser(any()) }
         coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaReportUsers) }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/UserServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/UserServiceTest.kt
@@ -21,7 +21,7 @@ class UserServiceTest {
     private val ldapService = mockk<LdapService>()
     private val userService = UserService(ldapService)
     private val deltaUserDnFormat = "CN=%s"
-    private val ldapConfig = LDAPConfig("testInvalidUrl", "", deltaUserDnFormat, "", "", "", "", "")
+    private val ldapConfig = LDAPConfig("testInvalidUrl", "", deltaUserDnFormat, "", "", "", "", "", "")
     private val userEmail = "user@example.com"
     private val registration = Registration("Test", "User", userEmail)
     private val container = slot<Attributes>()

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/service/MemberOfToDeltaRolesMapperTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/service/MemberOfToDeltaRolesMapperTest.kt
@@ -1,0 +1,112 @@
+package uk.gov.communities.delta.service
+
+import uk.gov.communities.delta.auth.services.AccessGroup
+import uk.gov.communities.delta.auth.services.MemberOfToDeltaRolesMapper
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MemberOfToDeltaRolesMapperTest {
+    @Test
+    fun testOrganisationMapping() {
+        val result = mapper().map(
+            listOf(
+                "user-dclg"
+            ).map { "datamart-delta-$it" }
+        )
+
+        assertEquals(emptyList(), result.systemRoles)
+        assertEquals(emptyList(), result.externalRoles)
+        assertEquals(emptyList(), result.accessGroups)
+        assertEquals(listOf("dclg"), result.organisationIds)
+    }
+
+    @Test
+    fun testIgnoresNonPrefixedGroupNames() {
+        val result = mapper().map(
+            listOf(
+                "user-dclg"
+            )
+        )
+
+        assertEquals(emptyList(), result.organisationIds)
+    }
+
+    @Test
+    fun testSystemRoles() {
+        val result = mapper().map(
+            listOf(
+                "user-dclg", "data-providers-dclg", "data-providers", "form-designers", "section-151-officers", "user"
+            ).map { "datamart-delta-$it" }
+        )
+
+        assertEquals(
+            listOf(
+                MemberOfToDeltaRolesMapper.SystemRole("data-providers", listOf("dclg")),
+                MemberOfToDeltaRolesMapper.SystemRole("form-designers", listOf()),
+                MemberOfToDeltaRolesMapper.SystemRole("user", listOf("dclg")),
+            ), result.systemRoles
+        )
+        assertEquals(
+            listOf(MemberOfToDeltaRolesMapper.ExternalRole("section-151-officers", listOf())),
+            result.externalRoles
+        )
+        assertEquals(0, result.accessGroups.size)
+        assertEquals(listOf("dclg"), result.organisationIds)
+    }
+
+    @Test
+    fun testIgnoresInvalidOrganisationMapping() {
+        val result = mapper().map(
+            listOf(
+                "dclg", "data-providers-dclg", "data-providers", "user-invalid-group"
+            ).map { "datamart-delta-$it" }
+        )
+
+        assertEquals(listOf(MemberOfToDeltaRolesMapper.SystemRole("data-providers", listOf())), result.systemRoles)
+        assertEquals(emptyList(), result.externalRoles)
+        assertEquals(emptyList(), result.accessGroups)
+        assertEquals(emptyList(), result.organisationIds)
+    }
+
+    @Test
+    fun testAccessGroupMapping() {
+        val result = mapper().map(
+            listOf(
+                "user-dclg", "access-group", "access-group-dclg", "another-group"
+            ).map { "datamart-delta-$it" }
+        )
+
+        assertEquals(emptyList(), result.systemRoles)
+        assertEquals(emptyList(), result.externalRoles)
+        assertEquals(
+            listOf(
+                MemberOfToDeltaRolesMapper.AccessGroupRole("access-group", "statistics", listOf("dclg")),
+                MemberOfToDeltaRolesMapper.AccessGroupRole("another-group", null, listOf()),
+            ), result.accessGroups
+        )
+        assertEquals(listOf("dclg"), result.organisationIds)
+    }
+
+    @Test
+    fun testIgnoresInvalidAccessGroups() {
+        val result = mapper().map(
+            listOf(
+                "user-dclg", "invalid-group", "invalid-group-dclg"
+            ).map { "datamart-delta-$it" }
+        )
+
+        assertEquals(emptyList(), result.systemRoles)
+        assertEquals(emptyList(), result.externalRoles)
+        assertEquals(emptyList(), result.accessGroups)
+        assertEquals(listOf("dclg"), result.organisationIds)
+    }
+
+    private fun mapper() = MemberOfToDeltaRolesMapper("username", organisationIds, accessGroups)
+
+    private val accessGroups = listOf(
+        AccessGroup("access-group", "statistics", null, enableOnlineRegistration = false, enableInternalUser = false),
+        AccessGroup("another-group", null, null, enableOnlineRegistration = false, enableInternalUser = false),
+    )
+
+    private val organisationIds = listOf("E1234", "dclg")
+}

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/service/MemberOfToDeltaRolesMapperTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/service/MemberOfToDeltaRolesMapperTest.kt
@@ -58,7 +58,7 @@ class MemberOfToDeltaRolesMapperTest {
     fun testIgnoresInvalidOrganisationMapping() {
         val result = mapper().map(
             listOf(
-                "dclg", "data-providers-dclg", "data-providers", "user-invalid-group"
+                "dclg", "data-providers-dclg", "data-providers", "user-invalid-group", "data-providers-E1234"
             ).map { "datamart-delta-$it" }
         )
 
@@ -99,6 +99,31 @@ class MemberOfToDeltaRolesMapperTest {
         assertEquals(emptyList(), result.externalRoles)
         assertEquals(emptyList(), result.accessGroups)
         assertEquals(listOf("dclg"), result.organisationIds)
+    }
+
+
+    @Test
+    fun testMultipleOrganisations() {
+        val result = mapper().map(
+            listOf(
+                "user-dclg", "user-E1234", "data-providers-dclg", "data-providers-E1234", "data-certifiers-E1234",
+                "data-certifiers", "data-providers", "access-group", "access-group-dclg", "access-group-E1234"
+            ).map { "datamart-delta-$it" }
+        )
+
+        assertEquals(
+            listOf(
+                MemberOfToDeltaRolesMapper.SystemRole("data-certifiers", listOf("E1234")),
+                MemberOfToDeltaRolesMapper.SystemRole("data-providers", listOf("dclg", "E1234")),
+            ), result.systemRoles
+        )
+        assertEquals(emptyList(), result.externalRoles)
+        assertEquals(
+            listOf(
+                MemberOfToDeltaRolesMapper.AccessGroupRole("access-group", "statistics", listOf("dclg", "E1234"))
+            ), result.accessGroups
+        )
+        assertEquals(listOf("dclg", "E1234"), result.organisationIds)
     }
 
     private fun mapper() = MemberOfToDeltaRolesMapper("username", organisationIds, accessGroups)


### PR DESCRIPTION
Map the user's groups into a list of Delta roles and access groups.

Given a group like `datamart-delta-some-role-some-org` there's no perfect way of determining which bit is an organisation id vs role, they can both have hyphens in, and there's nothing stopping a role suffix matching an organisation prefix.

I've taken the approach from Delta:

* Get a list of organisation ids from MarkLogic
* Have a hardcoded list of system roles, plus a list of all access groups from AD
* Match the group suffix against an organisation id if possible, longest wins
* Attempt to match the rest of the group name against a system role or access group

Invalid roles get discarded, as do (role, org) memberships where the user isn't part of both the role (datamart-delta-role) and the organisation (datamart-delta-user-org). The next step would be to construct the SAML token based on these instead so that invalid permissions get dropped from MarkLogic, but I haven't done that yet.

Neither the organisation or access group lookup are cached, so they both happen every login. I've added logs so we can figure out how long it takes, but I think it will be just about acceptable (~1 second), and we can add caching if required.