### PR TITLE
DT-612 Add CSV audit log export

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSSOLoginController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSSOLoginController.kt
@@ -19,7 +19,7 @@ import uk.gov.communities.delta.auth.config.AzureADSSOClient
 import uk.gov.communities.delta.auth.config.AzureADSSOConfig
 import uk.gov.communities.delta.auth.config.ClientConfig
 import uk.gov.communities.delta.auth.config.DeltaConfig
-import uk.gov.communities.delta.auth.plugins.HttpNotFoundException
+import uk.gov.communities.delta.auth.plugins.HttpNotFound404PageException
 import uk.gov.communities.delta.auth.plugins.UserVisibleServerError
 import uk.gov.communities.delta.auth.repositories.LdapUser
 import uk.gov.communities.delta.auth.services.*
@@ -137,10 +137,10 @@ class DeltaSSOLoginController(
     }
 
     private fun getSSOClient(call: ApplicationCall): AzureADSSOClient {
-        if (!call.parameters.contains("ssoClientId")) throw HttpNotFoundException("No SSO Client id")
+        if (!call.parameters.contains("ssoClientId")) throw HttpNotFound404PageException("No SSO Client id")
         val ssoClientId = call.parameters["ssoClientId"]!!
         return ssoConfig.ssoClients.firstOrNull { it.internalId == ssoClientId }
-            ?: throw HttpNotFoundException("No OAuth client found for id $ssoClientId")
+            ?: throw HttpNotFound404PageException("No OAuth client found for id $ssoClientId")
     }
 
     private fun validateOAuthStateInSession(call: ApplicationCall): LoginSessionCookie {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/FetchUserAuditController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/FetchUserAuditController.kt
@@ -35,7 +35,7 @@ class FetchUserAuditController(
         val session = principal<OAuthSession>()!!
         val page = parameters["page"]?.toInt()
         val audit = getUserAudit(session, parameters.getOrFail("cn"), page)
-        return respond(audit.map {
+        return respond(mapOf("userAudit" to audit.map {
             JsonObject(
                 mapOf(
                     "action" to JsonPrimitive(it.action.action),
@@ -46,7 +46,7 @@ class FetchUserAuditController(
                     "actionData" to it.actionData,
                 )
             )
-        })
+        }))
     }
 
     private suspend fun ApplicationCall.getUserAuditCSV() {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/FetchUserAuditController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/FetchUserAuditController.kt
@@ -10,34 +10,32 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.config.LDAPConfig.Companion.DATAMART_DELTA_PREFIX
+import uk.gov.communities.delta.auth.plugins.ApiError
 import uk.gov.communities.delta.auth.repositories.LdapUser
+import uk.gov.communities.delta.auth.repositories.UserAuditTrailRepo
 import uk.gov.communities.delta.auth.services.OAuthSession
 import uk.gov.communities.delta.auth.services.UserAuditService
 import uk.gov.communities.delta.auth.services.UserLookupService
 import uk.gov.communities.delta.auth.services.withSession
+import uk.gov.communities.delta.auth.utils.csvRow
 
 class FetchUserAuditController(
     private val userLookupService: UserLookupService,
     private val userAuditService: UserAuditService,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
+    private val pageSize = 100
 
     fun route(route: Route) {
-        route.get { getUserAudit(call) }
+        route.get { call.getUserAuditJson() }
+        route.get("/csv") { call.getUserAuditCSV() }
     }
 
-    private suspend fun getUserAudit(call: ApplicationCall) {
-        val session = call.principal<OAuthSession>()!!
-        val callingUser = userLookupService.lookupUserByCn(session.userCn)
-        val userCNParam = call.parameters.getOrFail("cn")
-
-        if (!userHasPermissionToReadAuditTrail(callingUser, userCNParam)) {
-            return call.respondUnauthorised(session, userCNParam)
-        }
-
-        logger.atInfo().withSession(session).log("Audit trail requested for {}", userCNParam)
-        val audit = userAuditService.getAuditForUser(userCNParam)
-        return call.respond(audit.map {
+    private suspend fun ApplicationCall.getUserAuditJson() {
+        val session = principal<OAuthSession>()!!
+        val page = parameters["page"]?.toInt()
+        val audit = getUserAudit(session, parameters.getOrFail("cn"), page)
+        return respond(audit.map {
             JsonObject(
                 mapOf(
                     "action" to JsonPrimitive(it.action.action),
@@ -51,6 +49,58 @@ class FetchUserAuditController(
         })
     }
 
+    private suspend fun ApplicationCall.getUserAuditCSV() {
+        val session = principal<OAuthSession>()!!
+        val audit = getUserAudit(session, parameters.getOrFail("cn"))
+        val csvString = buildCSVFromAudit(audit)
+        respondBytes(csvString.toByteArray(), ContentType.Text.CSV)
+    }
+
+    private fun buildCSVFromAudit(audit: List<UserAuditTrailRepo.UserAuditRow>): String {
+        val extraCSVHeaders = audit.flatMap { it.actionData.keys }.distinct()
+        val stringBuilder = StringBuilder()
+        stringBuilder.csvRow(listOf("action", "timestamp", "userCN", "editingUserCN", "requestId") + extraCSVHeaders)
+
+        for (auditRow in audit) {
+            val csvRow = mutableListOf(
+                auditRow.action.action,
+                auditRow.timestamp.toInstant().toString(),
+                auditRow.userCn,
+                auditRow.editingUserCn ?: "",
+                auditRow.requestId
+            )
+            extraCSVHeaders.forEach {
+                when (val jsonElement = auditRow.actionData[it]) {
+                    is JsonPrimitive -> csvRow.add(jsonElement.content)
+                    else -> csvRow.add("")
+                }
+            }
+            stringBuilder.csvRow(csvRow)
+        }
+        return stringBuilder.toString()
+    }
+
+    private suspend fun getUserAudit(
+        session: OAuthSession,
+        userCNParam: String,
+        page: Int? = null,
+    ): List<UserAuditTrailRepo.UserAuditRow> {
+        val callingUser = userLookupService.lookupUserByCn(session.userCn)
+
+        if (!userHasPermissionToReadAuditTrail(callingUser, userCNParam)) {
+            logger.atWarn().withSession(session)
+                .log("User does not have permission to read audit log for {}", userCNParam)
+            throw AccessDeniedError("User does not have permission to read audit log for $userCNParam")
+        }
+
+        logger.atInfo().withSession(session).log("Audit trail requested for {}", userCNParam)
+        return if (page == null) {
+            userAuditService.getAuditForUser(userCNParam)
+        } else {
+            userAuditService.getAuditForUserPaged(userCNParam, page, pageSize)
+        }
+    }
+
     private val viewAuditAdminGroupCNs = listOf("admin", "read-only-admin").map { DATAMART_DELTA_PREFIX + it }
 
     private fun userHasPermissionToReadAuditTrail(callingUser: LdapUser, auditTrailOfUserCN: String): Boolean {
@@ -59,15 +109,6 @@ class FetchUserAuditController(
         return callingUser.memberOfCNs.any { viewAuditAdminGroupCNs.contains(it) }
     }
 
-    private suspend fun ApplicationCall.respondUnauthorised(session: OAuthSession, userCNParam: String) {
-        logger.atWarn().withSession(session)
-            .log("User does not have permission to read audit log for {}", userCNParam)
-        respond(
-            HttpStatusCode.Forbidden,
-            mapOf(
-                "error" to "forbidden",
-                "error_description" to "User does not have permission to read audit log for '$userCNParam'"
-            )
-        )
-    }
+    class AccessDeniedError(description: String) :
+        ApiError(HttpStatusCode.Forbidden, "forbidden", description, description)
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditService.kt
@@ -12,10 +12,15 @@ import uk.gov.communities.delta.auth.repositories.DbPool
 import uk.gov.communities.delta.auth.repositories.UserAuditTrailRepo
 
 class UserAuditService(private val userAuditTrailRepo: UserAuditTrailRepo, private val dbPool: DbPool) {
-    suspend fun getAuditForUser(userCn: String): List<UserAuditTrailRepo.UserAuditRow> {
+    suspend fun getAuditForUser(userCn: String) = getAudit(userCn, null)
+
+    suspend fun getAuditForUserPaged(userCn: String, page: Int, pageSize: Int) =
+        getAudit(userCn, Pair(pageSize, (page - 1) * pageSize))
+
+    private suspend fun getAudit(userCn: String, limitOffset: Pair<Int, Int>?): List<UserAuditTrailRepo.UserAuditRow> {
         return withContext(Dispatchers.IO) {
             dbPool.useConnectionBlocking("user_audit_read") {
-                userAuditTrailRepo.getAuditForUser(it, userCn)
+                userAuditTrailRepo.getAuditForUser(it, userCn, limitOffset)
             }
         }
     }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/utils/CSVUtil.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/utils/CSVUtil.kt
@@ -1,0 +1,19 @@
+package uk.gov.communities.delta.auth.utils
+
+private val csvChars = Regex("[,\"\n]")
+
+fun StringBuilder.csvRow(row: List<String>) {
+    for (i in row.indices) {
+        val element = row[i]
+        if (element.contains(csvChars)) {
+            append('"')
+            append(element.replace("\"", "\"\""))
+            append('"')
+            if (i < row.size - 1) append(',')
+        } else {
+            append(element)
+            if (i < row.size - 1) append(',')
+        }
+    }
+    append('\n')
+}

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/FetchUserAuditControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/FetchUserAuditControllerTest.kt
@@ -10,8 +10,10 @@ import io.ktor.server.testing.*
 import io.ktor.test.dispatcher.*
 import io.mockk.coEvery
 import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.*
 import org.junit.AfterClass
+import org.junit.Assert
 import org.junit.BeforeClass
 import org.junit.Test
 import uk.gov.communities.delta.auth.bearerTokenRoutes
@@ -66,14 +68,16 @@ class FetchUserAuditControllerTest {
     }
 
     @Test
-    fun testUserCannotReadAdminAudit() = testSuspend {
-        testClient.get("/bearer/user-audit?cn=admin") {
-            headers {
-                append("Authorization", "Bearer ${userSession.authToken}")
-                append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+    fun testUserCannotReadAdminAudit() {
+        Assert.assertThrows(FetchUserAuditController.AccessDeniedError::class.java) {
+            runBlocking {
+                testClient.get("/bearer/user-audit?cn=admin") {
+                    headers {
+                        append("Authorization", "Bearer ${userSession.authToken}")
+                        append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+                    }
+                }
             }
-        }.apply {
-            assertEquals(HttpStatusCode.Forbidden, status)
         }
     }
 
@@ -90,6 +94,27 @@ class FetchUserAuditControllerTest {
                 "[{\"action\":\"sso_login\",\"timestamp\":\"1970-01-01T00:00:01Z\",\"userCN\":\"admin\"," +
                         "\"editingUserCN\":null,\"requestId\":\"adminRequestId\"," +
                         "\"actionData\":{\"azureObjectId\":\"oid\"}}]",
+                bodyAsText()
+            )
+        }
+    }
+
+    @Test
+    fun testCSVDownload() = testSuspend {
+        testClient.get("/bearer/user-audit/csv?cn=admin") {
+            headers {
+                append("Authorization", "Bearer ${adminSession.authToken}")
+                append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+                set("Accept", "application/csv")
+            }
+        }.apply {
+            assertEquals(HttpStatusCode.OK, status)
+            assertEquals(
+                """
+                    action,timestamp,userCN,editingUserCN,requestId,azureObjectId
+                    sso_login,1970-01-01T00:00:01Z,admin,,adminRequestId,oid
+                    
+                """.trimIndent(),
                 bodyAsText()
             )
         }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/FetchUserAuditControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/FetchUserAuditControllerTest.kt
@@ -46,7 +46,7 @@ class FetchUserAuditControllerTest {
             }
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
-            val response = Json.parseToJsonElement(bodyAsText()).jsonArray
+            val response = Json.parseToJsonElement(bodyAsText()).jsonObject["userAudit"]!!.jsonArray
             assertEquals(1, response.size)
             assertEquals(
                 UserAuditTrailRepo.AuditAction.SET_PASSWORD_EMAIL.action,
@@ -91,9 +91,9 @@ class FetchUserAuditControllerTest {
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
             assertEquals(
-                "[{\"action\":\"sso_login\",\"timestamp\":\"1970-01-01T00:00:01Z\",\"userCN\":\"admin\"," +
+                "{\"userAudit\":[{\"action\":\"sso_login\",\"timestamp\":\"1970-01-01T00:00:01Z\",\"userCN\":\"admin\"," +
                         "\"editingUserCN\":null,\"requestId\":\"adminRequestId\"," +
-                        "\"actionData\":{\"azureObjectId\":\"oid\"}}]",
+                        "\"actionData\":{\"azureObjectId\":\"oid\"}}]}",
                 bodyAsText()
             )
         }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditTrailRepoTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditTrailRepoTest.kt
@@ -10,30 +10,34 @@ import kotlin.test.assertNull
 
 class UserAuditTrailRepoTest {
     @Test
-    fun testUserAudit() {
+    fun testRetrievesAuditValues() {
         testDbPool.useConnectionBlocking("test_login_audit") {
-            assertEquals(0, repo.getAuditForUser(it, "some.user!example.com").size)
+            val audit = repo.getAuditForUser(it, "some.user!audit-test.com")
+            assertEquals(2, audit.size)
+            assertEquals("some.user!audit-test.com", audit[1].userCn)
+            assertEquals("requestId", audit[1].requestId)
+            assertNull(audit[1].editingUserCn)
+            assertEquals(UserAuditTrailRepo.AuditAction.FORM_LOGIN, audit[1].action)
+            assertEquals("value", audit[1].actionData.jsonObject["key"]!!.jsonPrimitive.content)
+        }
+    }
 
-            repo.insertAuditRow(
-                it,
-                UserAuditTrailRepo.AuditAction.FORM_LOGIN,
-                "some.user!example.com",
-                null,
-                "requestId",
-                "{\"key\": \"value\"}"
-            )
+    @Test
+    fun testOtherUserAuditIsEmpty() {
+        testDbPool.useConnectionBlocking("test_login_audit") {
+            assertEquals(0, repo.getAuditForUser(it, "other.user!audit-test.com").size)
+        }
+    }
 
-            val audit = repo.getAuditForUser(it, "some.user!example.com")
-            assertEquals(1, audit.size)
-            assertEquals("some.user!example.com", audit[0].userCn)
-            assertEquals("requestId", audit[0].requestId)
-            assertNull(audit[0].editingUserCn)
-            assertEquals(UserAuditTrailRepo.AuditAction.FORM_LOGIN, audit[0].action)
-            assertEquals("value", audit[0].actionData.jsonObject["key"]!!.jsonPrimitive.content)
-
-            assertEquals(0, repo.getAuditForUser(it, "other.user!example.com").size)
-
-            it.rollback()
+    @Test
+    fun testPagination() {
+        testDbPool.useConnectionBlocking("test_login_audit") {
+            val firstPage = repo.getAuditForUser(it, "some.user!audit-test.com", Pair(1, 0))
+            val secondPage = repo.getAuditForUser(it, "some.user!audit-test.com", Pair(1, 1))
+            val thirdPage = repo.getAuditForUser(it, "some.user!audit-test.com", Pair(1, 2))
+            assertEquals(UserAuditTrailRepo.AuditAction.FORGOT_PASSWORD_EMAIL, firstPage.single().action)
+            assertEquals(UserAuditTrailRepo.AuditAction.FORM_LOGIN, secondPage.single().action)
+            assertEquals(0, thirdPage.size)
         }
     }
 
@@ -44,6 +48,29 @@ class UserAuditTrailRepoTest {
         @JvmStatic
         fun setup() {
             repo = UserAuditTrailRepo()
+            testDbPool.useConnectionBlocking("test_login_audit") {
+                assertEquals(0, repo.getAuditForUser(it, "some.user!audit-test.com").size)
+
+                repo.insertAuditRow(
+                    it,
+                    UserAuditTrailRepo.AuditAction.FORM_LOGIN,
+                    "some.user!audit-test.com",
+                    null,
+                    "requestId",
+                    "{\"key\": \"value\"}"
+                )
+                it.commit() // So that the next row has a different timestamp, and we can check ordering (newest first)
+                Thread.sleep(1)
+                repo.insertAuditRow(
+                    it,
+                    UserAuditTrailRepo.AuditAction.FORGOT_PASSWORD_EMAIL,
+                    "some.user!audit-test.com",
+                    null,
+                    "requestId2",
+                    "{}"
+                )
+                it.commit()
+            }
         }
     }
 }


### PR DESCRIPTION
And (very) basic pagination logic that I'll flesh out when doing the Delta side changes.

I've made the CSV headers dynamic based on the top level attributes of "actionData". This feels slightly crazy, but I can't think of a better way of doing it, returning JSON as a CSV column sounds ugly, and whilst at the moment there's nothing important in there, when we're auditing user changes there will be. I think it would only really be an issue if you wanted to combine or compare audit logs for different users, but I don't see why you would.