### PR TITLE
DT-570: Testing fix

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaResetPasswordController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaResetPasswordController.kt
@@ -75,7 +75,7 @@ class DeltaResetPasswordController(
         val formParameters = call.receiveParameters()
         val userCN = formParameters["userCN"].orEmpty()
         val token = formParameters["token"].orEmpty()
-        val tokenResult = resetPasswordTokenService.consumeToken(token, userCN)
+        val tokenResult = resetPasswordTokenService.consumeTokenIfValid(token, userCN)
         if (tokenResult is PasswordTokenService.ExpiredToken) {
             logger.atInfo().addKeyValue("userCN", userCN).log("Sending new reset password link (after expiry)")
             sendNewResetPasswordLink(userCN)
@@ -101,7 +101,7 @@ class DeltaResetPasswordController(
 
         if (message != null) return call.respondResetPasswordPage(message)
         logger.atInfo().addKeyValue("userCN", userCN).log()
-        val tokenResult = resetPasswordTokenService.consumeToken(token, userCN)
+        val tokenResult = resetPasswordTokenService.consumeTokenIfValid(token, userCN)
         call.respondToResult(tokenResult, newPassword)
     }
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSetPasswordController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSetPasswordController.kt
@@ -72,7 +72,7 @@ class DeltaSetPasswordController(
         val formParameters = call.receiveParameters()
         val userCN = formParameters["userCN"].orEmpty()
         val token = formParameters["token"].orEmpty()
-        val tokenResult = registrationSetPasswordTokenService.consumeToken(token, userCN)
+        val tokenResult = registrationSetPasswordTokenService.consumeTokenIfValid(token, userCN)
         if (tokenResult is PasswordTokenService.ExpiredToken) {
             sendNewSetPasswordLink(userCN)
             call.respondNewEmailSentPage(userCN.replace("!", "@"))
@@ -96,7 +96,7 @@ class DeltaSetPasswordController(
         val (message, newPassword) = passwordChecker.checkPasswordForErrors(call, userCN)
 
         if (message != null) return call.respondSetPasswordPage(message)
-        val tokenResult = registrationSetPasswordTokenService.consumeToken(token, userCN)
+        val tokenResult = registrationSetPasswordTokenService.consumeTokenIfValid(token, userCN)
         call.respondToResult(tokenResult, newPassword)
     }
 

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaResetPasswordControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaResetPasswordControllerTest.kt
@@ -78,7 +78,7 @@ class DeltaResetPasswordControllerTest {
             url = "/reset-password?userCN=" + userCN.encodeURLParameter() + "&token=" + validToken,
             formParameters = correctFormParameters()
         ).apply {
-            coVerify(exactly = 1) { resetPasswordTokenService.consumeToken(validToken, userCN) }
+            coVerify(exactly = 1) { resetPasswordTokenService.consumeTokenIfValid(validToken, userCN) }
             coVerify(exactly = 1) { userService.resetPassword(userDN, validPassword) }
             assertSuccessPageRedirect(status, headers)
         }
@@ -93,7 +93,7 @@ class DeltaResetPasswordControllerTest {
                 append("confirmPassword", "Not$validPassword")
             }
         ).apply {
-            coVerify(exactly = 0) { resetPasswordTokenService.consumeToken(validToken, userCN) }
+            coVerify(exactly = 0) { resetPasswordTokenService.consumeTokenIfValid(validToken, userCN) }
             coVerify(exactly = 0) { userService.resetPassword(any(), any()) }
             assertFormPage(bodyAsText())
             assertContains(bodyAsText(), "Passwords did not match")
@@ -110,7 +110,7 @@ class DeltaResetPasswordControllerTest {
                 append("confirmPassword", badPassword)
             }
         ).apply {
-            coVerify(exactly = 0) { resetPasswordTokenService.consumeToken(validToken, userCN) }
+            coVerify(exactly = 0) { resetPasswordTokenService.consumeTokenIfValid(validToken, userCN) }
             coVerify(exactly = 0) { userService.resetPassword(any(), any()) }
             assertFormPage(bodyAsText())
             assertContains(bodyAsText(), "Password must not be a commonly used password.")
@@ -127,7 +127,7 @@ class DeltaResetPasswordControllerTest {
                 append("confirmPassword", badPassword)
             }
         ).apply {
-            coVerify(exactly = 0) { resetPasswordTokenService.consumeToken(validToken, userCN) }
+            coVerify(exactly = 0) { resetPasswordTokenService.consumeTokenIfValid(validToken, userCN) }
             coVerify(exactly = 0) { userService.resetPassword(any(), any()) }
             assertFormPage(bodyAsText())
             assertContains(bodyAsText(), "Password must not contain any part(s) your username")
@@ -161,7 +161,7 @@ class DeltaResetPasswordControllerTest {
                 append("token", expiredToken)
             }
         ).apply {
-            coVerify(exactly = 1) { resetPasswordTokenService.consumeToken(expiredToken, userCN) }
+            coVerify(exactly = 1) { resetPasswordTokenService.consumeTokenIfValid(expiredToken, userCN) }
             assertEquals(emailTemplate.captured, "reset-password")
             coVerify(exactly = 1) { resetPasswordTokenService.createToken(userCN) }
             assertEquals(HttpStatusCode.OK, status)
@@ -203,16 +203,16 @@ class DeltaResetPasswordControllerTest {
             resetPasswordTokenService.validateToken("", any())
         } returns PasswordTokenService.NoSuchToken
         coEvery {
-            resetPasswordTokenService.consumeToken(validToken, userCN)
+            resetPasswordTokenService.consumeTokenIfValid(validToken, userCN)
         } returns PasswordTokenService.ValidToken(validToken, userCN)
         coEvery {
-            resetPasswordTokenService.consumeToken(expiredToken, userCN)
+            resetPasswordTokenService.consumeTokenIfValid(expiredToken, userCN)
         } returns PasswordTokenService.ExpiredToken(expiredToken, userCN)
         coEvery {
-            resetPasswordTokenService.consumeToken(invalidToken, userCN)
+            resetPasswordTokenService.consumeTokenIfValid(invalidToken, userCN)
         } returns PasswordTokenService.NoSuchToken
         coEvery {
-            resetPasswordTokenService.consumeToken("", any())
+            resetPasswordTokenService.consumeTokenIfValid("", any())
         } returns PasswordTokenService.NoSuchToken
         coEvery { emailService.sendTemplateEmail(capture(emailTemplate), any(), any(), any()) } just runs
         coEvery { resetPasswordTokenService.createToken(userCN) } returns "token"

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaSetPasswordControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaSetPasswordControllerTest.kt
@@ -77,7 +77,7 @@ class DeltaSetPasswordControllerTest {
             url = "/set-password?userCN=" + userCN.encodeURLParameter() + "&token=" + validToken,
             formParameters = correctFormParameters()
         ).apply {
-            coVerify(exactly = 1) { registrationSetPasswordTokenService.consumeToken(validToken, userCN) }
+            coVerify(exactly = 1) { registrationSetPasswordTokenService.consumeTokenIfValid(validToken, userCN) }
             assertSuccessPageRedirect(status, headers)
         }
     }
@@ -91,7 +91,7 @@ class DeltaSetPasswordControllerTest {
                 append("confirmPassword", "Not$validPassword")
             }
         ).apply {
-            coVerify(exactly = 0) { registrationSetPasswordTokenService.consumeToken(validToken, userCN) }
+            coVerify(exactly = 0) { registrationSetPasswordTokenService.consumeTokenIfValid(validToken, userCN) }
             assertFormPage(bodyAsText())
             assertContains(bodyAsText(), "Passwords did not match")
         }
@@ -107,7 +107,7 @@ class DeltaSetPasswordControllerTest {
                 append("confirmPassword", badPassword)
             }
         ).apply {
-            coVerify(exactly = 0) { registrationSetPasswordTokenService.consumeToken(validToken, userCN) }
+            coVerify(exactly = 0) { registrationSetPasswordTokenService.consumeTokenIfValid(validToken, userCN) }
             assertFormPage(bodyAsText())
             assertContains(
                 bodyAsText(),
@@ -126,7 +126,7 @@ class DeltaSetPasswordControllerTest {
                 append("confirmPassword", badPassword)
             }
         ).apply {
-            coVerify(exactly = 0) { registrationSetPasswordTokenService.consumeToken(validToken, userCN) }
+            coVerify(exactly = 0) { registrationSetPasswordTokenService.consumeTokenIfValid(validToken, userCN) }
             assertFormPage(bodyAsText())
             assertContains(
                 bodyAsText(),
@@ -161,7 +161,7 @@ class DeltaSetPasswordControllerTest {
                 append("token", expiredToken)
             }
         ).apply {
-            coVerify(exactly = 1) { registrationSetPasswordTokenService.consumeToken(expiredToken, userCN) }
+            coVerify(exactly = 1) { registrationSetPasswordTokenService.consumeTokenIfValid(expiredToken, userCN) }
             assertEquals(emailTemplate.captured, "not-yet-enabled-user")
             coVerify(exactly = 1) { registrationSetPasswordTokenService.createToken(userCN) }
             assertEquals(HttpStatusCode.OK, status)
@@ -203,16 +203,16 @@ class DeltaSetPasswordControllerTest {
             registrationSetPasswordTokenService.validateToken("", any())
         } returns PasswordTokenService.NoSuchToken
         coEvery {
-            registrationSetPasswordTokenService.consumeToken(validToken, userCN)
+            registrationSetPasswordTokenService.consumeTokenIfValid(validToken, userCN)
         } returns PasswordTokenService.ValidToken(validToken, userCN)
         coEvery {
-            registrationSetPasswordTokenService.consumeToken(expiredToken, userCN)
+            registrationSetPasswordTokenService.consumeTokenIfValid(expiredToken, userCN)
         } returns PasswordTokenService.ExpiredToken(expiredToken, userCN)
         coEvery {
-            registrationSetPasswordTokenService.consumeToken(invalidToken, userCN)
+            registrationSetPasswordTokenService.consumeTokenIfValid(invalidToken, userCN)
         } returns PasswordTokenService.NoSuchToken
         coEvery {
-            registrationSetPasswordTokenService.consumeToken("", any())
+            registrationSetPasswordTokenService.consumeTokenIfValid("", any())
         } returns PasswordTokenService.NoSuchToken
         coEvery { emailService.sendTemplateEmail(capture(emailTemplate), any(), any(), any()) } just runs
         coEvery { registrationSetPasswordTokenService.createToken(userCN) } returns "token"

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/PasswordTokenServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/PasswordTokenServiceTest.kt
@@ -59,7 +59,7 @@ class PasswordTokenServiceTest {
     @Test
     fun testLookupForSetWithDelete() = testSuspend {
         val token = registrationSetPasswordTokenService.createToken(userCN)
-        var result = registrationSetPasswordTokenService.consumeToken(token, userCN)
+        var result = registrationSetPasswordTokenService.consumeTokenIfValid(token, userCN)
         assertTrue(result is PasswordTokenService.ValidToken)
         result = registrationSetPasswordTokenService.validateToken(token, userCN)
         assertTrue(result is PasswordTokenService.NoSuchToken)
@@ -68,7 +68,7 @@ class PasswordTokenServiceTest {
     @Test
     fun testLookupForResetWithDelete() = testSuspend {
         val token = resetPasswordTokenService.createToken(userCN)
-        var result = resetPasswordTokenService.consumeToken(token, userCN)
+        var result = resetPasswordTokenService.consumeTokenIfValid(token, userCN)
         assertTrue(result is PasswordTokenService.ValidToken)
         result = resetPasswordTokenService.validateToken(token, userCN)
         assertTrue(result is PasswordTokenService.NoSuchToken)
@@ -98,7 +98,7 @@ class PasswordTokenServiceTest {
         val replacementToken = registrationSetPasswordTokenService.createToken(userCN)
         var result = registrationSetPasswordTokenService.validateToken(originalToken, userCN)
         assertTrue(result is PasswordTokenService.NoSuchToken)
-        result = registrationSetPasswordTokenService.consumeToken(replacementToken, userCN)
+        result = registrationSetPasswordTokenService.consumeTokenIfValid(replacementToken, userCN)
         assertTrue(result is PasswordTokenService.ValidToken)
     }
 
@@ -108,7 +108,7 @@ class PasswordTokenServiceTest {
         val replacementToken = resetPasswordTokenService.createToken(userCN)
         var result = resetPasswordTokenService.validateToken(originalToken, userCN)
         assertTrue(result is PasswordTokenService.NoSuchToken)
-        result = resetPasswordTokenService.consumeToken(replacementToken, userCN)
+        result = resetPasswordTokenService.consumeTokenIfValid(replacementToken, userCN)
         assertTrue(result is PasswordTokenService.ValidToken)
     }
 
@@ -178,7 +178,7 @@ class PasswordTokenServiceTest {
         assertTrue(setTokenResult is PasswordTokenService.ValidToken)
         val setTokenAsResetTokenResult = resetPasswordTokenService.validateToken(setToken, userCN)
         assertEquals(PasswordTokenService.NoSuchToken, setTokenAsResetTokenResult)
-        val resetTokenResult = resetPasswordTokenService.consumeToken(resetToken, userCN)
+        val resetTokenResult = resetPasswordTokenService.consumeTokenIfValid(resetToken, userCN)
         assertTrue(resetTokenResult is PasswordTokenService.ValidToken)
         setTokenResult = registrationSetPasswordTokenService.validateToken(setToken, userCN)
         assertTrue(setTokenResult is PasswordTokenService.ValidToken)


### PR DESCRIPTION
Fix bug raised in testing (see comment: https://dluhcdigital.atlassian.net/browse/DT-570?focusedCommentId=441368)

> Mostly works, but if you register, load the set password page, then wait for your token to expire, you get the Send new activation email page, but pressing the button errors because the token has been deleted

All automated tests pass, manual testing of the expired token scenarios passes