### PR TITLE
DT-572 Add email domain mapping for Azure SSO

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/AzureADSSOConfig.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/AzureADSSOConfig.kt
@@ -13,6 +13,10 @@ data class AzureADSSOClient(
     val azClientSecret: String,
     // Only allows the SSO provider to log users in under this domain. Must include the "@" prefix.
     val emailDomain: String,
+    // Accept JWTs with this as the email domain, but log in the user with the above domain in their CN instead.
+    // This is a workaround for DLUHC users having "@levellingup.gov.uk" as their username in Delta,
+    // but "@communities.gov.uk" as their username in Azure AD.
+    val convertFromEmailDomain: String? = null,
     // Force users with a matching email domain to use the SSO flow rather than username + password
     // If SSO is required users cannot register normally or reset their password, an accounts will automatically be
     // created when they first sign in.
@@ -29,6 +33,9 @@ data class AzureADSSOClient(
     init {
         if (!emailDomain.startsWith("@")) {
             throw Exception("AzureADSSOConfig emailDomain must start with @")
+        }
+        if (convertFromEmailDomain != null && !convertFromEmailDomain.startsWith("@")) {
+            throw Exception("AzureADSSOConfig convertFromEmailDomain must start with @ if provided")
         }
     }
 }


### PR DESCRIPTION
The JWTs we get from DLUHC Azure have "communities.gov.uk" as the username, whilst Delta users have "levellingup.gov.uk". We don't get the user's email as part of the JWT, even when we requested the email scope on test.

We could presumably request user info from Microsoft Graph and get the email, but for this case it seems simpler if slightly magic to automatically convert communities -> levellingup during the login process.

I've added a new, optional, "convertFromEmailDomain" parameter to the SSO config which I'll set to "@communities.gov.uk". It's only used during the SSO callback, everything else uses the original domain, so users could still have accounts with @communities.gov.uk email addresses and sign in normally if they wanted.