### PR TITLE
DT-569: small fixes from testing

### DIFF
--- a/auth-service/src/main/resources/templates/thymeleaf/emails/fragments/template.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/emails/fragments/template.html
@@ -3,7 +3,7 @@
 
 <head th:fragment="email-head (title)">
     <meta charset="utf-8"/>
-    <title>${title}</title>
+    <title th:text="${title}"></title>
     <style>
         p {
             font-family: calibri, serif;

--- a/auth-service/src/main/resources/templates/thymeleaf/reset-password-email-sent.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/reset-password-email-sent.html
@@ -27,7 +27,7 @@
                     in the email is only valid for 24 hours. Click <b>'Reset your password'</b> link in the email to
                     complete the password reset. </p>
                 <p class="govuk-body">If you have not received an email after 15 minutes, please check the email address
-                    (<span data-th-text="${email}"></span>) is correctly spelt and is the email address linked to your
+                    (<span data-th-text="${emailAddress}"></span>) is correctly spelt and is the email address linked to your
                     account. If you have any issues contact the DLUHC Service Desk:
                     <a class="govuk-link" href="mailto:dluhc.digital-services@levellingup.gov.uk">dluhc.digital-services@levellingup.gov.uk</a>
                     or call 0203 829 0743.</p>


### PR DESCRIPTION
Fixes two small issues found in testing:
* Email title appears as `${title}` in the email content in some mail apps
* Email address doesn't appear in confirmation message because of var name typo

Also here are some other observations from testing that I haven't addressed because they're not super important:

* "Reset Password Error" - shouldn't this error appear when you land on the page rather than after you submit the new password? I know the validation has to be done on submit, so probably not worth also validating on page load just to improve UX for a rare scenario
* Request IDs - I think we might be too eager to tell the user to contact support with a request ID. It makes the error message a bit busier/intimidating and we should have a bit more faith in the app - if the system says their reset token is invalid, then it's invalid for a good reason and they should not contact support.

Also, I hit the rate limit on the site without triggering any CloudWatch alarm. Is that expected?