### PR TITLE
DT-612 Audit log

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -167,6 +167,7 @@ class Injection(
             authorizationCodeService,
             failedLoginCounter,
             successfulLoginCounter,
+            userAuditService,
         )
     }
 
@@ -241,6 +242,7 @@ class Injection(
             registrationService,
             organisationService,
             ssoLoginCounter,
+            userAuditService,
         )
 
     fun groupService() = GroupService(ldapService, ldapConfig)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -130,6 +130,7 @@ class Injection(
     val failedLoginCounter: Counter = meterRegistry.counter("login.failedLogins")
     val loginRateLimitCounter: Counter = meterRegistry.counter("login.rateLimitedRequests")
     val successfulLoginCounter: Counter = meterRegistry.counter("login.successfulLogins")
+    val ssoLoginCounter: Counter = meterRegistry.counter("login.ssoLogins")
 
     val registrationRateLimitCounter: Counter = meterRegistry.counter("registration.rateLimitedRequests")
     val setPasswordRateLimitCounter: Counter = meterRegistry.counter("setPassword.rateLimitedRequests")
@@ -239,6 +240,7 @@ class Injection(
             microsoftGraphService,
             registrationService,
             organisationService,
+            ssoLoginCounter,
         )
 
     fun groupService() = GroupService(ldapService, ldapConfig)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -90,6 +90,8 @@ class Injection(
 
     val dbPool = DbPool(databaseConfig)
 
+    val userAuditTrailRepo = UserAuditTrailRepo()
+    val userAuditService = UserAuditService(userAuditTrailRepo, dbPool)
     val registrationSetPasswordTokenService = RegistrationSetPasswordTokenService(dbPool, TimeSource.System)
     val resetPasswordTokenService = ResetPasswordTokenService(dbPool, TimeSource.System)
     val organisationService = OrganisationService(OrganisationService.makeHTTPClient(), deltaConfig)
@@ -163,7 +165,7 @@ class Injection(
             adLoginService,
             authorizationCodeService,
             failedLoginCounter,
-            successfulLoginCounter
+            successfulLoginCounter,
         )
     }
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaLoginController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaLoginController.kt
@@ -19,6 +19,7 @@ import uk.gov.communities.delta.auth.oauthClientLoginRoute
 import uk.gov.communities.delta.auth.security.IADLdapLoginService
 import uk.gov.communities.delta.auth.services.AuthorizationCodeService
 import uk.gov.communities.delta.auth.services.LdapUser
+import uk.gov.communities.delta.auth.services.UserAuditService
 import uk.gov.communities.delta.auth.services.withAuthCode
 
 
@@ -30,6 +31,7 @@ class DeltaLoginController(
     private val authorizationCodeService: AuthorizationCodeService,
     private val failedLoginCounter: Counter,
     private val successfulLoginCounter: Counter,
+    private val userAuditService: UserAuditService
 ) {
     private val logger = LoggerFactory.getLogger(this.javaClass)
 
@@ -184,6 +186,7 @@ class DeltaLoginController(
                 )
 
                 logger.atInfo().withAuthCode(authCode).log("Successful login")
+                userAuditService.userFormLoginAudit(loginResult.user.cn, call)
                 successfulLoginCounter.increment(1.0)
                 call.respondRedirect(client.deltaWebsiteUrl + "/login/oauth2/redirect?code=${authCode.code}&state=${queryParams.state.encodeURLParameter()}")
             }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSSOLoginController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSSOLoginController.kt
@@ -8,6 +8,7 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.server.sessions.*
 import io.ktor.util.*
+import io.micrometer.core.instrument.Counter
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -36,6 +37,7 @@ class DeltaSSOLoginController(
     private val microsoftGraphService: MicrosoftGraphService,
     private val registrationService: RegistrationService,
     private val organisationService: OrganisationService,
+    private val ssoLoginCounter: Counter,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -104,6 +106,7 @@ class DeltaSSOLoginController(
         )
 
         logger.atInfo().withAuthCode(authCode).log("Successful OAuth login")
+        ssoLoginCounter.increment()
         call.sessions.clear<LoginSessionCookie>()
         call.respondRedirect(client.deltaWebsiteUrl + "/login/oauth2/redirect?code=${authCode.code}&state=${session.deltaState.encodeURLParameter()}")
     }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
@@ -152,6 +152,7 @@ data class Registration(
     val firstName: String,
     val lastName: String,
     val emailAddress: String,
+    val azureObjectId: String? = null,
 )
 
 fun getResultTypeString(registrationResult: RegistrationService.RegistrationResult): String {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditService.kt
@@ -3,12 +3,27 @@ package uk.gov.communities.delta.auth.services
 import io.ktor.server.application.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import uk.gov.communities.delta.auth.config.AzureADSSOClient
 
 class UserAuditService(private val userAuditTrailRepo: UserAuditTrailRepo, private val dbPool: DbPool) {
     suspend fun userFormLoginAudit(userCn: String, call: ApplicationCall) {
         withContext(Dispatchers.IO) {
             dbPool.useConnectionBlocking("audit_form_login") {
                 userAuditTrailRepo.userFormLoginAudit(it, userCn, call)
+                it.commit()
+            }
+        }
+    }
+
+    suspend fun userSSOLoginAudit(
+        userCn: String,
+        ssoClient: AzureADSSOClient,
+        azureUserObjectId: String,
+        call: ApplicationCall,
+    ) {
+        withContext(Dispatchers.IO) {
+            dbPool.useConnectionBlocking("audit_sso_login") {
+                userAuditTrailRepo.userSSOLoginAudit(it, userCn, ssoClient, azureUserObjectId, call)
                 it.commit()
             }
         }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditService.kt
@@ -1,0 +1,16 @@
+package uk.gov.communities.delta.auth.services
+
+import io.ktor.server.application.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class UserAuditService(private val userAuditTrailRepo: UserAuditTrailRepo, private val dbPool: DbPool) {
+    suspend fun userFormLoginAudit(userCn: String, call: ApplicationCall) {
+        withContext(Dispatchers.IO) {
+            dbPool.useConnectionBlocking("audit_form_login") {
+                userAuditTrailRepo.userFormLoginAudit(it, userCn, call)
+                it.commit()
+            }
+        }
+    }
+}

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditTrailRepo.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditTrailRepo.kt
@@ -46,7 +46,8 @@ class UserAuditTrailRepo {
     fun getAuditForUser(conn: Connection, userCn: String): List<UserAuditRow> {
         val stmt = conn.prepareStatement(
             "SELECT action, timestamp, user_cn, editing_user_cn, request_id, action_data " +
-                    "FROM user_audit WHERE user_cn = ?"
+                    "FROM user_audit WHERE user_cn = ? " +
+                    "ORDER BY timestamp"
         )
         stmt.setString(1, userCn)
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditTrailRepo.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditTrailRepo.kt
@@ -1,0 +1,85 @@
+package uk.gov.communities.delta.auth.services
+
+import io.ktor.server.application.*
+import io.ktor.server.plugins.callid.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import org.jetbrains.annotations.Blocking
+import java.sql.Connection
+import java.sql.ResultSet
+import java.sql.Timestamp
+
+class UserAuditTrailRepo {
+    enum class AuditAction(val action: String) {
+        FORM_LOGIN("form_login");
+
+        companion object {
+            fun fromActionString(s: String) = entries.first { it.action == s }
+        }
+    }
+
+    @Blocking
+    fun userFormLoginAudit(conn: Connection, userCn: String, call: ApplicationCall) {
+        insertAuditRow(conn, AuditAction.FORM_LOGIN, userCn, null, call.callId!!, null)
+    }
+
+    @Blocking
+    fun getAuditForUser(conn: Connection, userCn: String): List<UserAuditRow> {
+        val stmt = conn.prepareStatement(
+            "SELECT action, timestamp, user_cn, editing_user_cn, request_id, action_data " +
+                    "FROM user_audit WHERE user_cn = ?"
+        )
+        stmt.setString(1, userCn)
+
+        return stmt.executeQuery().map {
+            UserAuditRow(
+                AuditAction.fromActionString(it.getString("action")),
+                it.getTimestamp("timestamp"),
+                it.getString("user_cn"),
+                it.getString("editing_user_cn"),
+                it.getString("request_id"),
+                Json.parseToJsonElement(it.getString("action_data")),
+            )
+        }
+    }
+
+    @Blocking
+    private fun insertAuditRow(
+        conn: Connection,
+        action: AuditAction,
+        userCn: String,
+        editingUserCn: String?,
+        requestId: String,
+        actionData: Serializable?,
+    ) {
+        val stmt = conn.prepareStatement(
+            "INSERT INTO user_audit (action, timestamp, user_cn, editing_user_cn, request_id, action_data) VALUES " +
+                    "(?, now(), ?, ?, ?, ? ::jsonb)"
+        )
+        stmt.setString(1, action.action)
+        stmt.setString(2, userCn)
+        stmt.setString(3, editingUserCn)
+        stmt.setString(4, requestId)
+        stmt.setString(5, if (actionData == null) "{}" else Json.encodeToString(actionData))
+        stmt.executeUpdate()
+    }
+
+    data class UserAuditRow(
+        val action: AuditAction,
+        val timestamp: Timestamp,
+        val userCn: String,
+        val editingUserCn: String?,
+        val requestId: String,
+        val actionData: JsonElement,
+    )
+}
+
+fun <T> ResultSet.map(m: (ResultSet) -> T): List<T> {
+    val result = mutableListOf<T>()
+    while (this.next()) {
+        result.add(m(this))
+    }
+    return result
+}

--- a/auth-service/src/main/resources/db/migration/V4__user_audit.sql
+++ b/auth-service/src/main/resources/db/migration/V4__user_audit.sql
@@ -1,0 +1,11 @@
+CREATE TABLE user_audit
+(
+    action          text      NOT NULL,
+    timestamp       timestamp NOT NULL,
+    user_cn         text      NOT NULL,
+    editing_user_cn text,
+    request_id      text      NOT NULL,
+    action_data     jsonb     NOT NULL
+);
+
+CREATE INDEX user_audit_user_timestamp ON user_audit (user_cn, timestamp);

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditServiceTest.kt
@@ -1,0 +1,64 @@
+package uk.gov.communities.delta.dbintegration
+
+import io.ktor.server.application.*
+import io.ktor.server.plugins.callid.*
+import io.ktor.test.dispatcher.*
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.BeforeClass
+import org.junit.Test
+import uk.gov.communities.delta.auth.config.AzureADSSOClient
+import uk.gov.communities.delta.auth.services.UserAuditService
+import uk.gov.communities.delta.auth.services.UserAuditTrailRepo
+import uk.gov.communities.delta.helper.testServiceClient
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class UserAuditServiceTest {
+    @Test
+    fun testUserLoginAudit() = testSuspend {
+        assertEquals(0, service.getAuditForUser("login.user!example.com").size)
+
+        service.userFormLoginAudit("login.user!example.com", call)
+
+        val audit = service.getAuditForUser("login.user!example.com")
+        assertEquals(1, audit.size)
+        assertEquals("login.user!example.com", audit[0].userCn)
+        assertEquals(call.callId, audit[0].requestId)
+        assertNull(audit[0].editingUserCn)
+        assertEquals(UserAuditTrailRepo.AuditAction.FORM_LOGIN, audit[0].action)
+    }
+
+    @Test
+    fun testSSOLoginAudit() = testSuspend {
+        service.userSSOLoginAudit(
+            "sso.user!example.com",
+                AzureADSSOClient("sso-id", "", "", "", "@example.com"),
+                "az-123", call,
+            )
+
+        val audit = service.getAuditForUser("sso.user!example.com")
+        assertEquals(1, audit.size)
+        assertEquals("sso.user!example.com", audit[0].userCn)
+        assertEquals(call.callId, audit[0].requestId)
+        assertNull(audit[0].editingUserCn)
+        assertEquals(UserAuditTrailRepo.AuditAction.SSO_LOGIN, audit[0].action)
+        assertEquals("az-123", audit[0].actionData.jsonObject["azureUserObjectId"]!!.jsonPrimitive.content)
+    }
+
+    companion object {
+        lateinit var service: UserAuditService
+        val client = testServiceClient()
+        val call = mockk<ApplicationCall>()
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            val repo = UserAuditTrailRepo()
+            service = UserAuditService(repo, testDbPool)
+            every { call.callId } returns "request-id-1234"
+        }
+    }
+}

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditTrailRepoTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditTrailRepoTest.kt
@@ -1,54 +1,37 @@
 package uk.gov.communities.delta.dbintegration
 
-import io.ktor.server.application.*
-import io.ktor.server.plugins.callid.*
-import io.mockk.every
-import io.mockk.mockk
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.BeforeClass
 import org.junit.Test
-import uk.gov.communities.delta.auth.config.AzureADSSOClient
 import uk.gov.communities.delta.auth.services.UserAuditTrailRepo
-import uk.gov.communities.delta.helper.testServiceClient
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class UserAuditTrailRepoTest {
     @Test
-    fun testUserLoginAudit() {
+    fun testUserAudit() {
         testDbPool.useConnectionBlocking("test_login_audit") {
             assertEquals(0, repo.getAuditForUser(it, "some.user!example.com").size)
 
-            repo.userFormLoginAudit(it, "some.user!example.com", call)
-
-            val audit = repo.getAuditForUser(it, "some.user!example.com")
-            assertEquals(1, audit.size)
-            assertEquals("some.user!example.com", audit[0].userCn)
-            assertEquals(call.callId, audit[0].requestId)
-            assertNull(audit[0].editingUserCn)
-            assertEquals(UserAuditTrailRepo.AuditAction.FORM_LOGIN, audit[0].action)
-
-            it.rollback()
-        }
-    }
-
-    @Test
-    fun testSSOLoginAudit() {
-        testDbPool.useConnectionBlocking("test_sso_login_audit") {
-            repo.userSSOLoginAudit(
-                it, "some.user!example.com",
-                AzureADSSOClient("sso-id", "", "", "", "@example.com"),
-                "az-123", call,
+            repo.insertAuditRow(
+                it,
+                UserAuditTrailRepo.AuditAction.FORM_LOGIN,
+                "some.user!example.com",
+                null,
+                "requestId",
+                "{\"key\": \"value\"}"
             )
 
             val audit = repo.getAuditForUser(it, "some.user!example.com")
             assertEquals(1, audit.size)
             assertEquals("some.user!example.com", audit[0].userCn)
-            assertEquals(call.callId, audit[0].requestId)
+            assertEquals("requestId", audit[0].requestId)
             assertNull(audit[0].editingUserCn)
-            assertEquals(UserAuditTrailRepo.AuditAction.SSO_LOGIN, audit[0].action)
-            assertEquals("az-123", audit[0].actionData.jsonObject["azureUserObjectId"]!!.jsonPrimitive.content)
+            assertEquals(UserAuditTrailRepo.AuditAction.FORM_LOGIN, audit[0].action)
+            assertEquals("value", audit[0].actionData.jsonObject["key"]!!.jsonPrimitive.content)
+
+            assertEquals(0, repo.getAuditForUser(it, "other.user!example.com").size)
 
             it.rollback()
         }
@@ -56,14 +39,11 @@ class UserAuditTrailRepoTest {
 
     companion object {
         lateinit var repo: UserAuditTrailRepo
-        val client = testServiceClient()
-        val call = mockk<ApplicationCall>()
 
         @BeforeClass
         @JvmStatic
         fun setup() {
             repo = UserAuditTrailRepo()
-            every { call.callId } returns "request-id-1234"
         }
     }
 }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditTrailRepoTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditTrailRepoTest.kt
@@ -2,22 +2,54 @@ package uk.gov.communities.delta.dbintegration
 
 import io.ktor.server.application.*
 import io.ktor.server.plugins.callid.*
-import io.ktor.test.dispatcher.*
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.BeforeClass
 import org.junit.Test
+import uk.gov.communities.delta.auth.config.AzureADSSOClient
 import uk.gov.communities.delta.auth.services.UserAuditTrailRepo
 import uk.gov.communities.delta.helper.testServiceClient
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class UserAuditTrailRepoTest {
     @Test
     fun testUserLoginAudit() {
         testDbPool.useConnectionBlocking("test_login_audit") {
             assertEquals(0, repo.getAuditForUser(it, "some.user!example.com").size)
+
             repo.userFormLoginAudit(it, "some.user!example.com", call)
-            assertEquals(1, repo.getAuditForUser(it, "some.user!example.com").size)
+
+            val audit = repo.getAuditForUser(it, "some.user!example.com")
+            assertEquals(1, audit.size)
+            assertEquals("some.user!example.com", audit[0].userCn)
+            assertEquals(call.callId, audit[0].requestId)
+            assertNull(audit[0].editingUserCn)
+            assertEquals(UserAuditTrailRepo.AuditAction.FORM_LOGIN, audit[0].action)
+
+            it.rollback()
+        }
+    }
+
+    @Test
+    fun testSSOLoginAudit() {
+        testDbPool.useConnectionBlocking("test_sso_login_audit") {
+            repo.userSSOLoginAudit(
+                it, "some.user!example.com",
+                AzureADSSOClient("sso-id", "", "", "", "@example.com"),
+                "az-123", call,
+            )
+
+            val audit = repo.getAuditForUser(it, "some.user!example.com")
+            assertEquals(1, audit.size)
+            assertEquals("some.user!example.com", audit[0].userCn)
+            assertEquals(call.callId, audit[0].requestId)
+            assertNull(audit[0].editingUserCn)
+            assertEquals(UserAuditTrailRepo.AuditAction.SSO_LOGIN, audit[0].action)
+            assertEquals("az-123", audit[0].actionData.jsonObject["azureUserObjectId"]!!.jsonPrimitive.content)
+
             it.rollback()
         }
     }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditTrailRepoTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditTrailRepoTest.kt
@@ -1,0 +1,37 @@
+package uk.gov.communities.delta.dbintegration
+
+import io.ktor.server.application.*
+import io.ktor.server.plugins.callid.*
+import io.ktor.test.dispatcher.*
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.BeforeClass
+import org.junit.Test
+import uk.gov.communities.delta.auth.services.UserAuditTrailRepo
+import uk.gov.communities.delta.helper.testServiceClient
+import kotlin.test.assertEquals
+
+class UserAuditTrailRepoTest {
+    @Test
+    fun testUserLoginAudit() {
+        testDbPool.useConnectionBlocking("test_login_audit") {
+            assertEquals(0, repo.getAuditForUser(it, "some.user!example.com").size)
+            repo.userFormLoginAudit(it, "some.user!example.com", call)
+            assertEquals(1, repo.getAuditForUser(it, "some.user!example.com").size)
+            it.rollback()
+        }
+    }
+
+    companion object {
+        lateinit var repo: UserAuditTrailRepo
+        val client = testServiceClient()
+        val call = mockk<ApplicationCall>()
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            repo = UserAuditTrailRepo()
+            every { call.callId } returns "request-id-1234"
+        }
+    }
+}

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthSSOLoginTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthSSOLoginTest.kt
@@ -30,6 +30,7 @@ import uk.gov.communities.delta.auth.services.*
 import uk.gov.communities.delta.auth.services.sso.MicrosoftGraphService
 import uk.gov.communities.delta.auth.services.sso.SSOLoginSessionStateService
 import uk.gov.communities.delta.auth.services.sso.SSOOAuthClientProviderLookupService
+import uk.gov.communities.delta.controllers.DeltaLoginControllerTest
 import uk.gov.communities.delta.helper.testLdapUser
 import uk.gov.communities.delta.helper.testServiceClient
 import java.time.Instant
@@ -285,6 +286,7 @@ class OAuthSSOLoginTest {
             listOf(ssoClient.requiredGroupId!!)
         }
         every { ssoConfig.ssoClients } answers { listOf(ssoClient) }
+        coEvery { DeltaLoginControllerTest.userAuditService.userFormLoginAudit(any(), any()) } returns Unit
     }
 
     private fun String.stateFromRedirectUrl() =
@@ -314,6 +316,7 @@ class OAuthSSOLoginTest {
         private lateinit var ssoLoginStateService: SSOLoginSessionStateService
         private lateinit var registrationService: RegistrationService
         private lateinit var organisationService: OrganisationService
+        private lateinit var  userAuditService: UserAuditService
 
         @BeforeClass
         @JvmStatic
@@ -324,6 +327,7 @@ class OAuthSSOLoginTest {
             ldapUserLookupServiceMock = mockk<UserLookupService>()
             registrationService = mockk<RegistrationService>()
             organisationService = mockk<OrganisationService>()
+            userAuditService = mockk<UserAuditService>()
             val loginPageController = DeltaLoginController(
                 listOf(serviceClient),
                 ssoConfig,
@@ -331,7 +335,8 @@ class OAuthSSOLoginTest {
                 mockk(),
                 authorizationCodeServiceMock,
                 counter("failedLoginNoopCounter"),
-                counter("successfulLoginNoopCounter")
+                counter("successfulLoginNoopCounter"),
+                userAuditService
             )
             val oauthController = DeltaSSOLoginController(
                 deltaConfig,

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthSSOLoginTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthSSOLoginTest.kt
@@ -76,7 +76,7 @@ class OAuthSSOLoginTest {
             assertEquals(HttpStatusCode.Found, status)
             assertEquals("https://delta/login/oauth2/redirect?code=code&state=delta-state", headers["Location"])
             coVerify(exactly = 1) { authorizationCodeServiceMock.generateAndStore("cn", serviceClient, any()) }
-            verify(exactly = 1) { loginCounter.increment() }
+            verify(exactly = 1) { ssoLoginCounter.increment() }
             coVerify(exactly = 1) {
                 userAuditService.userSSOLoginAudit("cn", ssoClient, "abc-123", any())
             }
@@ -291,7 +291,7 @@ class OAuthSSOLoginTest {
         }
         every { ssoConfig.ssoClients } answers { listOf(ssoClient) }
         coEvery { userAuditService.userSSOLoginAudit(any(), any(), any(), any()) } returns Unit
-        every { loginCounter.increment() } just runs
+        every { ssoLoginCounter.increment() } just runs
     }
 
     private fun String.stateFromRedirectUrl() =
@@ -322,7 +322,7 @@ class OAuthSSOLoginTest {
         private lateinit var registrationService: RegistrationService
         private lateinit var organisationService: OrganisationService
         private lateinit var userAuditService: UserAuditService
-        private lateinit var loginCounter: Counter
+        private lateinit var ssoLoginCounter: Counter
 
         @BeforeClass
         @JvmStatic
@@ -334,7 +334,7 @@ class OAuthSSOLoginTest {
             registrationService = mockk<RegistrationService>()
             organisationService = mockk<OrganisationService>()
             userAuditService = mockk<UserAuditService>()
-            loginCounter = mockk<Counter>()
+            ssoLoginCounter = mockk<Counter>()
             val loginPageController = DeltaLoginController(
                 listOf(serviceClient),
                 ssoConfig,
@@ -355,7 +355,7 @@ class OAuthSSOLoginTest {
                 microsoftGraphServiceMock,
                 registrationService,
                 organisationService,
-                loginCounter,
+                ssoLoginCounter,
                 userAuditService,
             )
             val oauthClientProviderLookupService = SSOOAuthClientProviderLookupService(


### PR DESCRIPTION
Start adding an audit log, currently only auditing logins.

See [DT-612](https://dluhcdigital.atlassian.net/browse/DT-612) for a HLD.

I think the service (business logic, suspend functions) and repositories (plumbing, in this case database queries that are blocking) pattern fits quite well here. It's nice to divide blocking + suspend, and it should make it easy to combine queries into larger transactions which isn't straightforward at the moment. If everyone else is happy with it I'll do some refactoring of the other services too at some point.

[DT-612]: https://dluhcdigital.atlassian.net/browse/DT-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ