### PR TITLE
Log HTTP request timeouts

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OrganisationService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OrganisationService.kt
@@ -57,7 +57,12 @@ class OrganisationService(private val httpClient: HttpClient, private val deltaC
         block: suspend () -> List<T>,
     ): List<T> {
         val startTime = System.currentTimeMillis()
-        val result = block()
+        val result = try {
+            block()
+        } catch (e: Exception) {
+            logger.error("Request failed after {}ms", System.currentTimeMillis() - startTime, e)
+            throw e
+        }
         logger.atInfo().addKeyValue("organisationCount", result.size)
             .addKeyValue("durationMs", System.currentTimeMillis() - startTime)
             .log(message, *logParams)

--- a/auth-service/src/main/resources/logback.xml
+++ b/auth-service/src/main/resources/logback.xml
@@ -17,8 +17,9 @@
             </providers>
         </encoder>
     </appender>
-    <!-- The Ktor OAuth plugin only logs errors, and it logs them at TRACE -->
+    <!-- These two only log errors, and log them at TRACE -->
     <logger name="io.ktor.auth.oauth" level="TRACE"/>
+    <logger name="io.ktor.client.plugins.HttpTimeout" level="TRACE"/>
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>


### PR DESCRIPTION
The HttpTimeout plugin for Ktor's HTTP Client seems to cancel the coroutine, which I think isn't being logged usefully by ktor