### PR TITLE
Refactor registration error handling

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaUserRegistrationController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaUserRegistrationController.kt
@@ -125,26 +125,27 @@ class DeltaUserRegistrationController(
             }
 
             val registration = Registration(firstName, lastName, emailAddress)
-            lateinit var registrationResult: RegistrationService.RegistrationResult
-            try {
-                registrationResult = registrationService.register(registration, organisations)
-                registrationService.sendRegistrationEmail(registrationResult)
-            } catch (e: EmailException) {
-                logger.error(
-                    "Error sending email after registration for first name: {}, last name: {}, email address: {}. Result of registration was {}",
-                    firstName,
-                    lastName,
-                    emailAddress,
-                    getResultTypeString(registrationResult),
-                    e
-                )
-                throw e.e
+            val registrationResult = try {
+                registrationService.register(registration, organisations)
             } catch (e: Exception) {
                 logger.error(
                     "Error registering user with  name: {} {}, email address: {}",
                     firstName,
                     lastName,
                     emailAddress,
+                    e
+                )
+                throw e
+            }
+            try {
+                registrationService.sendRegistrationEmail(registrationResult)
+            } catch (e: Exception) {
+                logger.error(
+                    "Error sending email after registration for first name: {}, last name: {}, email address: {}. Result of registration was {}",
+                    firstName,
+                    lastName,
+                    emailAddress,
+                    getResultTypeString(registrationResult),
                     e
                 )
                 throw e

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/RateLimiting.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/RateLimiting.kt
@@ -24,15 +24,15 @@ fun Application.configureRateLimiting(
         register(RateLimitName(rateLimitName)) {
             rateLimiter(limit = rateLimit, refillPeriod = 5.minutes)
             requestKey { applicationCall ->
-                val remoteHost = applicationCall.request.origin.remoteHost
-                logger.info("Request to $pageName page from $remoteHost")
-                remoteHost
+                val ipAddress = applicationCall.request.origin.remoteAddress
+                logger.info("Request to $pageName page from $ipAddress")
+                ipAddress
             }
             modifyResponse { applicationCall, state ->
                 if (state is RateLimiter.State.Exhausted) {
-                    val remoteHost = applicationCall.request.origin.remoteHost
+                    val ipAddress = applicationCall.request.origin.remoteAddress
                     counter.increment(1.0)
-                    logger.warn("$pageName page rate limit reached for IP Address $remoteHost")
+                    logger.warn("$pageName page rate limit reached for IP Address $ipAddress")
                 }
             }
         }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
@@ -106,54 +106,47 @@ class RegistrationService(
     }
 
     fun sendRegistrationEmail(registrationResult: RegistrationResult) {
-        try {
-            when (registrationResult) {
-                is UserCreated -> {
-                    emailService.sendTemplateEmail(
-                        "new-user",
-                        getRegistrationEmailContacts(registrationResult.registration),
-                        "DLUHC DELTA - New User Account",
-                        mapOf(
-                            "deltaUrl" to deltaConfig.deltaWebsiteUrl,
-                            "userFirstName" to registrationResult.registration.firstName,
-                            "setPasswordUrl" to getSetPasswordURL(
-                                registrationResult.token,
-                                registrationResult.userCN,
-                                authServiceConfig.serviceUrl
-                            )
+        when (registrationResult) {
+            is UserCreated -> {
+                emailService.sendTemplateEmail(
+                    "new-user",
+                    getRegistrationEmailContacts(registrationResult.registration),
+                    "DLUHC DELTA - New User Account",
+                    mapOf(
+                        "deltaUrl" to deltaConfig.deltaWebsiteUrl,
+                        "userFirstName" to registrationResult.registration.firstName,
+                        "setPasswordUrl" to getSetPasswordURL(
+                            registrationResult.token,
+                            registrationResult.userCN,
+                            authServiceConfig.serviceUrl
                         )
                     )
-                }
-
-                is SSOUserCreated -> {
-                    // No email sent
-                }
-
-                is UserAlreadyExists -> {
-                    emailService.sendTemplateEmail(
-                        "already-a-user",
-                        getRegistrationEmailContacts(registrationResult.registration),
-                        "DLUHC DELTA - Account",
-                        mapOf(
-                            "deltaUrl" to deltaConfig.deltaWebsiteUrl,
-                            "userFirstName" to registrationResult.registration.firstName,
-                        )
-                    )
-                }
-
-                is RegistrationFailure -> {
-                    // No email needs to be sent if the registration fails
-                }
+                )
             }
-        } catch (e: Exception) {
-            logger.atError().log("Problem sending email", e)
-            throw EmailException(e)
-        }
 
+            is SSOUserCreated -> {
+                // No email sent
+            }
+
+            is UserAlreadyExists -> {
+                emailService.sendTemplateEmail(
+                    "already-a-user",
+                    getRegistrationEmailContacts(registrationResult.registration),
+                    "DLUHC DELTA - Account",
+                    mapOf(
+                        "deltaUrl" to deltaConfig.deltaWebsiteUrl,
+                        "userFirstName" to registrationResult.registration.firstName,
+                    )
+                )
+            }
+
+            is RegistrationFailure -> {
+                // No email needs to be sent if the registration fails
+            }
+        }
     }
 }
 
-class EmailException(val e: Exception) : Exception("Issue sending email")
 
 data class Registration(
     val firstName: String,


### PR DESCRIPTION
Move the email error handling into a separate try/catch block. Logic should all be the same, but I think this is a bit easier to follow