### PR TITLE
Increase org request timeout to 20s

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OrganisationService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OrganisationService.kt
@@ -76,7 +76,7 @@ class OrganisationService(private val httpClient: HttpClient, private val deltaC
                     json(Json { ignoreUnknownKeys = true })
                 }
                 install(HttpTimeout) {
-                    requestTimeoutMillis = 10.seconds.inWholeMilliseconds
+                    requestTimeoutMillis = 20.seconds.inWholeMilliseconds
                 }
                 defaultRequest { headers.append("Accept", "application/json") }
             }


### PR DESCRIPTION
It doesn't actually take this long, but between it taking a few seconds sometimes and SAML library initialisation blocking out the thread for the rest it sometimes times out for the first login on our tiny 0.25 CPU core test instance.