### PR TITLE
DT-553 Return updated roles with token refresh

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -197,7 +197,13 @@ class Injection(
         ::MemberOfToDeltaRolesMapper
     )
 
-    fun refreshUserInfoController() = RefreshUserInfoController(userLookupService, samlTokenService)
+    fun refreshUserInfoController() = RefreshUserInfoController(
+        userLookupService,
+        samlTokenService,
+        accessGroupsService,
+        organisationService,
+        ::MemberOfToDeltaRolesMapper
+    )
 
     fun deltaOAuthLoginController() =
         DeltaSSOLoginController(

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/RefreshUserInfoController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/RefreshUserInfoController.kt
@@ -4,16 +4,19 @@ import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.serialization.Serializable
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.saml.SAMLTokenService
-import uk.gov.communities.delta.auth.services.LdapUser
-import uk.gov.communities.delta.auth.services.OAuthSession
-import uk.gov.communities.delta.auth.services.UserLookupService
+import uk.gov.communities.delta.auth.services.*
 
 class RefreshUserInfoController(
     private val userLookupService: UserLookupService,
     private val samlTokenService: SAMLTokenService,
+    private val accessGroupsService: AccessGroupsService,
+    private val organisationService: OrganisationService,
+    private val memberOfToDeltaRolesMapperFactory: MemberOfToDeltaRolesMapperFactory,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -25,11 +28,20 @@ class RefreshUserInfoController(
         val session = call.principal<OAuthSession>()!!
 
         val user = userLookupService.lookupUserByCn(session.userCn)
-        // The user's roles may have changed so generate a new token
-        val samlToken = samlTokenService.samlTokenForSession(session, user)
 
-        logger.info("Retrieved updated user info")
-        call.respond(UserInfoResponse(user, samlToken.token, samlToken.expiry.epochSecond))
+        coroutineScope {
+            val allOrganisations = async { organisationService.findAllNamesAndCodes().map { it.code } }
+            val allAccessGroups = async { accessGroupsService.getAllAccessGroups() }
+
+            val samlToken = samlTokenService.samlTokenForSession(session, user)
+
+            val roles = memberOfToDeltaRolesMapperFactory(
+                user.cn, allOrganisations.await(), allAccessGroups.await()
+            ).map(user.memberOfCNs)
+
+            logger.info("Retrieved updated user info")
+            call.respond(UserInfoResponse(user, samlToken.token, roles, samlToken.expiry.epochSecond))
+        }
     }
 
     @Suppress("PropertyName")
@@ -37,6 +49,7 @@ class RefreshUserInfoController(
     data class UserInfoResponse(
         val delta_ldap_user: LdapUser,
         val saml_token: String,
+        val delta_user_roles: MemberOfToDeltaRolesMapper.Roles,
         val expires_at_epoch_second: Long,
     )
 }


### PR DESCRIPTION
Similar to the OAuth token endpoint.

This code should probably be shared somewhere, I might try and restructure the auth service a bit and find somewhere to put it. Separate PR though.