### PR TITLE
Allow apostrophes and trim usernames for form login

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_ci }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_key_ci }}
       AWS_REGION: "eu-west-1"
-      VERSION: "0.4.6"
+      VERSION: "0.4.7"
       REPOSITORY: "delta-auth-service"
       ECR_PATH: "468442790030.dkr.ecr.eu-west-1.amazonaws.com"
     outputs:

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/LDAPConfig.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/LDAPConfig.kt
@@ -31,7 +31,7 @@ data class LDAPConfig(
             authServiceUserPassword = Env.getRequired("LDAP_AUTH_SERVICE_USER_PASSWORD")
         )
 
-        val VALID_USERNAME_REGEX = Regex("^[\\w-.!]+$")
+        val VALID_USERNAME_REGEX = Regex("^[\\w-.!']+$")
     }
 
     val authServiceUserDn = serviceUserDnFormat.format(authServiceUserCn)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaLoginController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaLoginController.kt
@@ -111,7 +111,7 @@ class DeltaLoginController(
 
         val client = queryParams.client
         val formParameters = call.receiveParameters()
-        val formUsername = formParameters["username"]
+        val formUsername = formParameters["username"]?.trim()
         val password = formParameters["password"]
 
         if (formUsername.isNullOrEmpty()) return call.respondLoginPage(

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/ADLdapLoginService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/ADLdapLoginService.kt
@@ -59,7 +59,7 @@ class ADLdapLoginService(
         }
 
         if (!username.matches(LDAPConfig.VALID_USERNAME_REGEX)) {
-            logger.warn("Invalid username '{}'", username)
+            logger.atWarn().addKeyValue("username", username).log("Invalid username")
             return IADLdapLoginService.InvalidUsername
         }
 


### PR DESCRIPTION
Fix for https://dluhcdigital.atlassian.net/browse/MSD-65223.

I'm planning to check it briefly on test, then deploy straight through to production.