### PR TITLE
Miscellaneous changes - Ignore delegate groups, logging changes, gradle prop

### DIFF
--- a/auth-service/gradle.properties
+++ b/auth-service/gradle.properties
@@ -1,1 +1,3 @@
 kotlin.code.style=official
+# Causes performance issues on Windows
+org.gradle.vfs.watch=false

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaResetPasswordController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaResetPasswordController.kt
@@ -56,7 +56,7 @@ class DeltaResetPasswordController(
         val token = call.request.queryParameters["token"].orEmpty()
         when (val tokenResult = resetPasswordTokenService.validateToken(token, userCN)) {
             is PasswordTokenService.NoSuchToken -> {
-                logger.error("Reset password get request with invalid token and/or userCN")
+                logger.warn("Reset password get request with invalid token and/or userCN")
                 throw ResetPasswordException("reset_password_no_token", "Reset password token did not exist")
             }
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/StatusPages.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/StatusPages.kt
@@ -105,7 +105,7 @@ fun Application.configureStatusPages(deltaWebsiteUrl: String, ssoConfig: AzureAD
             }
         }
         exception(UserVisibleServerError::class) { call, ex ->
-            logger.error("StatusPages user visible error {}", keyValue("errorCode", ex.errorCode), ex)
+            logger.warn("StatusPages user visible error {}", keyValue("errorCode", ex.errorCode), ex)
             val errorPage = StatusErrorPageDefinition(
                 HttpStatusCode.InternalServerError,
                 "user_visible_server_error",

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/service/MemberOfToDeltaRolesMapperTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/service/MemberOfToDeltaRolesMapperTest.kt
@@ -92,7 +92,7 @@ class MemberOfToDeltaRolesMapperTest {
     fun testIgnoresInvalidAccessGroups() {
         val result = mapper().map(
             listOf(
-                "user-dclg", "invalid-group", "invalid-group-dclg"
+                "user-dclg", "invalid-group", "invalid-group-dclg", "delegate-access-group"
             ).map { "datamart-delta-$it" }
         )
 


### PR DESCRIPTION
[Change error to warn for invalid reset password token](https://github.com/communitiesuk/delta-auth-service/commit/4b4ee9783f109b8a6bc14eef52337068721ce16f)
Keeping the error logs clean

[Explicitly ignore delegate groups](https://github.com/communitiesuk/delta-auth-service/commit/6605e13e00071b2e3461345b65299203b68ed1c9)
I didn't even know how these were supposed to work until recently, as far as I can tell they don't, so explicitly ignore them for now to reduce noisy logs

[Add org.gradle.vfs.watch=false to gradle.properties](https://github.com/communitiesuk/delta-auth-service/commit/ef37cec7ae1a1a13d0652984c71f4ba993f5be15) 
This caused very slow startup of gradle for me on Windows, even when gradle was already running as a daemon, it took ~20 seconds to start doing anything. It probably won't fix your IntelliJ issues @PhoebeJackson1, but it's worth a try.