### PR TITLE
Send domain_hint with SSO login redirect

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/sso/SSOOAuthClientProviderLookupService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/sso/SSOOAuthClientProviderLookupService.kt
@@ -60,6 +60,8 @@ class SSOOAuthClientProviderLookupService(
             },
             extraAuthParameters = if (expectedEmail != null) listOf(
                 Pair("login_hint", expectedEmail)
-            ) else emptyList()
+            ) else listOf(
+                Pair("domain_hint", ssoClient.convertFromEmailDomain ?: ssoClient.emailDomain)
+            )
         )
 }


### PR DESCRIPTION
I haven't tested it, but I'm hoping this will fix the issue where it logs you straight in with your Softwire account when trying to use DLUHC SSO, then errors, when you're also logged in with a communities.gov.uk account.

Documentation here https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow#request-an-authorization-code which isn't very helpful:

> If included, the app skips the email-based discovery process that user goes through on the sign-in page, leading to a slightly more streamlined user experience. For example, sending them to their federated identity provider. Apps can use this parameter during reauthentication, by extracting the tid from a previous sign-in.

Let's see if it works on staging.