### PR TITLE
DT-572 Display message on register page for non-required SSO

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSSOLoginController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSSOLoginController.kt
@@ -83,7 +83,7 @@ class DeltaSSOLoginController(
         if (user == null) {
             if (!ssoClient.required) {
                 logger.info("User {} not found in AD, and SSO is not required, so redirecting to register page", email)
-                return call.respondRedirect("/delta/register?sso_email=${email.encodeURLParameter()}")
+                return call.respondRedirect("/delta/register?fromSSOEmail=${email.encodeURLParameter()}")
             }
             val registration = Registration(jwt.givenName, jwt.familyName, email, jwt.userObjectId)
             logger.info(

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSSOLoginController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSSOLoginController.kt
@@ -83,7 +83,7 @@ class DeltaSSOLoginController(
         if (user == null) {
             if (!ssoClient.required) {
                 logger.info("User {} not found in AD, and SSO is not required, so redirecting to register page", email)
-                return call.respondRedirect("/delta/register")
+                return call.respondRedirect("/delta/register?sso_email=${email.encodeURLParameter()}")
             }
             val registration = Registration(jwt.givenName, jwt.familyName, email, jwt.userObjectId)
             logger.info(

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaUserRegistrationController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaUserRegistrationController.kt
@@ -48,6 +48,15 @@ class DeltaUserRegistrationController(
     }
 
     private suspend fun registerGet(call: ApplicationCall) {
+        val ssoEmail = call.parameters["sso_email"]
+        if (!ssoEmail.isNullOrEmpty()) {
+            call.respondRegisterPage(
+                emailAddress = ssoEmail,
+                confirmEmailAddress = ssoEmail,
+                otherErrors = listOf("No Delta account found with email $ssoEmail. Please register below, or contact the service desk if you already have an account with a different email."),
+                errorSummary = "Account not found",
+            )
+        }
         call.respondRegisterPage()
     }
 
@@ -202,23 +211,25 @@ class DeltaUserRegistrationController(
         lastName: String = "",
         emailAddress: String = "",
         confirmEmailAddress: String = "",
-        firstNameErrors: ArrayList<String> = ArrayList(),
-        lastNameErrors: ArrayList<String> = ArrayList(),
-        emailAddressErrors: ArrayList<String> = ArrayList(),
-        confirmEmailAddressErrors: ArrayList<String> = ArrayList(),
+        firstNameErrors: List<String> = emptyList(),
+        lastNameErrors: List<String> = emptyList(),
+        emailAddressErrors: List<String> = emptyList(),
+        confirmEmailAddressErrors: List<String> = emptyList(),
+        otherErrors: List<String> = emptyList(),
+        errorSummary: String = "There is a problem",
     ) {
-        val errors = ArrayList<ArrayList<String>>()
+        val errors = otherErrors.map { Pair(it, "#") }.toMutableList()
         firstNameErrors.forEach { message ->
-            errors.add(arrayListOf(message, "#firstName"))
+            errors.add(Pair(message, "#firstName"))
         }
         lastNameErrors.forEach { message ->
-            errors.add(arrayListOf(message, "#lastName"))
+            errors.add(Pair(message, "#lastName"))
         }
         emailAddressErrors.forEach { message ->
-            errors.add(arrayListOf(message, "#emailAddress"))
+            errors.add(Pair(message, "#emailAddress"))
         }
         confirmEmailAddressErrors.forEach { message ->
-            errors.add(arrayListOf(message, "#confirmEmailAddress"))
+            errors.add(Pair(message, "#confirmEmailAddress"))
         }
         respond(
             ThymeleafContent(
@@ -234,6 +245,7 @@ class DeltaUserRegistrationController(
                     "emailAddress" to emailAddress,
                     "confirmEmailErrorMessages" to confirmEmailAddressErrors,
                     "confirmEmailAddress" to confirmEmailAddress,
+                    "errorSummary" to errorSummary,
                 )
             )
         )

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaUserRegistrationController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaUserRegistrationController.kt
@@ -48,7 +48,7 @@ class DeltaUserRegistrationController(
     }
 
     private suspend fun registerGet(call: ApplicationCall) {
-        val ssoEmail = call.parameters["sso_email"]
+        val ssoEmail = call.parameters["fromSSOEmail"]
         if (!ssoEmail.isNullOrEmpty()) {
             call.respondRegisterPage(
                 emailAddress = ssoEmail,

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/StatusPages.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/StatusPages.kt
@@ -29,7 +29,8 @@ fun Application.configureStatusPages(deltaWebsiteUrl: String, ssoConfig: AzureAD
                             "register-user-form",
                             mapOf(
                                 "deltaUrl" to deltaConfig.deltaWebsiteUrl,
-                                "allErrors" to arrayListOf(arrayListOf(tooManyRequestsErrorMessage, "#")),
+                                "allErrors" to arrayListOf(Pair(tooManyRequestsErrorMessage, "#")),
+                                "errorSummary" to "Rate limit reached",
                             )
                         )
                     )

--- a/auth-service/src/main/resources/templates/thymeleaf/register-user-form.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/register-user-form.html
@@ -11,7 +11,7 @@
 
 <!--/*@thymesVar id="deltaUrl" type="java.lang.String" */-->
 <!-- List of errors paired with error links -->
-<!--/*@thymesVar id="allErrors" type="java.lang.ArrayList" */-->
+<!--/*@thymesVar id="allErrors" type="java.lang.ArrayList<kotlin.Pair<String, String>>" */-->
 <!--/*@thymesVar id="firstNameErrorMessages" type="java.lang.ArrayList" */-->
 <!--/*@thymesVar id="firstName" type="java.lang.String" */-->
 <!--/*@thymesVar id="lastNameErrorMessages" type="java.lang.ArrayList" */-->
@@ -20,6 +20,7 @@
 <!--/*@thymesVar id="emailAddress" type="java.lang.String" */-->
 <!--/*@thymesVar id="confirmEmailErrorMessages" type="java.lang.ArrayList" */-->
 <!--/*@thymesVar id="confirmEmailAddress" type="java.lang.String" */-->
+<!--/*@thymesVar id="errorSummary" type="java.lang.String" */-->
 
 <div class="govuk-width-container" id="registerPage">
     <ol class="govuk-breadcrumbs__list">
@@ -32,13 +33,14 @@
         <div th:if="${not #lists.isEmpty(allErrors)}" class="govuk-error-summary"
              data-module="govuk-error-summary">
             <div role="alert">
-                <h2 class="govuk-error-summary__title">
+                <h2 class="govuk-error-summary__title" th:text="${errorSummary}">
                     There is a problem
                 </h2>
                 <div class="govuk-error-summary__body">
                     <ul class="govuk-list govuk-error-summary__list">
                         <li th:each="error: ${allErrors}">
-                            <a th:text="${error[0]}" th:href="${error[1]}" href="#">Error message</a>
+                            <!--/*@thymesVar id="error" type="kotlin.Pair<String, String>"*/-->
+                            <a th:text="${error.first}" th:href="${error.second}" href="#">Error message</a>
                         </li>
                     </ul>
                 </div>

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaUserRegistrationControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaUserRegistrationControllerTest.kt
@@ -33,6 +33,14 @@ class DeltaUserRegistrationControllerTest {
     }
 
     @Test
+    fun testRegisterPageFromSSO() = testSuspend {
+        testClient.get("/register?sso_email=user@example.com").apply {
+            assertFormPage(bodyAsText(), status)
+            assertTrue(bodyAsText().contains("No Delta account found with email user@example.com"))
+        }
+    }
+
+    @Test
     fun testRegisterSuccessPage() = testSuspend {
         testClient.get("/register/success?emailAddress=" + (emailStart + standardDomain).encodeURLParameter()).apply {
             assertEquals(HttpStatusCode.OK, status)

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaUserRegistrationControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaUserRegistrationControllerTest.kt
@@ -34,7 +34,7 @@ class DeltaUserRegistrationControllerTest {
 
     @Test
     fun testRegisterPageFromSSO() = testSuspend {
-        testClient.get("/register?sso_email=user@example.com").apply {
+        testClient.get("/register?fromSSOEmail=${"user@example.com".encodeURLParameter()}").apply {
             assertFormPage(bodyAsText(), status)
             assertTrue(bodyAsText().contains("No Delta account found with email user@example.com"))
         }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthSSOLoginTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthSSOLoginTest.kt
@@ -151,7 +151,7 @@ class OAuthSSOLoginTest {
                 val registration = Registration("Example", "User", "user@example.com")
                 coVerify(exactly = 0) { registrationService.register(registration, organisations, true) }
                 assertEquals(HttpStatusCode.Found, status)
-                assertEquals("/delta/register", headers["Location"])
+                assertEquals("/delta/register?sso_email=user%40example.com", headers["Location"])
             }
     }
 

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthSSOLoginTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthSSOLoginTest.kt
@@ -151,7 +151,7 @@ class OAuthSSOLoginTest {
                 val registration = Registration("Example", "User", "user@example.com")
                 coVerify(exactly = 0) { registrationService.register(registration, organisations, true) }
                 assertEquals(HttpStatusCode.Found, status)
-                assertEquals("/delta/register?sso_email=user%40example.com", headers["Location"])
+                assertEquals("/delta/register?fromSSOEmail=user%40example.com", headers["Location"])
             }
     }
 


### PR DESCRIPTION
A nice to have that we skipped before.

When a user signs in with SSO, and they don't have an associated Delta account, and SSO is not required for their domain (so they don't automatically have an account created) they get redirected to the register page. This change displays a message, and pre-fills the email inputs.

![register page screenshot](https://github.com/communitiesuk/delta-auth-service/assets/35066342/5a59cf45-069e-4d9d-a065-55b371725efa)
