### PR TITLE
Migration to remove dup index on set_password_tokens user_cn

### DIFF
--- a/auth-service/src/main/resources/db/migration/V2.1__password_tokens_dup_index.sql
+++ b/auth-service/src/main/resources/db/migration/V2.1__password_tokens_dup_index.sql
@@ -1,0 +1,1 @@
+DROP INDEX set_password_token_user_cn;


### PR DESCRIPTION
An identical index was made automatically for the primary key