### PR TITLE
Log healthchecks + increase timeout + cpu + memory

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/Monitoring.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/Monitoring.kt
@@ -24,7 +24,8 @@ fun Application.configureMonitoring(meterRegistry: MeterRegistry) {
     install(CallLogging) {
         level = Level.INFO
         callIdMdc("requestId")
-        filter { it.request.path() != "/health" }
+        // Temporarily enable call logging for health checks
+        //  filter { it.request.path() != "/health" }
         mdc("username") { it.principal<DeltaLdapPrincipal>(DELTA_AD_LDAP_SERVICE_USERS_AUTH_NAME)?.username }
         mdc("IPAddress") { it.request.origin.remoteAddress }
         disableDefaultColors()

--- a/terraform/modules/auth_service/load_balancing.tf
+++ b/terraform/modules/auth_service/load_balancing.tf
@@ -25,6 +25,7 @@ resource "aws_lb_target_group" "internal" {
     path              = "/health"
     protocol          = "HTTPS"
     healthy_threshold = 2
+    timeout           = 10
   }
 
   lifecycle {
@@ -106,6 +107,7 @@ resource "aws_lb_target_group" "external" {
     path              = "/health"
     protocol          = "HTTPS"
     healthy_threshold = 2
+    timeout           = 10
   }
 
   lifecycle {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -61,8 +61,8 @@ module "auth_service" {
     ACCESS_GROUP_CONTAINER_DN   = "CN=datamart-delta,OU=Groups,OU=dluhcdata,DC=dluhcdata,DC=local"
   }
   ecs = {
-    cpu           = 1024
-    memory        = 2048
+    cpu           = 2048
+    memory        = 4096
     desired_count = 2
   }
   mail_settings = {


### PR DESCRIPTION
Load balancer healthchecks are failing in production. I'm not sure what the cause of this is, the metrics all look healthy and getting the `/health` endpoint through CloudFront returns in <200ms so it's hard to believe it's timing out twice in a row.

Enabling logs for the healthcheck endpoint, bumping up resources and healthcheck timeout to see if that helps.