### PR TITLE
Email address checking from SSO changes

### DIFF
--- a/auth-service/src/main/resources/templates/thymeleaf/delta-login.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/delta-login.html
@@ -75,8 +75,8 @@
                 </a>
                 <div th:if="${ssoClients.size() > 0}">
                     <h2 class="govuk-heading-m">DLUHC users</h2>
-                    <a class="govuk-button govuk-button--secondary" draggable="false" href="/delta/oauth/login"
-                       role="button" style="margin-right: 1.5em" th:each="ssoClient: ${ssoClients}"
+                    <a class="govuk-button govuk-button--secondary govuk-!-margin-right-4" draggable="false" role="button"
+                       href="/delta/oauth/login" th:each="ssoClient: ${ssoClients}"
                        th:href="'/delta/oauth/' + ${ssoClient.internalId} + '/login'" th:text="${ssoClient.buttonText}">
                         Single Sign On
                     </a>


### PR DESCRIPTION
Removing a TODO now we've tested with DLUHC AD.

`unique_name` does seem to be an email in DLUHC test AD. A `mail` claim doesn't get returned, even when requesting the "email" scope, so we rely on `unique_name`, and check that it looks like an email address.