### PR TITLE
Fix SMTP error + add timeout

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
@@ -58,7 +58,7 @@ fun Route.externalRoutes(
     deltaLoginController: DeltaLoginController,
     deltaSSOLoginController: DeltaSSOLoginController,
     deltaUserRegistrationController: DeltaUserRegistrationController,
-    deltaSetPasswordController: DeltaSetPasswordController
+    deltaSetPasswordController: DeltaSetPasswordController,
 ) {
     staticResources("/static", "static") {
         cacheControl { listOf(CacheControl.MaxAge(86400)) } // Currently set to 1 day
@@ -107,7 +107,7 @@ fun Route.deltaSetPasswordRoutes(deltaSetPasswordController: DeltaSetPasswordCon
 }
 
 fun Route.deltaRegisterRoutes(
-    deltaUserRegistrationController: DeltaUserRegistrationController
+    deltaUserRegistrationController: DeltaUserRegistrationController,
 ) {
     route("/success") {
         deltaUserRegistrationController.registerSuccessRoute(this)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/EmailConfig.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/EmailConfig.kt
@@ -43,6 +43,7 @@ class EmailConfig(
             }
             props["mail.smtp.auth"] = useAuth
             props["mail.smtp.starttls.enable"] = useAuth
+            if (useAuth) props["mail.smtp.socketFactory.class"] = "javax.net.ssl.SSLSocketFactory"
             props["mail.smtp.host"] = Env.getRequiredOrDevFallback("MAIL_SMTP_HOST", "localhost")
             props["mail.smtp.port"] = Env.getRequiredOrDevFallback("MAIL_SMTP_PORT", "25")
             props["mail.smtp.timeout"] = 10.seconds.inWholeMilliseconds

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/EmailConfig.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/EmailConfig.kt
@@ -24,7 +24,7 @@ class EmailConfig(
             val props = Properties()
             val smtpUserJSON = Env.getEnv("MAIL_SMTP_USER")
             val useAuth = smtpUserJSON != null
-            if (useAuth){
+            if (useAuth) {
                 val smtpMailUser = Json.decodeFromString<MailSMTPUserBody>(smtpUserJSON!!)
                 smtpUsername = smtpMailUser.username
                 smtpPassword = smtpMailUser.password

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/EmailConfig.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/EmailConfig.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.slf4j.spi.LoggingEventBuilder
 import java.util.*
+import kotlin.time.Duration.Companion.seconds
 
 class EmailConfig(
     val emailProps: Properties,
@@ -44,6 +45,9 @@ class EmailConfig(
             props["mail.smtp.starttls.enable"] = useAuth
             props["mail.smtp.host"] = Env.getRequiredOrDevFallback("MAIL_SMTP_HOST", "localhost")
             props["mail.smtp.port"] = Env.getRequiredOrDevFallback("MAIL_SMTP_PORT", "25")
+            props["mail.smtp.timeout"] = 10.seconds.inWholeMilliseconds
+            @Suppress("SpellCheckingInspection")
+            props["mail.smtp.connectiontimeout"] = 10.seconds.inWholeMilliseconds
             return EmailConfig(
                 emailProps = props,
                 emailAuthenticator = authenticator,

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/LDAPConfig.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/LDAPConfig.kt
@@ -38,6 +38,7 @@ data class LDAPConfig(
             authServiceUserPassword = Env.getRequired("LDAP_AUTH_SERVICE_USER_PASSWORD"),
             domainRealm = Env.getRequiredOrDevFallback("LDAP_DOMAIN_REALM", "dluhctest.local"),
         )
+
         val VALID_EMAIL_REGEX = Regex("^[\\w\\-+.']+@([\\w\\-']+\\.)+[\\w\\-]{2,4}$")
         val VALID_USERNAME_REGEX = Regex("^[\\w\\-+.!']+$")
     }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaLoginController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaLoginController.kt
@@ -11,7 +11,10 @@ import io.ktor.server.thymeleaf.*
 import io.micrometer.core.instrument.Counter
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.LoginSessionCookie
-import uk.gov.communities.delta.auth.config.*
+import uk.gov.communities.delta.auth.config.AzureADSSOClient
+import uk.gov.communities.delta.auth.config.AzureADSSOConfig
+import uk.gov.communities.delta.auth.config.DeltaConfig
+import uk.gov.communities.delta.auth.config.DeltaLoginEnabledClient
 import uk.gov.communities.delta.auth.oauthClientLoginRoute
 import uk.gov.communities.delta.auth.security.IADLdapLoginService
 import uk.gov.communities.delta.auth.services.AuthorizationCodeService

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSetPasswordController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSetPasswordController.kt
@@ -145,7 +145,7 @@ class DeltaSetPasswordController(
 
     private suspend fun ApplicationCall.respondToResult(
         tokenResult: SetPasswordTokenService.TokenResult,
-        newPassword: String
+        newPassword: String,
     ) {
         when (tokenResult) {
             is SetPasswordTokenService.NoSuchToken -> {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaUserRegistrationController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaUserRegistrationController.kt
@@ -158,7 +158,7 @@ class DeltaUserRegistrationController(
         firstNameErrors: ArrayList<String>,
         lastNameErrors: ArrayList<String>,
         emailAddressErrors: ArrayList<String>,
-        confirmEmailAddressErrors: ArrayList<String>
+        confirmEmailAddressErrors: ArrayList<String>,
     ): Boolean {
         return arrayOf(
             firstNameErrors,
@@ -203,7 +203,7 @@ class DeltaUserRegistrationController(
         firstNameErrors: ArrayList<String> = ArrayList(),
         lastNameErrors: ArrayList<String> = ArrayList(),
         emailAddressErrors: ArrayList<String> = ArrayList(),
-        confirmEmailAddressErrors: ArrayList<String> = ArrayList()
+        confirmEmailAddressErrors: ArrayList<String> = ArrayList(),
     ) {
         val errors = ArrayList<ArrayList<String>>()
         firstNameErrors.forEach { message ->

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/Monitoring.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/Monitoring.kt
@@ -10,7 +10,6 @@ import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.config.MeterFilter
 import kotlinx.coroutines.slf4j.MDCContext
 import kotlinx.coroutines.withContext
-import org.slf4j.Logger
 import org.slf4j.MDC
 import org.slf4j.event.Level
 import uk.gov.communities.delta.auth.security.CLIENT_HEADER_AUTH_NAME
@@ -94,26 +93,4 @@ val addBearerSessionInfoToMDC = createRouteScopedPlugin("AddBearerSessionInfoToM
             proceed()
         }
     }
-}
-
-suspend fun <T> Logger.timed(
-    action: String,
-    logParams: (T) -> List<Pair<String, Any>> = { emptyList() },
-    block: suspend () -> T,
-): T {
-    val startTime = System.currentTimeMillis()
-    val result = try {
-        block()
-    } catch (e: Exception) {
-        this.atWarn()
-            .addKeyValue("durationMs", System.currentTimeMillis() - startTime)
-            .log("Timed action {} failed", action, e)
-        throw e
-    }
-    this.atInfo()
-        .addKeyValue("timedAction", action)
-        .addKeyValue("durationMs", System.currentTimeMillis() - startTime)
-        .apply { logParams(result).forEach { addKeyValue(it.first, it.second) } }
-        .log("Timed action {} complete", action)
-    return result
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/RateLimiting.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/RateLimiting.kt
@@ -16,7 +16,7 @@ fun Application.configureRateLimiting(
     rateLimit: Int,
     loginRateLimitCounter: Counter,
     registrationRateLimitCounter: Counter,
-    setPasswordRateLimitCounter: Counter
+    setPasswordRateLimitCounter: Counter,
 ) {
     val logger = LoggerFactory.getLogger("Application.RateLimiting")
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/DbPool.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/DbPool.kt
@@ -7,6 +7,7 @@ import org.flywaydb.core.Flyway
 import org.jetbrains.annotations.Blocking
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.config.DatabaseConfig
+import uk.gov.communities.delta.auth.utils.timed
 import java.sql.Connection
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
@@ -26,11 +27,13 @@ class DbPool(private val config: DatabaseConfig) : Closeable {
 
     @Blocking
     @OptIn(ExperimentalContracts::class)
-    inline fun <R> useConnection(block: (Connection) -> R): R {
+    fun <R> useConnectionBlocking(action: String, block: (Connection) -> R): R {
         contract {
             callsInPlace(block, InvocationKind.EXACTLY_ONCE)
         }
-        return connection().use(block)
+        return logger.timed(action) {
+            connection().use(block)
+        }
     }
 
     fun eagerInit() {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/EmailService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/EmailService.kt
@@ -14,7 +14,7 @@ import org.thymeleaf.TemplateEngine
 import org.thymeleaf.context.Context
 import uk.gov.communities.delta.auth.config.EmailConfig
 import uk.gov.communities.delta.auth.plugins.makeTemplateResolver
-import uk.gov.communities.delta.auth.plugins.timed
+import uk.gov.communities.delta.auth.utils.timedSuspend
 import java.util.*
 
 
@@ -36,7 +36,7 @@ class EmailService(emailConfig: EmailConfig) {
         mappedValues: Map<String, String>,
     ) {
         withContext(Dispatchers.IO) {
-            logger.timed(
+            logger.timedSuspend(
                 "Send templated email",
                 { listOf(Pair("emailTemplate", template)) }
             ) {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/EmailService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/EmailService.kt
@@ -6,11 +6,15 @@ import jakarta.mail.Session
 import jakarta.mail.Transport
 import jakarta.mail.internet.InternetAddress
 import jakarta.mail.internet.MimeMessage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jetbrains.annotations.Blocking
 import org.slf4j.LoggerFactory
 import org.thymeleaf.TemplateEngine
 import org.thymeleaf.context.Context
 import uk.gov.communities.delta.auth.config.EmailConfig
 import uk.gov.communities.delta.auth.plugins.makeTemplateResolver
+import uk.gov.communities.delta.auth.plugins.timed
 import java.util.*
 
 
@@ -21,11 +25,28 @@ class EmailService(emailConfig: EmailConfig) {
 
     init {
         val templateResolver = templateEngine.makeTemplateResolver()
-        templateResolver.prefix = templateResolver.prefix + "emails/"
+        templateResolver.prefix += "emails/"
         templateEngine.setTemplateResolver(templateResolver)
     }
 
-    fun sendTemplateEmail(
+    suspend fun sendTemplateEmail(
+        template: String,
+        emailContacts: EmailContacts,
+        subject: String,
+        mappedValues: Map<String, String>,
+    ) {
+        withContext(Dispatchers.IO) {
+            logger.timed(
+                "Send templated email",
+                { listOf(Pair("emailTemplate", template)) }
+            ) {
+                blockingSendEmail(template, emailContacts, subject, mappedValues)
+            }
+        }
+    }
+
+    @Blocking
+    private fun blockingSendEmail(
         template: String,
         emailContacts: EmailContacts,
         subject: String,
@@ -33,6 +54,11 @@ class EmailService(emailConfig: EmailConfig) {
     ) {
         val context = Context(Locale.getDefault(), mappedValues)
         val content = templateEngine.process(template, context)
+        logger.atInfo()
+            .addKeyValue("emailTemplate", template)
+            .addKeyValue("emailTo", emailContacts.getTo())
+            .addKeyValue("emailSubject", subject)
+            .log("Sending email")
         try {
             val msg: Message = MimeMessage(session)
             msg.setFrom(emailContacts.getFrom())

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/GroupService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/GroupService.kt
@@ -25,8 +25,8 @@ class GroupService(
         return try {
             val attributes = ldapService.useServiceUserBind {
                 it.getAttributes(
-                        groupDn,
-                        arrayOf("cn")
+                    groupDn,
+                    arrayOf("cn")
                 )
             }
             attributes.get("cn") != null

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OAuthSessionService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OAuthSessionService.kt
@@ -59,7 +59,7 @@ class OAuthSessionService(private val dbPool: DbPool, private val timeSource: Ti
 
     @Blocking
     private fun insert(authCode: AuthCode, client: DeltaLoginEnabledClient, token: String, now: Instant): OAuthSession {
-        return dbPool.useConnection {
+        return dbPool.useConnectionBlocking("Insert delta_session") {
             val stmt = it.prepareStatement(
                 "INSERT INTO delta_session (username, client_id, auth_token_hash, created_at, trace_id) " +
                         "VALUES (?, ?, ?, ?, ?) RETURNING id"
@@ -86,7 +86,7 @@ class OAuthSessionService(private val dbPool: DbPool, private val timeSource: Ti
 
     @Blocking
     private fun select(authToken: String, client: DeltaLoginEnabledClient): OAuthSession? {
-        return dbPool.useConnection {
+        return dbPool.useConnectionBlocking("Read delta_session") {
             val stmt =
                 it.prepareStatement(
                     "SELECT id, username, client_id, created_at, trace_id " +

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OrganisationService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OrganisationService.kt
@@ -13,6 +13,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.config.DeltaConfig
+import uk.gov.communities.delta.auth.plugins.timed
 import java.time.LocalDate
 import kotlin.time.Duration.Companion.seconds
 
@@ -38,35 +39,21 @@ class OrganisationService(private val httpClient: HttpClient, private val deltaC
     private val logger = LoggerFactory.getLogger(javaClass)
 
     suspend fun findAllByDomain(domain: String): List<Organisation> {
-        return timed("Fetched organisations for domain {}", domain) {
+        return logger.timed(
+            "Fetch organisations for domain",
+            { listOf(Pair("organisationCount", it.size), Pair("domain", domain)) }) {
             httpClient.get(deltaConfig.masterStoreBaseNoAuth + "organisation/search?domain=${domain.encodeURLParameter()}")
                 .body<OrganisationSearchResponse>().organisations
         }
     }
 
     suspend fun findAllNamesAndCodes(): List<OrganisationNameAndCode> {
-        return timed("Fetched all organisation names and codes") {
+        return logger.timed(
+            "Fetch all organisation names and codes",
+            { listOf(Pair("organisationCount", it.size)) }) {
             httpClient.get(deltaConfig.masterStoreBaseNoAuth + "organisation/all-names-and-codes")
                 .body<List<OrganisationNameAndCode>>()
         }
-    }
-
-    private suspend fun <T> timed(
-        message: String,
-        vararg logParams: String,
-        block: suspend () -> List<T>,
-    ): List<T> {
-        val startTime = System.currentTimeMillis()
-        val result = try {
-            block()
-        } catch (e: Exception) {
-            logger.error("Request failed after {}ms", System.currentTimeMillis() - startTime, e)
-            throw e
-        }
-        logger.atInfo().addKeyValue("organisationCount", result.size)
-            .addKeyValue("durationMs", System.currentTimeMillis() - startTime)
-            .log(message, *logParams)
-        return result
     }
 
     companion object {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OrganisationService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OrganisationService.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.config.DeltaConfig
-import uk.gov.communities.delta.auth.plugins.timed
+import uk.gov.communities.delta.auth.utils.timedSuspend
 import java.time.LocalDate
 import kotlin.time.Duration.Companion.seconds
 
@@ -39,7 +39,7 @@ class OrganisationService(private val httpClient: HttpClient, private val deltaC
     private val logger = LoggerFactory.getLogger(javaClass)
 
     suspend fun findAllByDomain(domain: String): List<Organisation> {
-        return logger.timed(
+        return logger.timedSuspend(
             "Fetch organisations for domain",
             { listOf(Pair("organisationCount", it.size), Pair("domain", domain)) }) {
             httpClient.get(deltaConfig.masterStoreBaseNoAuth + "organisation/search?domain=${domain.encodeURLParameter()}")
@@ -48,7 +48,7 @@ class OrganisationService(private val httpClient: HttpClient, private val deltaC
     }
 
     suspend fun findAllNamesAndCodes(): List<OrganisationNameAndCode> {
-        return logger.timed(
+        return logger.timedSuspend(
             "Fetch all organisation names and codes",
             { listOf(Pair("organisationCount", it.size)) }) {
             httpClient.get(deltaConfig.masterStoreBaseNoAuth + "organisation/all-names-and-codes")

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
@@ -132,7 +132,7 @@ class RegistrationService(
                 emailService.sendTemplateEmail(
                     "already-a-user",
                     getRegistrationEmailContacts(registrationResult.registration),
-                    "DLUHC DELTA - Account",
+                    "DLUHC DELTA - Existing Account",
                     mapOf(
                         "deltaUrl" to deltaConfig.deltaWebsiteUrl,
                         "userFirstName" to registrationResult.registration.firstName,

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
@@ -34,7 +34,7 @@ class RegistrationService(
     suspend fun register(
         registration: Registration,
         organisations: List<Organisation>,
-        ssoUser: Boolean = false
+        ssoUser: Boolean = false,
     ): RegistrationResult {
         val adUser = UserService.ADUser(registration, ssoUser, ldapConfig)
         if (userLookupService.userExists(adUser.cn)) {
@@ -82,7 +82,7 @@ class RegistrationService(
                         organisationUserGroup(it.code)
                     )
                     logger.atInfo().addKeyValue("UserDN", adUser.dn)
-                            .log("Added user to domain organisation with code {}", it.code)
+                        .log("Added user to domain organisation with code {}", it.code)
                 } else {
                     logger.info("Organisation {} is retired, with retirement date: {}", it.code, it.retirementDate)
                 }
@@ -151,7 +151,7 @@ class RegistrationService(
 data class Registration(
     val firstName: String,
     val lastName: String,
-    val emailAddress: String
+    val emailAddress: String,
 )
 
 fun getResultTypeString(registrationResult: RegistrationService.RegistrationResult): String {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
@@ -105,7 +105,7 @@ class RegistrationService(
         )
     }
 
-    fun sendRegistrationEmail(registrationResult: RegistrationResult) {
+    suspend fun sendRegistrationEmail(registrationResult: RegistrationResult) {
         when (registrationResult) {
             is UserCreated -> {
                 emailService.sendTemplateEmail(

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserLookupService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserLookupService.kt
@@ -1,7 +1,5 @@
 package uk.gov.communities.delta.auth.services
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 import javax.naming.NameNotFoundException
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/tasks/DeleteOldAuthCodes.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/tasks/DeleteOldAuthCodes.kt
@@ -12,7 +12,7 @@ class DeleteOldAuthCodes(private val db: DbPool) : AuthServiceTask("DeleteOldAut
     // Tasks are run separately anyway
     @Suppress("BlockingMethodInNonBlockingContext")
     override suspend fun execute() {
-        db.useConnection {
+        db.useConnectionBlocking("DeleteOldAuthCodes") {
             val stmt = it.prepareStatement(
                 "DELETE FROM authorization_code WHERE created_at < ?"
             )

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/tasks/DeleteOldDeltaSessions.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/tasks/DeleteOldDeltaSessions.kt
@@ -13,7 +13,7 @@ class DeleteOldDeltaSessions(private val db: DbPool) :
     // Tasks are run separately anyway
     @Suppress("BlockingMethodInNonBlockingContext")
     override suspend fun execute() {
-        db.useConnection {
+        db.useConnectionBlocking("DeleteOldDeltaSessions") {
             val stmt = it.prepareStatement(
                 "DELETE FROM delta_session WHERE created_at < ?"
             )

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/utils/LoggerTimed.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/utils/LoggerTimed.kt
@@ -1,0 +1,49 @@
+package uk.gov.communities.delta.auth.utils
+
+import org.slf4j.Logger
+
+@Suppress("DuplicatedCode")
+fun <T> Logger.timed(
+    action: String,
+    logParams: (T) -> List<Pair<String, Any>> = { emptyList() },
+    block: () -> T,
+): T {
+    val startTime = System.currentTimeMillis()
+    val result = try {
+        block()
+    } catch (e: Exception) {
+        this.atWarn()
+            .addKeyValue("durationMs", System.currentTimeMillis() - startTime)
+            .log("Timed action {} failed", action, e)
+        throw e
+    }
+    this.atInfo()
+        .addKeyValue("timedAction", action)
+        .addKeyValue("durationMs", System.currentTimeMillis() - startTime)
+        .apply { logParams(result).forEach { addKeyValue(it.first, it.second) } }
+        .log("Timed action {} complete", action)
+    return result
+}
+
+@Suppress("DuplicatedCode")
+suspend fun <T> Logger.timedSuspend(
+    action: String,
+    logParams: (T) -> List<Pair<String, Any>> = { emptyList() },
+    block: suspend () -> T,
+): T {
+    val startTime = System.currentTimeMillis()
+    val result = try {
+        block()
+    } catch (e: Exception) {
+        this.atWarn()
+            .addKeyValue("durationMs", System.currentTimeMillis() - startTime)
+            .log("Timed action {} failed", action, e)
+        throw e
+    }
+    this.atInfo()
+        .addKeyValue("timedAction", action)
+        .addKeyValue("durationMs", System.currentTimeMillis() - startTime)
+        .apply { logParams(result).forEach { addKeyValue(it.first, it.second) } }
+        .log("Timed action {} complete", action)
+    return result
+}

--- a/auth-service/src/main/resources/logback.xml
+++ b/auth-service/src/main/resources/logback.xml
@@ -20,6 +20,8 @@
     <!-- These two only log errors, and log them at TRACE -->
     <logger name="io.ktor.auth.oauth" level="TRACE"/>
     <logger name="io.ktor.client.plugins.HttpTimeout" level="TRACE"/>
+    <!-- Timeouts and socket errors are logged at debug -->
+    <logger name="Application" level="DEBUG"/>
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaUserRegistrationControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaUserRegistrationControllerTest.kt
@@ -120,7 +120,7 @@ class DeltaUserRegistrationControllerTest {
                 emailService.sendTemplateEmail(
                     "already-a-user",
                     any(),
-                    "DLUHC DELTA - Account",
+                    "DLUHC DELTA - Existing Account",
                     any()
                 )
             }
@@ -185,7 +185,7 @@ class DeltaUserRegistrationControllerTest {
                 emailService.sendTemplateEmail(
                     "already-a-user",
                     any(),
-                    "DLUHC DELTA - Account",
+                    "DLUHC DELTA - Existing Account",
                     any()
                 )
             }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/SetPasswordTokenServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/SetPasswordTokenServiceTest.kt
@@ -65,7 +65,7 @@ class SetPasswordTokenServiceTest {
     fun testLookupExpiredToken() = testSuspend {
         val token = service.createToken(userCN)
         withContext(Dispatchers.IO) {
-            testDbPool.useConnection {
+            testDbPool.useConnectionBlocking("Test expire token") {
                 val stmt = it.prepareStatement(
                     "UPDATE set_password_tokens SET created_at = ? WHERE user_cn = ? "
                 )

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/tasks/DeleteOldAuthCodesTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/tasks/DeleteOldAuthCodesTest.kt
@@ -30,7 +30,7 @@ class DeleteOldAuthCodesTest {
         authorizationCodeService.generateAndStore("DeleteOldAuthCodesTest-old-user", testServiceClient(), "old-trace")
         time = { Instant.now() }
 
-        testDbPool.useConnection {
+        testDbPool.useConnectionBlocking("test") {
             assertEquals(
                 1,
                 countOldAuthCodes()
@@ -39,7 +39,7 @@ class DeleteOldAuthCodesTest {
 
         underTest.execute()
 
-        testDbPool.useConnection {
+        testDbPool.useConnectionBlocking("test") {
             assertEquals(
                 0,
                 countOldAuthCodes()
@@ -49,7 +49,7 @@ class DeleteOldAuthCodesTest {
     }
 
     private fun countOldAuthCodes(): Int {
-        return testDbPool.useConnection {
+        return testDbPool.useConnectionBlocking("test") {
             val resultSet = it.createStatement()
                 .executeQuery("SELECT COUNT(*) FROM authorization_code WHERE username = 'DeleteOldAuthCodesTest-old-user'")
             resultSet.next()


### PR DESCRIPTION
I think what happened on prod this morning:

* Someone tried to register, and it tried to send an email
* It needed the SSL socket factory setting, it was trying to send to the TLS port over plaintext
  * We must not have tested this on staging, sorry I should have done that when testing, I just tried test
* This took a long time/possibly forever to timeout
  * If it ever did timeout Ktor's error handler logs CancellationExceptions (from the HTTP request being cancelled) at Debug level, so we wouldn't have seen it
* It's a blocking call on one of the default threads, seems like it kept getting some requests waiting for it
* So then some requests started timing out waiting to be picked up, eventually enough of them did that ECS replaced it, then the next one would work fine until someone tried to register

This PR:

* Fixes the bug, adding `props["mail.smtp.socketFactory.class"] = "javax.net.ssl.SSLSocketFactory"`
* Adds timeouts to SMTP requests
* Moves email sending to the IO thread pool
* Enables Debug logging for the "Application" logger, so cancellation exceptions get logged
* Adds more logs for how long different operations take
