### PR TITLE
DT 610 - Emails through auth service

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/LDAPConfig.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/LDAPConfig.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.delta.auth.config
 
+import com.google.common.base.Strings
 import org.slf4j.spi.LoggingEventBuilder
 
 data class LDAPConfig(
@@ -42,6 +43,10 @@ data class LDAPConfig(
         val VALID_EMAIL_REGEX = Regex("^[\\w\\-+.']+@([\\w\\-']+\\.)+[\\w\\-]{2,4}$")
         val VALID_USERNAME_REGEX = Regex("^[\\w\\-+.!']+$")
         const val DATAMART_DELTA_PREFIX = "datamart-delta-"
+
+        fun emailToCN(email: String): String {
+            return Strings.nullToEmpty(email).replace("@", "!")
+        }
     }
 
     val authServiceUserDn = serviceUserDnFormat.format(authServiceUserCn)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaForgotPasswordController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaForgotPasswordController.kt
@@ -76,7 +76,7 @@ class DeltaForgotPasswordController(
             val user = userLookupService.lookupUserByCn(userCN)
             if (!user.accountEnabled && setPasswordTokenService.passwordNeverSetForUserCN(userCN))
                 emailService.sendPasswordNeverSetEmail(user, setPasswordTokenService.createToken(user.cn), call)
-            else emailService.sendResetPasswordEmail(user, resetPasswordTokenService.createToken(user.cn), call)
+            else emailService.sendResetPasswordEmail(user, resetPasswordTokenService.createToken(user.cn), false, call)
         } catch (e: NameNotFoundException) {
             emailService.sendNoUserEmail(emailAddress)
         } catch (e: Exception) {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaForgotPasswordController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaForgotPasswordController.kt
@@ -76,7 +76,7 @@ class DeltaForgotPasswordController(
             val user = userLookupService.lookupUserByCn(userCN)
             if (!user.accountEnabled && setPasswordTokenService.passwordNeverSetForUserCN(userCN))
                 emailService.sendPasswordNeverSetEmail(user, setPasswordTokenService.createToken(user.cn), call)
-            else emailService.sendResetPasswordEmail(user, resetPasswordTokenService.createToken(user.cn), false, call)
+            else emailService.sendResetPasswordEmail(user, resetPasswordTokenService.createToken(user.cn), null, call)
         } catch (e: NameNotFoundException) {
             emailService.sendNoUserEmail(emailAddress)
         } catch (e: Exception) {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaResetPasswordController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaResetPasswordController.kt
@@ -82,7 +82,7 @@ class DeltaResetPasswordController(
             emailService.sendResetPasswordEmail(
                 userLookupService.lookupUserByCn(userCN),
                 resetPasswordTokenService.createToken(userCN),
-                false,
+                null,
                 call
             )
             call.respondNewEmailSentPage(userCN.replace("!", "@"))

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaResetPasswordController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaResetPasswordController.kt
@@ -82,6 +82,7 @@ class DeltaResetPasswordController(
             emailService.sendResetPasswordEmail(
                 userLookupService.lookupUserByCn(userCN),
                 resetPasswordTokenService.createToken(userCN),
+                false,
                 call
             )
             call.respondNewEmailSentPage(userCN.replace("!", "@"))

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaUserRegistrationController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaUserRegistrationController.kt
@@ -150,7 +150,7 @@ class DeltaUserRegistrationController(
                 userAuditService.userSelfRegisterAudit(registrationResult.userCN, call)
             }
             try {
-                registrationService.sendRegistrationEmail(registrationResult)
+                registrationService.sendRegistrationEmail(registrationResult, call)
             } catch (e: Exception) {
                 logger.error(
                     "Error sending email after registration for first name: {}, last name: {}, email address: {}. Result of registration was {}",

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminEmailController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminEmailController.kt
@@ -55,7 +55,7 @@ class AdminEmailController(
 
         try {
             val token = setPasswordTokenService.createToken(receivingUser.cn)
-            emailService.sendSetPasswordEmail(receivingUser, token, true, call)
+            emailService.sendSetPasswordEmail(receivingUser, token, call.principal<OAuthSession>()!!, call)
         } catch (e: Exception) {
             logger.atError().addKeyValue("userCNToSendEmailTo", receivingUser.cn).log("Failed to send activation email")
             throw ApiError(
@@ -97,7 +97,7 @@ class AdminEmailController(
 
         try {
             val token = resetPasswordTokenService.createToken(receivingUser.cn)
-            emailService.sendResetPasswordEmail(receivingUser, token, true, call)
+            emailService.sendResetPasswordEmail(receivingUser, token, call.principal<OAuthSession>()!!, call)
         } catch (e: Exception) {
             logger.atError().addKeyValue("userCNToSendEmailTo", receivingUser.cn).log("Failed to send email")
             throw ApiError(

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminEmailController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminEmailController.kt
@@ -1,0 +1,123 @@
+package uk.gov.communities.delta.auth.controllers.internal
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import org.slf4j.LoggerFactory
+import uk.gov.communities.delta.auth.config.AzureADSSOConfig
+import uk.gov.communities.delta.auth.config.LDAPConfig
+import uk.gov.communities.delta.auth.repositories.LdapUser
+import uk.gov.communities.delta.auth.services.*
+
+class AdminEmailController(
+    private val ssoConfig: AzureADSSOConfig,
+    private val emailService: EmailService,
+    private val userLookupService: UserLookupService,
+    private val setPasswordTokenService: SetPasswordTokenService,
+    private val resetPasswordTokenService: ResetPasswordTokenService,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    fun route(route: Route) {
+        route.post("/activation") { adminSendActivationEmail(call) }
+        route.post("/reset-password") { adminSendResetPasswordEmail(call) }
+    }
+
+    private suspend fun adminSendActivationEmail(call: ApplicationCall) {
+        val (callingUser, receivingUser) = getUsersFromCall(call)
+
+        if (!userHasPermissionToTriggerEmails(callingUser)) return call.respondUnauthorised(receivingUser)
+
+        if (receivingUser.accountEnabled) {
+            logger.atError().addKeyValue("userCNToSendEmailTo", receivingUser.cn).log("User already enabled")
+            return call.respondText("User is already enabled", status = HttpStatusCode.ExpectationFailed)
+        }
+
+        if (isRequiredSSOUser(receivingUser)) {
+            logger.atError().addKeyValue("userCNToSendEmailTo", receivingUser.cn)
+                .log("Trying to send activation email to SSO User")
+            return call.respondText(
+                "SSO user - account is automatically activated, can be enabled using the Enable Access button",
+                status = HttpStatusCode.ExpectationFailed
+            )
+        }
+
+        try {
+            val token = setPasswordTokenService.createToken(receivingUser.cn)
+            emailService.sendSetPasswordEmail(receivingUser, token, call)
+        } catch (e: Exception) {
+            logger.atError().addKeyValue("userCNToSendEmailTo", receivingUser.cn).log("Failed to send email")
+            return call.respondText("Failed to send email", status = HttpStatusCode.ExpectationFailed)
+        }
+        logger.atInfo().addKeyValue("userCNToSendEmailTo", receivingUser.cn).log("New activation email sent")
+        return call.respondText("New activation email sent")
+    }
+
+    private suspend fun adminSendResetPasswordEmail(call: ApplicationCall) {
+        val (callingUser, receivingUser) = getUsersFromCall(call)
+
+        if (!userHasPermissionToTriggerEmails(callingUser)) return call.respondUnauthorised(receivingUser)
+
+        if (!receivingUser.accountEnabled) {
+            logger.atError().addKeyValue("userCNToSendEmailTo", receivingUser.cn).log("User not enabled")
+            return call.respondText("User not enabled", status = HttpStatusCode.ExpectationFailed)
+        }
+
+        if (isRequiredSSOUser(receivingUser)) {
+            logger.atError().addKeyValue("userCNToSendEmailTo", receivingUser.cn)
+                .log("Trying to send reset password to SSO User")
+            return call.respondText(
+                "SSO user - account doesn't have a password",
+                status = HttpStatusCode.ExpectationFailed
+            )
+        }
+
+        try {
+            val token = resetPasswordTokenService.createToken(receivingUser.cn)
+            emailService.sendResetPasswordEmail(receivingUser, token, call)
+        } catch (e: Exception) {
+            logger.atError().addKeyValue("userCNToSendEmailTo", receivingUser.cn).log("Failed to send email")
+            return call.respondText("Failed to send email", status = HttpStatusCode.ExpectationFailed)
+        }
+        logger.atInfo().addKeyValue("userCNToSendEmailTo", receivingUser.cn).log("Reset password email sent")
+        return call.respondText("Reset password email sent")
+    }
+
+    private suspend fun getUsersFromCall(call: ApplicationCall): Array<LdapUser> {
+        val session = call.principal<OAuthSession>()!!
+        val callingUser = userLookupService.lookupUserByCn(session.userCn)
+        val receivingEmailAddress = call.parameters["userEmail"]!!
+        val receivingUserCN = LDAPConfig.emailToCN(receivingEmailAddress)
+        val receivingUser = userLookupService.lookupUserByCn(receivingUserCN)
+        return arrayOf(callingUser, receivingUser)
+    }
+
+    // Help desk are read-only-admin s and can trigger these emails as well as other admins
+    private val triggerEmailsAdminGroupCNs =
+        listOf("admin", "read-only-admin").map { LDAPConfig.DATAMART_DELTA_PREFIX + it }
+
+    private fun userHasPermissionToTriggerEmails(callingUser: LdapUser): Boolean {
+        return callingUser.memberOfCNs.any { triggerEmailsAdminGroupCNs.contains(it) }
+    }
+
+    private fun isRequiredSSOUser(receivingUser: LdapUser): Boolean {
+        return ssoConfig.ssoClients.any {
+            it.required && receivingUser.email!!.lowercase().endsWith(it.emailDomain)
+        }
+    }
+
+    private suspend fun ApplicationCall.respondUnauthorised(receivingUser: LdapUser) {
+        logger.atWarn().withSession(this.principal<OAuthSession>()!!)
+            .addKeyValue("userCNToSendEmailTo", receivingUser.cn)
+            .log("User does not have permission to trigger password emails for {}", receivingUser.cn)
+        respond(
+            HttpStatusCode.Forbidden,
+            mapOf(
+                "error" to "forbidden",
+                "error_description" to "User does not have permission to trigger password emails for '$receivingUser.cn'"
+            )
+        )
+    }
+}

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminEmailController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminEmailController.kt
@@ -55,7 +55,7 @@ class AdminEmailController(
 
         try {
             val token = setPasswordTokenService.createToken(receivingUser.cn)
-            emailService.sendSetPasswordEmail(receivingUser, token, call)
+            emailService.sendSetPasswordEmail(receivingUser, token, true, call)
         } catch (e: Exception) {
             logger.atError().addKeyValue("userCNToSendEmailTo", receivingUser.cn).log("Failed to send activation email")
             throw ApiError(
@@ -97,7 +97,7 @@ class AdminEmailController(
 
         try {
             val token = resetPasswordTokenService.createToken(receivingUser.cn)
-            emailService.sendResetPasswordEmail(receivingUser, token, call)
+            emailService.sendResetPasswordEmail(receivingUser, token, true, call)
         } catch (e: Exception) {
             logger.atError().addKeyValue("userCNToSendEmailTo", receivingUser.cn).log("Failed to send email")
             throw ApiError(

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/EmailRepository.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/EmailRepository.kt
@@ -1,0 +1,62 @@
+package uk.gov.communities.delta.auth.repositories
+
+import jakarta.mail.Message
+import jakarta.mail.Session
+import jakarta.mail.Transport
+import jakarta.mail.internet.MimeMessage
+import org.jetbrains.annotations.Blocking
+import org.slf4j.LoggerFactory
+import org.thymeleaf.TemplateEngine
+import org.thymeleaf.context.Context
+import uk.gov.communities.delta.auth.config.EmailConfig
+import uk.gov.communities.delta.auth.plugins.makeTemplateResolver
+import uk.gov.communities.delta.auth.services.EmailContacts
+import java.util.*
+
+class EmailRepository(emailConfig: EmailConfig) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private var session: Session = Session.getInstance(emailConfig.emailProps, emailConfig.emailAuthenticator)
+    private var templateEngine: TemplateEngine = TemplateEngine()
+
+    init {
+        val templateResolver = templateEngine.makeTemplateResolver()
+        templateResolver.prefix += "emails/"
+        templateEngine.setTemplateResolver(templateResolver)
+    }
+
+    @Blocking
+    fun sendEmail(
+        template: String,
+        emailContacts: EmailContacts,
+        subject: String,
+        mappedValues: Map<String, String>,
+    ) {
+        val context = Context(Locale.getDefault(), mappedValues)
+        val content = templateEngine.process(template, context)
+        logger.atInfo()
+            .addKeyValue("emailTemplate", template)
+            .addKeyValue("emailTo", emailContacts.getTo())
+            .addKeyValue("emailSubject", subject)
+            .log("Sending email")
+        try {
+            val msg: Message = MimeMessage(session)
+            msg.setFrom(emailContacts.getFrom())
+            msg.replyTo = arrayOf(
+                emailContacts.getReplyTo()
+            )
+            msg.setRecipients(
+                Message.RecipientType.TO, arrayOf(
+                    emailContacts.getTo()
+                )
+            )
+            msg.subject = subject
+            msg.setText(content)
+            msg.setHeader("Content-Type", "text/html")
+            Transport.send(msg)
+        } catch (e: Exception) {
+            logger.error("Failed to sendTemplateEmail", e)
+            throw e
+        }
+    }
+}

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/UserAuditTrailRepo.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/UserAuditTrailRepo.kt
@@ -12,7 +12,7 @@ class UserAuditTrailRepo {
     enum class AuditAction(val action: String) {
         FORM_LOGIN("form_login"),
         SSO_LOGIN("sso_login"),
-        FORGOT_PASSWORD_EMAIL("forgot_password_email"),
+        RESET_PASSWORD_EMAIL("reset_password_email"),
         SET_PASSWORD_EMAIL("set_password_email"),
         RESET_PASSWORD("reset_password"),
         SET_PASSWORD("set_password"),

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/EmailService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/EmailService.kt
@@ -58,12 +58,12 @@ class EmailService(
         logger.atInfo().addKeyValue("userCN", userCN).log("Sent already-a-user email")
     }
 
-    suspend fun sendSetPasswordEmail(user: LdapUser, token: String, triggeredByAdmin: Boolean, call: ApplicationCall) {
+    suspend fun sendSetPasswordEmail(user: LdapUser, token: String, triggeringAdminSession: OAuthSession?, call: ApplicationCall) {
         sendSetPasswordEmail(
             user.firstName,
             token,
             user.cn,
-            triggeredByAdmin,
+            triggeringAdminSession,
             EmailContacts(user.email!!, user.fullName, emailConfig),
             call
         )
@@ -73,7 +73,7 @@ class EmailService(
         firstName: String,
         token: String,
         userCN: String,
-        triggeredByAdmin: Boolean,
+        triggeringAdminSession: OAuthSession?,
         contacts: EmailContacts,
         call: ApplicationCall,
     ) {
@@ -91,9 +91,9 @@ class EmailService(
                 )
             )
         )
-        if (triggeredByAdmin) userAuditService.adminResendActivationEmailAudit(
+        if (triggeringAdminSession != null) userAuditService.adminResendActivationEmailAudit(
             userCN,
-            call.principal<OAuthSession>()!!.userCn,
+            triggeringAdminSession.userCn,
             call
         )
         else userAuditService.setPasswordEmailAudit(userCN, call)
@@ -188,14 +188,14 @@ class EmailService(
     suspend fun sendResetPasswordEmail(
         user: LdapUser,
         token: String,
-        triggeredByAdmin: Boolean,
+        triggeringAdminSession: OAuthSession?,
         call: ApplicationCall
     ) {
         sendResetPasswordEmail(
             user.firstName,
             token,
             user.cn,
-            triggeredByAdmin,
+            triggeringAdminSession,
             EmailContacts(user.email!!, user.fullName, emailConfig),
             call,
         )
@@ -205,7 +205,7 @@ class EmailService(
         firstName: String,
         token: String,
         userCN: String,
-        triggeredByAdmin: Boolean,
+        triggeringAdminSession: OAuthSession?,
         contacts: EmailContacts,
         call: ApplicationCall,
     ) {
@@ -223,9 +223,9 @@ class EmailService(
                 )
             )
         )
-        if (triggeredByAdmin) userAuditService.adminResetPasswordEmailAudit(
+        if (triggeringAdminSession != null) userAuditService.adminResetPasswordEmailAudit(
             userCN,
-            call.principal<OAuthSession>()!!.userCn,
+            triggeringAdminSession.userCn,
             call
         )
         else userAuditService.resetPasswordEmailAudit(userCN, call)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/EmailService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/EmailService.kt
@@ -1,94 +1,228 @@
 package uk.gov.communities.delta.auth.services
 
+import io.ktor.server.application.*
 import jakarta.mail.Address
-import jakarta.mail.Message
-import jakarta.mail.Session
-import jakarta.mail.Transport
 import jakarta.mail.internet.InternetAddress
-import jakarta.mail.internet.MimeMessage
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.jetbrains.annotations.Blocking
 import org.slf4j.LoggerFactory
-import org.thymeleaf.TemplateEngine
-import org.thymeleaf.context.Context
+import uk.gov.communities.delta.auth.config.AuthServiceConfig
+import uk.gov.communities.delta.auth.config.DeltaConfig
 import uk.gov.communities.delta.auth.config.EmailConfig
-import uk.gov.communities.delta.auth.plugins.makeTemplateResolver
-import uk.gov.communities.delta.auth.utils.timedSuspend
-import java.util.*
+import uk.gov.communities.delta.auth.controllers.external.getResetPasswordURL
+import uk.gov.communities.delta.auth.controllers.external.getSetPasswordURL
+import uk.gov.communities.delta.auth.repositories.EmailRepository
+import uk.gov.communities.delta.auth.repositories.LdapUser
+import uk.gov.communities.delta.auth.utils.timed
 
-
-class EmailService(emailConfig: EmailConfig) {
+class EmailService(
+    private val emailConfig: EmailConfig,
+    private val deltaConfig: DeltaConfig,
+    private val authServiceConfig: AuthServiceConfig,
+    private val userAuditService: UserAuditService,
+    private val emailRepository: EmailRepository,
+) {
     private val logger = LoggerFactory.getLogger(javaClass)
-    private var session: Session = Session.getInstance(emailConfig.emailProps, emailConfig.emailAuthenticator)
-    private var templateEngine: TemplateEngine = TemplateEngine()
 
-    init {
-        val templateResolver = templateEngine.makeTemplateResolver()
-        templateResolver.prefix += "emails/"
-        templateEngine.setTemplateResolver(templateResolver)
-    }
-
-    suspend fun sendTemplateEmail(
+    private suspend fun sendTemplateEmail(
         template: String,
         emailContacts: EmailContacts,
         subject: String,
         mappedValues: Map<String, String>,
     ) {
         withContext(Dispatchers.IO) {
-            logger.timedSuspend(
+            logger.timed(
                 "Send templated email",
                 { listOf(Pair("emailTemplate", template)) }
             ) {
-                blockingSendEmail(template, emailContacts, subject, mappedValues)
+                emailRepository.sendEmail(template, emailContacts, subject, mappedValues)
             }
         }
     }
 
-    @Blocking
-    private fun blockingSendEmail(
-        template: String,
-        emailContacts: EmailContacts,
-        subject: String,
-        mappedValues: Map<String, String>,
+    suspend fun sendAlreadyAUserEmail(
+        firstName: String,
+        userCN: String,
+        contacts: EmailContacts,
     ) {
-        val context = Context(Locale.getDefault(), mappedValues)
-        val content = templateEngine.process(template, context)
-        logger.atInfo()
-            .addKeyValue("emailTemplate", template)
-            .addKeyValue("emailTo", emailContacts.getTo())
-            .addKeyValue("emailSubject", subject)
-            .log("Sending email")
-        try {
-            val msg: Message = MimeMessage(session)
-            msg.setFrom(emailContacts.getFrom())
-            msg.replyTo = arrayOf(
-                emailContacts.getReplyTo()
+        sendTemplateEmail(
+            "already-a-user",
+            contacts,
+            "DLUHC DELTA - Existing Account",
+            mapOf(
+                "deltaUrl" to deltaConfig.deltaWebsiteUrl,
+                "userFirstName" to firstName,
             )
-            msg.setRecipients(
-                Message.RecipientType.TO, arrayOf(
-                    emailContacts.getTo()
+        )
+        logger.atInfo().addKeyValue("userCN", userCN).log("Sent already-a-user email")
+    }
+
+    suspend fun sendSetPasswordEmail(user: LdapUser, token: String, call: ApplicationCall) {
+        sendSetPasswordEmail(
+            user.firstName,
+            token,
+            user.cn,
+            EmailContacts(user.email!!, user.fullName, emailConfig),
+            call
+        )
+    }
+
+    suspend fun sendSetPasswordEmail(
+        firstName: String,
+        token: String,
+        userCN: String,
+        contacts: EmailContacts,
+        call: ApplicationCall,
+    ) {
+        sendTemplateEmail(
+            "new-user",
+            contacts,
+            "DLUHC DELTA - New User Account",
+            mapOf(
+                "deltaUrl" to deltaConfig.deltaWebsiteUrl,
+                "userFirstName" to firstName,
+                "setPasswordUrl" to getSetPasswordURL(
+                    token,
+                    userCN,
+                    authServiceConfig.serviceUrl
                 )
             )
-            msg.subject = subject
-            msg.setText(content)
-            msg.setHeader("Content-Type", "text/html")
-            Transport.send(msg)
-        } catch (e: Exception) {
-            logger.error("Failed to sendTemplateEmail", e)
-            throw e
-        }
+        )
+        userAuditService.setPasswordEmailAudit(userCN, call)
+        logger.atInfo().addKeyValue("userCN", userCN).log("Sent new-user email")
+    }
+
+    suspend fun sendNoUserEmail(emailAddress: String) {
+        logger.atInfo().addKeyValue("emailAddress", emailAddress).log("Sending no-user-account email")
+        sendTemplateEmail(
+            "no-user-account",
+            EmailContacts(
+                emailAddress,
+                emailAddress,
+                emailConfig
+            ),
+            "DLUHC DELTA - No User Account",
+            mapOf("deltaUrl" to deltaConfig.deltaWebsiteUrl)
+        )
+        logger.atInfo().addKeyValue("emailAddress", emailAddress).log("Sent no-user-account email")
+    }
+
+    suspend fun sendNotYetEnabledEmail(user: LdapUser, token: String, call: ApplicationCall) {
+        sendNotYetEnabledEmail(
+            user.firstName,
+            token,
+            user.cn,
+            EmailContacts(user.email!!, user.fullName, emailConfig),
+            call,
+        )
+    }
+
+    private suspend fun sendNotYetEnabledEmail(
+        firstName: String,
+        token: String,
+        userCN: String,
+        contacts: EmailContacts,
+        call: ApplicationCall,
+    ) {
+        sendTemplateEmail(
+            "not-yet-enabled-user",
+            contacts,
+            "DLUHC DELTA - Set Your Password",
+            mapOf(
+                "deltaUrl" to deltaConfig.deltaWebsiteUrl,
+                "userFirstName" to firstName,
+                "setPasswordUrl" to getSetPasswordURL(
+                    token,
+                    userCN,
+                    authServiceConfig.serviceUrl
+                )
+            )
+        )
+        userAuditService.setPasswordEmailAudit(userCN, call)
+        logger.atInfo().addKeyValue("userCN", userCN).log("Sent not-yet-enabled-user email")
+    }
+
+    suspend fun sendPasswordNeverSetEmail(user: LdapUser, token: String, call: ApplicationCall) {
+        sendPasswordNeverSetEmail(
+            user.firstName,
+            token,
+            user.cn,
+            EmailContacts(user.email!!, user.fullName, emailConfig),
+            call,
+        )
+    }
+
+    private suspend fun sendPasswordNeverSetEmail(
+        firstName: String,
+        token: String,
+        userCN: String,
+        contacts: EmailContacts,
+        call: ApplicationCall,
+    ) {
+        sendTemplateEmail(
+            "password-never-set",
+            contacts,
+            "DLUHC DELTA - Set Password",
+            mapOf(
+                "deltaUrl" to deltaConfig.deltaWebsiteUrl,
+                "setPasswordUrl" to getSetPasswordURL(
+                    token,
+                    userCN,
+                    authServiceConfig.serviceUrl
+                ),
+                "userFirstName" to firstName,
+            )
+        )
+        userAuditService.setPasswordEmailAudit(userCN, call)
+        logger.atInfo().addKeyValue("userCN", userCN).log("Sent password-never-set email")
+    }
+
+    suspend fun sendResetPasswordEmail(user: LdapUser, token: String, call: ApplicationCall) {
+        sendResetPasswordEmail(
+            user.firstName,
+            token,
+            user.cn,
+            EmailContacts(user.email!!, user.fullName, emailConfig),
+            call,
+        )
+    }
+
+    private suspend fun sendResetPasswordEmail(
+        firstName: String,
+        token: String,
+        userCN: String,
+        contacts: EmailContacts,
+        call: ApplicationCall,
+    ) {
+        sendTemplateEmail(
+            "reset-password",
+            contacts,
+            "DLUHC DELTA - Reset Your Password",
+            mapOf(
+                "deltaUrl" to deltaConfig.deltaWebsiteUrl,
+                "userFirstName" to firstName,
+                "resetPasswordUrl" to getResetPasswordURL(
+                    token,
+                    userCN,
+                    authServiceConfig.serviceUrl
+                )
+            )
+        )
+        userAuditService.resetPasswordEmailAudit(userCN, call)
+        logger.atInfo().addKeyValue("userCN", userCN).log("Sent reset-password email")
     }
 }
 
 class EmailContacts(
     private val toEmail: String,
     private val toName: String,
-    private val fromEmail: String,
-    private val fromName: String,
-    private val replyToEmail: String,
-    private val replyToName: String,
+    emailConfig: EmailConfig,
 ) {
+    private val fromEmail: String = emailConfig.fromEmailAddress
+    private val fromName: String = emailConfig.fromEmailName
+    private val replyToEmail: String = emailConfig.replyToEmailAddress
+    private val replyToName: String = emailConfig.replyToEmailName
+
     fun getTo(): Address {
         return InternetAddress(toEmail, toName, "UTF-8")
     }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/PasswordTokenService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/PasswordTokenService.kt
@@ -14,7 +14,10 @@ import java.sql.Timestamp
 import java.time.Instant
 import kotlin.time.Duration.Companion.hours
 
-class RegistrationSetPasswordTokenService(private val dbPool: DbPool, timeSource: TimeSource) :
+// Set Password tokens are used for users where their account needs enabling upon password being set:
+//  - first time users
+//  - accounts that had been disabled (via email sent by an admin)
+class SetPasswordTokenService(private val dbPool: DbPool, timeSource: TimeSource) :
     PasswordTokenService(dbPool, timeSource) {
     override val tableName: String = "set_password_tokens"
     suspend fun passwordNeverSetForUserCN(userCN: String): Boolean {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
@@ -107,7 +107,7 @@ class RegistrationService(
                     registrationResult.registration.firstName,
                     registrationResult.token,
                     registrationResult.userCN,
-                    false,
+                    null,
                     getRegistrationEmailContacts(registrationResult.registration),
                     call,
                 )

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
@@ -107,6 +107,7 @@ class RegistrationService(
                     registrationResult.registration.firstName,
                     registrationResult.token,
                     registrationResult.userCN,
+                    false,
                     getRegistrationEmailContacts(registrationResult.registration),
                     call,
                 )

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
@@ -1,18 +1,16 @@
 package uk.gov.communities.delta.auth.services
 
+import io.ktor.server.application.*
 import org.slf4j.LoggerFactory
-import uk.gov.communities.delta.auth.config.AuthServiceConfig
 import uk.gov.communities.delta.auth.config.DeltaConfig
 import uk.gov.communities.delta.auth.config.EmailConfig
 import uk.gov.communities.delta.auth.config.LDAPConfig
-import uk.gov.communities.delta.auth.controllers.external.getSetPasswordURL
 
 class RegistrationService(
     private val deltaConfig: DeltaConfig,
     private val emailConfig: EmailConfig,
     private val ldapConfig: LDAPConfig,
-    private val authServiceConfig: AuthServiceConfig,
-    private val registrationSetPasswordTokenService: RegistrationSetPasswordTokenService,
+    private val setPasswordTokenService: SetPasswordTokenService,
     private val emailService: EmailService,
     private val userService: UserService,
     private val userLookupService: UserLookupService,
@@ -21,7 +19,7 @@ class RegistrationService(
     sealed class RegistrationResult
     class UserCreated(val registration: Registration, val token: String, val userCN: String) : RegistrationResult()
     class SSOUserCreated(val userCN: String) : RegistrationResult()
-    class UserAlreadyExists(val registration: Registration) : RegistrationResult()
+    class UserAlreadyExists(val registration: Registration, val userCN: String) : RegistrationResult()
     class RegistrationFailure(val exception: Exception) : RegistrationResult()
 
     // Previously users could be datamart users but not delta users, at migration we only transferred over users who
@@ -39,7 +37,7 @@ class RegistrationService(
         val adUser = UserService.ADUser(registration, ssoUser, ldapConfig)
         if (userLookupService.userExists(adUser.cn)) {
             logger.atWarn().addKeyValue("UserDN", adUser.dn).log("User tried to register but user already exists")
-            return UserAlreadyExists(registration)
+            return UserAlreadyExists(registration, adUser.cn)
         }
         try {
             userService.createUser(adUser)
@@ -54,7 +52,7 @@ class RegistrationService(
         return if (ssoUser)
             SSOUserCreated(adUser.cn)
         else
-            UserCreated(registration, registrationSetPasswordTokenService.createToken(adUser.cn), adUser.cn)
+            UserCreated(registration, setPasswordTokenService.createToken(adUser.cn), adUser.cn)
     }
 
     private suspend fun addUserToDefaultGroups(adUser: UserService.ADUser) {
@@ -98,29 +96,19 @@ class RegistrationService(
         return EmailContacts(
             registration.emailAddress,
             registration.firstName + " " + registration.lastName,
-            emailConfig.fromEmailAddress,
-            emailConfig.fromEmailName,
-            emailConfig.replyToEmailAddress,
-            emailConfig.replyToEmailName,
+            emailConfig
         )
     }
 
-    suspend fun sendRegistrationEmail(registrationResult: RegistrationResult) {
+    suspend fun sendRegistrationEmail(registrationResult: RegistrationResult, call: ApplicationCall) {
         when (registrationResult) {
             is UserCreated -> {
-                emailService.sendTemplateEmail(
-                    "new-user",
+                emailService.sendSetPasswordEmail(
+                    registrationResult.registration.firstName,
+                    registrationResult.token,
+                    registrationResult.userCN,
                     getRegistrationEmailContacts(registrationResult.registration),
-                    "DLUHC DELTA - New User Account",
-                    mapOf(
-                        "deltaUrl" to deltaConfig.deltaWebsiteUrl,
-                        "userFirstName" to registrationResult.registration.firstName,
-                        "setPasswordUrl" to getSetPasswordURL(
-                            registrationResult.token,
-                            registrationResult.userCN,
-                            authServiceConfig.serviceUrl
-                        )
-                    )
+                    call,
                 )
             }
 
@@ -129,14 +117,10 @@ class RegistrationService(
             }
 
             is UserAlreadyExists -> {
-                emailService.sendTemplateEmail(
-                    "already-a-user",
+                emailService.sendAlreadyAUserEmail(
+                    registrationResult.registration.firstName,
+                    registrationResult.userCN,
                     getRegistrationEmailContacts(registrationResult.registration),
-                    "DLUHC DELTA - Existing Account",
-                    mapOf(
-                        "deltaUrl" to deltaConfig.deltaWebsiteUrl,
-                        "userFirstName" to registrationResult.registration.firstName,
-                    )
                 )
             }
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditService.kt
@@ -41,7 +41,7 @@ class UserAuditService(private val userAuditTrailRepo: UserAuditTrailRepo, priva
         )
     }
 
-    val userForgotPasswordAudit = insertSimpleAuditRowFun(UserAuditTrailRepo.AuditAction.FORGOT_PASSWORD_EMAIL)
+    val resetPasswordEmailAudit = insertSimpleAuditRowFun(UserAuditTrailRepo.AuditAction.RESET_PASSWORD_EMAIL)
 
     val setPasswordEmailAudit = insertSimpleAuditRowFun(UserAuditTrailRepo.AuditAction.SET_PASSWORD_EMAIL)
 
@@ -51,7 +51,12 @@ class UserAuditService(private val userAuditTrailRepo: UserAuditTrailRepo, priva
 
     val userSelfRegisterAudit = insertSimpleAuditRowFun(UserAuditTrailRepo.AuditAction.SELF_REGISTER)
 
-    suspend fun ssoUserCreatedAudit(userCn: String, azureUserObjectId: String, ssoClient: AzureADSSOClient, call: ApplicationCall) {
+    suspend fun ssoUserCreatedAudit(
+        userCn: String,
+        azureUserObjectId: String,
+        ssoClient: AzureADSSOClient,
+        call: ApplicationCall,
+    ) {
         insertAuditRow(
             UserAuditTrailRepo.AuditAction.SSO_USER_CREATED, userCn, null, call.callId!!,
             Json.encodeToString(SSOLoginAuditData(ssoClient.internalId, azureUserObjectId))

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditService.kt
@@ -43,7 +43,11 @@ class UserAuditService(private val userAuditTrailRepo: UserAuditTrailRepo, priva
 
     val resetPasswordEmailAudit = insertSimpleAuditRowFun(UserAuditTrailRepo.AuditAction.RESET_PASSWORD_EMAIL)
 
+    val adminResetPasswordEmailAudit = insertAuditRowFun(UserAuditTrailRepo.AuditAction.RESET_PASSWORD_EMAIL)
+
     val setPasswordEmailAudit = insertSimpleAuditRowFun(UserAuditTrailRepo.AuditAction.SET_PASSWORD_EMAIL)
+
+    val adminResendActivationEmailAudit = insertAuditRowFun(UserAuditTrailRepo.AuditAction.SET_PASSWORD_EMAIL)
 
     val resetPasswordAudit = insertSimpleAuditRowFun(UserAuditTrailRepo.AuditAction.RESET_PASSWORD)
 
@@ -66,6 +70,12 @@ class UserAuditService(private val userAuditTrailRepo: UserAuditTrailRepo, priva
     private fun insertSimpleAuditRowFun(auditAction: UserAuditTrailRepo.AuditAction): suspend (String, ApplicationCall) -> Unit {
         return { userCn: String, call: ApplicationCall ->
             insertAuditRow(auditAction, userCn, null, call.callId!!, "{}")
+        }
+    }
+
+    private fun insertAuditRowFun(auditAction: UserAuditTrailRepo.AuditAction): suspend (String, String, ApplicationCall) -> Unit {
+        return { userCn: String, editingUserCn: String, call: ApplicationCall ->
+            insertAuditRow(auditAction, userCn, editingUserCn, call.callId!!, "{}")
         }
     }
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserService.kt
@@ -1,6 +1,5 @@
 package uk.gov.communities.delta.auth.services
 
-import com.google.common.base.Strings
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.config.LDAPConfig
 import uk.gov.communities.delta.auth.controllers.external.ResetPasswordException
@@ -96,7 +95,7 @@ class UserService(
     }
 
     class ADUser(registration: Registration, ssoUser: Boolean, private val ldapConfig: LDAPConfig) {
-        var cn: String = emailToCN(registration.emailAddress)
+        var cn: String = LDAPConfig.emailToCN(registration.emailAddress)
         var givenName: String = registration.firstName
         var sn: String = registration.lastName
         var mail: String = registration.emailAddress
@@ -115,10 +114,6 @@ class UserService(
             objClasses.add("person")
             objClasses.add("top")
             return objClasses
-        }
-
-        private fun emailToCN(email: String): String {
-            return Strings.nullToEmpty(email).replace("@", "!")
         }
 
         private fun cnToDN(cn: String): String {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/utils/EmailAddressChecker.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/utils/EmailAddressChecker.kt
@@ -18,7 +18,7 @@ class EmailAddressChecker {
             return false
         }
 
-        val cn = email.replace("@", "!")
+        val cn = LDAPConfig.emailToCN(email)
         return LDAPConfig.VALID_EMAIL_REGEX.matches(email) && LDAPConfig.VALID_USERNAME_REGEX.matches(cn)
     }
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/utils/LoggerTimed.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/utils/LoggerTimed.kt
@@ -1,8 +1,10 @@
 package uk.gov.communities.delta.auth.utils
 
+import org.jetbrains.annotations.Blocking
 import org.slf4j.Logger
 
 @Suppress("DuplicatedCode")
+@Blocking
 fun <T> Logger.timed(
     action: String,
     logParams: (T) -> List<Pair<String, Any>> = { emptyList() },

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEmailControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEmailControllerTest.kt
@@ -38,7 +38,7 @@ class AdminEmailControllerTest {
             parameter("userEmail", disabledReceivingUserEmail)
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
-            coVerify(exactly = 1) { emailService.sendSetPasswordEmail(disabledReceivingUser, any(), true, any()) }
+            coVerify(exactly = 1) { emailService.sendSetPasswordEmail(disabledReceivingUser, any(), adminSession, any()) }
             coVerify(exactly = 1) { setPasswordTokenService.createToken(disabledReceivingUser.cn) }
         }
     }
@@ -110,7 +110,7 @@ class AdminEmailControllerTest {
             parameter("userEmail", enabledReceivingUserEmail)
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
-            coVerify(exactly = 1) { emailService.sendResetPasswordEmail(enabledReceivingUser, "token", true, any()) }
+            coVerify(exactly = 1) { emailService.sendResetPasswordEmail(enabledReceivingUser, "token", adminSession, any()) }
             coVerify(exactly = 1) { resetPasswordTokenService.createToken(any()) }
         }
     }
@@ -191,8 +191,8 @@ class AdminEmailControllerTest {
         coEvery { userLookupService.lookupUserByCn(disabledReceivingSSOUser.cn) } returns disabledReceivingSSOUser
         coEvery { resetPasswordTokenService.createToken(any()) } returns "token"
         coEvery { setPasswordTokenService.createToken(any()) } returns "token"
-        coEvery { emailService.sendSetPasswordEmail(disabledReceivingUser, "token", true, any()) } just runs
-        coEvery { emailService.sendResetPasswordEmail(enabledReceivingUser, "token", true, any()) } just runs
+        coEvery { emailService.sendSetPasswordEmail(disabledReceivingUser, "token", adminSession, any()) } just runs
+        coEvery { emailService.sendResetPasswordEmail(enabledReceivingUser, "token", adminSession, any()) } just runs
     }
 
     companion object {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEmailControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEmailControllerTest.kt
@@ -38,7 +38,7 @@ class AdminEmailControllerTest {
             parameter("userEmail", disabledReceivingUserEmail)
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
-            coVerify(exactly = 1) { emailService.sendSetPasswordEmail(disabledReceivingUser, any(), any()) }
+            coVerify(exactly = 1) { emailService.sendSetPasswordEmail(disabledReceivingUser, any(), true, any()) }
             coVerify(exactly = 1) { setPasswordTokenService.createToken(disabledReceivingUser.cn) }
         }
     }
@@ -58,7 +58,7 @@ class AdminEmailControllerTest {
         }.apply {
             assertEquals("already_enabled", errorCode)
         }
-        coVerify(exactly = 0) { emailService.sendSetPasswordEmail(any(), any(), any()) }
+        coVerify(exactly = 0) { emailService.sendSetPasswordEmail(any(), any(), any(), any()) }
         coVerify(exactly = 0) { setPasswordTokenService.createToken(any()) }
     }
 
@@ -77,7 +77,7 @@ class AdminEmailControllerTest {
         }.apply {
             assertEquals("forbidden", errorCode)
         }
-        coVerify(exactly = 0) { emailService.sendSetPasswordEmail(any(), any(), any()) }
+        coVerify(exactly = 0) { emailService.sendSetPasswordEmail(any(), any(), any(), any()) }
         coVerify(exactly = 0) { setPasswordTokenService.createToken(any()) }
     }
 
@@ -96,7 +96,7 @@ class AdminEmailControllerTest {
         }.apply {
             assertEquals("no_emails_to_sso_users", errorCode)
         }
-        coVerify(exactly = 0) { emailService.sendSetPasswordEmail(any(), any(), any()) }
+        coVerify(exactly = 0) { emailService.sendSetPasswordEmail(any(), any(), any(), any()) }
         coVerify(exactly = 0) { setPasswordTokenService.createToken(any()) }
     }
 
@@ -110,7 +110,7 @@ class AdminEmailControllerTest {
             parameter("userEmail", enabledReceivingUserEmail)
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
-            coVerify(exactly = 1) { emailService.sendResetPasswordEmail(enabledReceivingUser, "token", any()) }
+            coVerify(exactly = 1) { emailService.sendResetPasswordEmail(enabledReceivingUser, "token", true, any()) }
             coVerify(exactly = 1) { resetPasswordTokenService.createToken(any()) }
         }
     }
@@ -130,7 +130,7 @@ class AdminEmailControllerTest {
         }.apply {
             assertEquals("not_enabled", errorCode)
         }
-        coVerify(exactly = 0) { emailService.sendResetPasswordEmail(any(), any(), any()) }
+        coVerify(exactly = 0) { emailService.sendResetPasswordEmail(any(), any(), any(), any()) }
         coVerify(exactly = 0) { resetPasswordTokenService.createToken(any()) }
     }
 
@@ -149,7 +149,7 @@ class AdminEmailControllerTest {
         }.apply {
             assertEquals("forbidden", errorCode)
         }
-        coVerify(exactly = 0) { emailService.sendResetPasswordEmail(any(), any(), any()) }
+        coVerify(exactly = 0) { emailService.sendResetPasswordEmail(any(), any(), any(), any()) }
         coVerify(exactly = 0) { resetPasswordTokenService.createToken(any()) }
     }
 
@@ -168,7 +168,7 @@ class AdminEmailControllerTest {
         }.apply {
             assertEquals("no_emails_to_sso_users", errorCode)
         }
-        coVerify(exactly = 0) { emailService.sendResetPasswordEmail(any(), any(), any()) }
+        coVerify(exactly = 0) { emailService.sendResetPasswordEmail(any(), any(), any(), any()) }
         coVerify(exactly = 0) { resetPasswordTokenService.createToken(any()) }
     }
 
@@ -191,8 +191,8 @@ class AdminEmailControllerTest {
         coEvery { userLookupService.lookupUserByCn(disabledReceivingSSOUser.cn) } returns disabledReceivingSSOUser
         coEvery { resetPasswordTokenService.createToken(any()) } returns "token"
         coEvery { setPasswordTokenService.createToken(any()) } returns "token"
-        coEvery { emailService.sendSetPasswordEmail(disabledReceivingUser, "token", any()) } just runs
-        coEvery { emailService.sendResetPasswordEmail(enabledReceivingUser, "token", any()) } just runs
+        coEvery { emailService.sendSetPasswordEmail(disabledReceivingUser, "token", true, any()) } just runs
+        coEvery { emailService.sendResetPasswordEmail(enabledReceivingUser, "token", true, any()) } just runs
     }
 
     companion object {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEmailControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEmailControllerTest.kt
@@ -1,0 +1,263 @@
+package uk.gov.communities.delta.controllers
+
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.server.auth.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import io.ktor.test.dispatcher.*
+import io.mockk.*
+import org.junit.AfterClass
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import uk.gov.communities.delta.auth.bearerTokenRoutes
+import uk.gov.communities.delta.auth.config.AzureADSSOClient
+import uk.gov.communities.delta.auth.config.AzureADSSOConfig
+import uk.gov.communities.delta.auth.config.LDAPConfig
+import uk.gov.communities.delta.auth.controllers.internal.AdminEmailController
+import uk.gov.communities.delta.auth.plugins.configureSerialization
+import uk.gov.communities.delta.auth.security.CLIENT_HEADER_AUTH_NAME
+import uk.gov.communities.delta.auth.security.OAUTH_ACCESS_BEARER_TOKEN_AUTH_NAME
+import uk.gov.communities.delta.auth.security.clientHeaderAuth
+import uk.gov.communities.delta.auth.services.*
+import uk.gov.communities.delta.helper.testLdapUser
+import uk.gov.communities.delta.helper.testServiceClient
+import java.time.Instant
+import kotlin.test.assertEquals
+
+class AdminEmailControllerTest {
+
+    @Test
+    fun testAdminSendActivationEmail() = testSuspend {
+        testClient.post("/bearer/email/activation") {
+            headers {
+                append("Authorization", "Bearer ${adminSession.authToken}")
+                append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+            }
+            parameter("userEmail", disabledReceivingUserEmail)
+        }.apply {
+            assertEquals(HttpStatusCode.OK, status)
+            coVerify(exactly = 1) { emailService.sendSetPasswordEmail(disabledReceivingUser, any(), any()) }
+            coVerify(exactly = 1) { setPasswordTokenService.createToken(disabledReceivingUser.cn) }
+        }
+    }
+
+    @Test
+    fun testAdminSendActivationEmailEnabledUser() = testSuspend {
+        testClient.post("/bearer/email/activation") {
+            headers {
+                append("Authorization", "Bearer ${adminSession.authToken}")
+                append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+            }
+            parameter("userEmail", enabledReceivingUserEmail)
+        }.apply {
+            assertEquals(HttpStatusCode.ExpectationFailed, status)
+            coVerify(exactly = 0) { emailService.sendSetPasswordEmail(any(), any(), any()) }
+            coVerify(exactly = 0) { setPasswordTokenService.createToken(any()) }
+        }
+    }
+
+    @Test
+    fun testAdminSendActivationEmailAsNotAdmin() = testSuspend {
+        testClient.post("/bearer/email/activation") {
+            headers {
+                append("Authorization", "Bearer ${userSession.authToken}")
+                append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+            }
+            parameter("userEmail", disabledReceivingUserEmail)
+        }.apply {
+            assertEquals(HttpStatusCode.Forbidden, status)
+            coVerify(exactly = 0) { emailService.sendSetPasswordEmail(any(), any(), any()) }
+            coVerify(exactly = 0) { setPasswordTokenService.createToken(any()) }
+        }
+    }
+
+    @Test
+    fun testAdminSendActivationEmailSSOUser() = testSuspend {
+        testClient.post("/bearer/email/activation") {
+            headers {
+                append("Authorization", "Bearer ${adminSession.authToken}")
+                append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+            }
+            parameter("userEmail", disabledReceivingSSOUserEmail)
+        }.apply {
+            assertEquals(HttpStatusCode.ExpectationFailed, status)
+            coVerify(exactly = 0) { emailService.sendSetPasswordEmail(any(), any(), any()) }
+            coVerify(exactly = 0) { setPasswordTokenService.createToken(any()) }
+        }
+    }
+
+    @Test
+    fun testAdminSendResetPasswordEmail() = testSuspend {
+        testClient.post("/bearer/email/reset-password") {
+            headers {
+                append("Authorization", "Bearer ${adminSession.authToken}")
+                append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+            }
+            parameter("userEmail", enabledReceivingUserEmail)
+        }.apply {
+            assertEquals(HttpStatusCode.OK, status)
+            coVerify(exactly = 1) { emailService.sendResetPasswordEmail(enabledReceivingUser, "token", any()) }
+            coVerify(exactly = 1) { resetPasswordTokenService.createToken(any()) }
+        }
+    }
+
+    @Test
+    fun testAdminSendResetPasswordEmailDisabledUser() = testSuspend {
+        testClient.post("/bearer/email/reset-password") {
+            headers {
+                append("Authorization", "Bearer ${adminSession.authToken}")
+                append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+            }
+            parameter("userEmail", disabledReceivingUserEmail)
+        }.apply {
+            assertEquals(HttpStatusCode.ExpectationFailed, status)
+            coVerify(exactly = 0) { emailService.sendResetPasswordEmail(any(), any(), any()) }
+            coVerify(exactly = 0) { resetPasswordTokenService.createToken(any()) }
+        }
+    }
+
+    @Test
+    fun testAdminSendResetPasswordEmailNotAdmin() = testSuspend {
+        testClient.post("/bearer/email/reset-password") {
+            headers {
+                append("Authorization", "Bearer ${userSession.authToken}")
+                append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+            }
+            parameter("userEmail", enabledReceivingUserEmail)
+        }.apply {
+            assertEquals(HttpStatusCode.Forbidden, status)
+            coVerify(exactly = 0) { emailService.sendResetPasswordEmail(any(), any(), any()) }
+            coVerify(exactly = 0) { resetPasswordTokenService.createToken(any()) }
+        }
+    }
+
+    @Test
+    fun testAdminSendResetPasswordEmailSSOUser() = testSuspend {
+        testClient.post("/bearer/email/reset-password") {
+            headers {
+                append("Authorization", "Bearer ${adminSession.authToken}")
+                append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+            }
+            parameter("userEmail", enabledReceivingSSOUserEmail)
+        }.apply {
+            assertEquals(HttpStatusCode.ExpectationFailed, status)
+            coVerify(exactly = 0) { emailService.sendResetPasswordEmail(any(), any(), any()) }
+            coVerify(exactly = 0) { resetPasswordTokenService.createToken(any()) }
+        }
+    }
+
+    @Before
+    fun resetMocks() {
+        clearAllMocks()
+        coEvery { oauthSessionService.retrieveFomAuthToken(any(), client) } answers { null }
+        coEvery {
+            oauthSessionService.retrieveFomAuthToken(
+                adminSession.authToken,
+                client
+            )
+        } answers { adminSession }
+        coEvery { oauthSessionService.retrieveFomAuthToken(userSession.authToken, client) } answers { userSession }
+        coEvery { userLookupService.lookupUserByCn(adminUser.cn) } returns adminUser
+        coEvery { userLookupService.lookupUserByCn(regularUser.cn) } returns regularUser
+        coEvery { userLookupService.lookupUserByCn(enabledReceivingUser.cn) } returns enabledReceivingUser
+        coEvery { userLookupService.lookupUserByCn(enabledReceivingSSOUser.cn) } returns enabledReceivingSSOUser
+        coEvery { userLookupService.lookupUserByCn(disabledReceivingUser.cn) } returns disabledReceivingUser
+        coEvery { userLookupService.lookupUserByCn(disabledReceivingSSOUser.cn) } returns disabledReceivingSSOUser
+        coEvery { resetPasswordTokenService.createToken(any()) } returns "token"
+        coEvery { setPasswordTokenService.createToken(any()) } returns "token"
+        coEvery { emailService.sendSetPasswordEmail(disabledReceivingUser, "token", any()) } just runs
+        coEvery { emailService.sendResetPasswordEmail(enabledReceivingUser, "token", any()) } just runs
+    }
+
+    companion object {
+        private lateinit var testApp: TestApplication
+        private lateinit var testClient: HttpClient
+        private lateinit var controller: AdminEmailController
+
+        private val oauthSessionService = mockk<OAuthSessionService>()
+        private val userLookupService = mockk<UserLookupService>()
+        private val resetPasswordTokenService = mockk<ResetPasswordTokenService>()
+        private val setPasswordTokenService = mockk<SetPasswordTokenService>()
+        private val emailService = mockk<EmailService>()
+
+        private val client = testServiceClient()
+        private val adminUser = testLdapUser(cn = "admin", memberOfCNs = listOf("datamart-delta-admin"))
+        private val regularUser = testLdapUser(cn = "user", memberOfCNs = emptyList())
+        private const val enabledReceivingUserEmail = "enabled-receiving-user@test.com"
+        private const val enabledReceivingSSOUserEmail = "enabled-receiving-user@sso.domain"
+        private const val disabledReceivingUserEmail = "disabled-receiving-user@test.com"
+        private const val disabledReceivingSSOUserEmail = "disabled-receiving-user@sso.domain"
+
+        private val enabledReceivingUser = testLdapUser(
+            email = enabledReceivingUserEmail,
+            cn = LDAPConfig.emailToCN(enabledReceivingUserEmail),
+            accountEnabled = true
+        )
+        private val enabledReceivingSSOUser = testLdapUser(
+            email = enabledReceivingSSOUserEmail,
+            cn = LDAPConfig.emailToCN(enabledReceivingSSOUserEmail),
+            accountEnabled = true
+        )
+        private val disabledReceivingUser = testLdapUser(
+            email = disabledReceivingUserEmail,
+            cn = LDAPConfig.emailToCN(disabledReceivingUserEmail),
+            accountEnabled = false
+        )
+        private val disabledReceivingSSOUser = testLdapUser(
+            email = disabledReceivingSSOUserEmail,
+            cn = LDAPConfig.emailToCN(disabledReceivingSSOUserEmail),
+            accountEnabled = false
+        )
+        private val adminSession = OAuthSession(1, adminUser.cn, client, "adminAccessToken", Instant.now(), "trace")
+        private val userSession = OAuthSession(1, regularUser.cn, client, "userAccessToken", Instant.now(), "trace")
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            controller = AdminEmailController(
+                AzureADSSOConfig(listOf(AzureADSSOClient("dev", "", "", "", "@sso.domain", required = true))),
+                emailService,
+                userLookupService,
+                setPasswordTokenService,
+                resetPasswordTokenService,
+            )
+
+            testApp = TestApplication {
+                application {
+                    configureSerialization()
+                    authentication {
+                        bearer(OAUTH_ACCESS_BEARER_TOKEN_AUTH_NAME) {
+                            realm = "auth-service"
+                            authenticate { oauthSessionService.retrieveFomAuthToken(it.token, client) }
+                        }
+                        clientHeaderAuth(CLIENT_HEADER_AUTH_NAME) {
+                            headerName = "Delta-Client"
+                            clients = listOf(testServiceClient())
+                        }
+                    }
+                    routing {
+                        bearerTokenRoutes(
+                            mockk(relaxed = true),
+                            controller,
+                            mockk(relaxed = true),
+                        )
+                    }
+                }
+            }
+
+            testClient = testApp.createClient {
+                followRedirects = false
+            }
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDown() {
+            testApp.stop()
+        }
+    }
+
+}

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaForgotPasswordControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaForgotPasswordControllerTest.kt
@@ -55,7 +55,7 @@ class DeltaForgotPasswordControllerTest {
             url = "/forgot-password",
             formParameters = parameters { append("emailAddress", userEmail) }
         ).apply {
-            coVerify(exactly = 1) { emailService.sendResetPasswordEmail(any(), any(), false, any()) }
+            coVerify(exactly = 1) { emailService.sendResetPasswordEmail(any(), any(), null, any()) }
             assertEquals(HttpStatusCode.Found, status)
             assertTrue("Should redirect to email sent page") { headers["Location"]!!.contains("/delta/forgot-password/email-sent") }
         }
@@ -130,7 +130,7 @@ class DeltaForgotPasswordControllerTest {
         clearAllMocks()
         coEvery { resetPasswordTokenService.createToken(any()) } returns "token"
         coEvery { emailService.sendNoUserEmail(any()) } just runs
-        coEvery { emailService.sendResetPasswordEmail(any(), any(), false, any()) } just runs
+        coEvery { emailService.sendResetPasswordEmail(any(), any(), null, any()) } just runs
         coEvery { emailService.sendPasswordNeverSetEmail(any(), any(), any()) } just runs
     }
 

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaForgotPasswordControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaForgotPasswordControllerTest.kt
@@ -55,7 +55,7 @@ class DeltaForgotPasswordControllerTest {
             url = "/forgot-password",
             formParameters = parameters { append("emailAddress", userEmail) }
         ).apply {
-            coVerify(exactly = 1) { emailService.sendResetPasswordEmail(any(), any(), any()) }
+            coVerify(exactly = 1) { emailService.sendResetPasswordEmail(any(), any(), false, any()) }
             assertEquals(HttpStatusCode.Found, status)
             assertTrue("Should redirect to email sent page") { headers["Location"]!!.contains("/delta/forgot-password/email-sent") }
         }
@@ -130,7 +130,7 @@ class DeltaForgotPasswordControllerTest {
         clearAllMocks()
         coEvery { resetPasswordTokenService.createToken(any()) } returns "token"
         coEvery { emailService.sendNoUserEmail(any()) } just runs
-        coEvery { emailService.sendResetPasswordEmail(any(), any(), any()) } just runs
+        coEvery { emailService.sendResetPasswordEmail(any(), any(), false, any()) } just runs
         coEvery { emailService.sendPasswordNeverSetEmail(any(), any(), any()) } just runs
     }
 

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaResetPasswordControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaResetPasswordControllerTest.kt
@@ -163,7 +163,7 @@ class DeltaResetPasswordControllerTest {
             }
         ).apply {
             coVerify(exactly = 1) { resetPasswordTokenService.consumeTokenIfValid(expiredToken, userCN) }
-            coVerify(exactly = 1) { emailService.sendResetPasswordEmail(any(), any(), false, any()) }
+            coVerify(exactly = 1) { emailService.sendResetPasswordEmail(any(), any(), null, any()) }
             coVerify(exactly = 1) { resetPasswordTokenService.createToken(userCN) }
             assertEquals(HttpStatusCode.OK, status)
             assertContains(bodyAsText(), "Your password reset link has been email to you")
@@ -217,7 +217,7 @@ class DeltaResetPasswordControllerTest {
         } returns PasswordTokenService.NoSuchToken
         coEvery { resetPasswordTokenService.createToken(userCN) } returns "token"
         coEvery { userService.resetPassword(userDN, validPassword) } just runs
-        coEvery { emailService.sendResetPasswordEmail(any(), any(), false, any()) } just runs
+        coEvery { emailService.sendResetPasswordEmail(any(), any(), null, any()) } just runs
     }
 
     companion object {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaResetPasswordControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaResetPasswordControllerTest.kt
@@ -163,9 +163,8 @@ class DeltaResetPasswordControllerTest {
             }
         ).apply {
             coVerify(exactly = 1) { resetPasswordTokenService.consumeTokenIfValid(expiredToken, userCN) }
-            assertEquals(emailTemplate.captured, "reset-password")
+            coVerify(exactly = 1) { emailService.sendResetPasswordEmail(any(), any(), any()) }
             coVerify(exactly = 1) { resetPasswordTokenService.createToken(userCN) }
-            coVerify(exactly = 1) { userAuditService.userForgotPasswordAudit(userCN, any()) }
             assertEquals(HttpStatusCode.OK, status)
             assertContains(bodyAsText(), "Your password reset link has been email to you")
         }
@@ -216,9 +215,9 @@ class DeltaResetPasswordControllerTest {
         coEvery {
             resetPasswordTokenService.consumeTokenIfValid("", any())
         } returns PasswordTokenService.NoSuchToken
-        coEvery { emailService.sendTemplateEmail(capture(emailTemplate), any(), any(), any()) } just runs
         coEvery { resetPasswordTokenService.createToken(userCN) } returns "token"
         coEvery { userService.resetPassword(userDN, validPassword) } just runs
+        coEvery { emailService.sendResetPasswordEmail(any(), any(), any()) } just runs
     }
 
     companion object {
@@ -245,7 +244,6 @@ class DeltaResetPasswordControllerTest {
         private val emailService = mockk<EmailService>()
         private val userService = mockk<UserService>()
         private val userLookupService = mockk<UserLookupService>()
-        private var emailTemplate = slot<String>()
         private var userAuditService = mockk<UserAuditService>(relaxed = true)
 
 

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaResetPasswordControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaResetPasswordControllerTest.kt
@@ -163,7 +163,7 @@ class DeltaResetPasswordControllerTest {
             }
         ).apply {
             coVerify(exactly = 1) { resetPasswordTokenService.consumeTokenIfValid(expiredToken, userCN) }
-            coVerify(exactly = 1) { emailService.sendResetPasswordEmail(any(), any(), any()) }
+            coVerify(exactly = 1) { emailService.sendResetPasswordEmail(any(), any(), false, any()) }
             coVerify(exactly = 1) { resetPasswordTokenService.createToken(userCN) }
             assertEquals(HttpStatusCode.OK, status)
             assertContains(bodyAsText(), "Your password reset link has been email to you")
@@ -217,7 +217,7 @@ class DeltaResetPasswordControllerTest {
         } returns PasswordTokenService.NoSuchToken
         coEvery { resetPasswordTokenService.createToken(userCN) } returns "token"
         coEvery { userService.resetPassword(userDN, validPassword) } just runs
-        coEvery { emailService.sendResetPasswordEmail(any(), any(), any()) } just runs
+        coEvery { emailService.sendResetPasswordEmail(any(), any(), false, any()) } just runs
     }
 
     companion object {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaUserRegistrationControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaUserRegistrationControllerTest.kt
@@ -67,7 +67,7 @@ class DeltaUserRegistrationControllerTest {
                     "Test",
                     "token",
                     cnStart + standardDomain,
-                    false,
+                    null,
                     any(),
                     any()
                 )
@@ -173,7 +173,7 @@ class DeltaUserRegistrationControllerTest {
                     "Test",
                     "token",
                     cnStart + notRequiredDomain,
-                    false,
+                    null,
                     any(),
                     any()
                 )
@@ -251,7 +251,7 @@ class DeltaUserRegistrationControllerTest {
         coEvery { groupService.addUserToGroup(any(), any()) } just runs
         coEvery { setPasswordTokenService.createToken(any()) } returns "token"
         coEvery { emailService.sendAlreadyAUserEmail(any(), any(), any()) } just runs
-        coEvery { emailService.sendSetPasswordEmail(any(), any(), any(), false, any(), any()) } just runs
+        coEvery { emailService.sendSetPasswordEmail(any(), any(), any(), null, any(), any()) } just runs
     }
 
     companion object {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaUserRegistrationControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaUserRegistrationControllerTest.kt
@@ -67,6 +67,7 @@ class DeltaUserRegistrationControllerTest {
                     "Test",
                     "token",
                     cnStart + standardDomain,
+                    false,
                     any(),
                     any()
                 )
@@ -172,6 +173,7 @@ class DeltaUserRegistrationControllerTest {
                     "Test",
                     "token",
                     cnStart + notRequiredDomain,
+                    false,
                     any(),
                     any()
                 )
@@ -202,7 +204,7 @@ class DeltaUserRegistrationControllerTest {
             formParameters = correctFormParameters(emailStart + notRequiredDomain)
         ).apply {
             coVerify(exactly = 0) { userService.createUser(any()) }
-            coVerify(exactly = 0) { emailService.sendSetPasswordEmail(any(), any(), any()) }
+            coVerify(exactly = 0) { emailService.sendSetPasswordEmail(any(), any(), any(), any()) }
             assertFormPage(bodyAsText(), status)
             assertContains(bodyAsText(), "Email address domain not recognised")
         }
@@ -249,7 +251,7 @@ class DeltaUserRegistrationControllerTest {
         coEvery { groupService.addUserToGroup(any(), any()) } just runs
         coEvery { setPasswordTokenService.createToken(any()) } returns "token"
         coEvery { emailService.sendAlreadyAUserEmail(any(), any(), any()) } just runs
-        coEvery { emailService.sendSetPasswordEmail(any(), any(), any(), any(), any()) } just runs
+        coEvery { emailService.sendSetPasswordEmail(any(), any(), any(), false, any(), any()) } just runs
     }
 
     companion object {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/FetchUserAuditControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/FetchUserAuditControllerTest.kt
@@ -17,6 +17,7 @@ import org.junit.Assert
 import org.junit.BeforeClass
 import org.junit.Test
 import uk.gov.communities.delta.auth.bearerTokenRoutes
+import uk.gov.communities.delta.auth.controllers.internal.AdminEmailController
 import uk.gov.communities.delta.auth.controllers.internal.FetchUserAuditController
 import uk.gov.communities.delta.auth.controllers.internal.RefreshUserInfoController
 import uk.gov.communities.delta.auth.plugins.configureSerialization
@@ -192,7 +193,11 @@ class FetchUserAuditControllerTest {
                         }
                     }
                     routing {
-                        bearerTokenRoutes(mockk<RefreshUserInfoController>(relaxed = true), controller)
+                        bearerTokenRoutes(
+                            mockk<RefreshUserInfoController>(relaxed = true),
+                            mockk<AdminEmailController>(relaxed = true),
+                            controller
+                        )
                     }
                 }
             }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditTrailRepoTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditTrailRepoTest.kt
@@ -35,7 +35,7 @@ class UserAuditTrailRepoTest {
             val firstPage = repo.getAuditForUser(it, "some.user!audit-test.com", Pair(1, 0))
             val secondPage = repo.getAuditForUser(it, "some.user!audit-test.com", Pair(1, 1))
             val thirdPage = repo.getAuditForUser(it, "some.user!audit-test.com", Pair(1, 2))
-            assertEquals(UserAuditTrailRepo.AuditAction.FORGOT_PASSWORD_EMAIL, firstPage.single().action)
+            assertEquals(UserAuditTrailRepo.AuditAction.RESET_PASSWORD_EMAIL, firstPage.single().action)
             assertEquals(UserAuditTrailRepo.AuditAction.FORM_LOGIN, secondPage.single().action)
             assertEquals(0, thirdPage.size)
         }
@@ -63,7 +63,7 @@ class UserAuditTrailRepoTest {
                 Thread.sleep(1)
                 repo.insertAuditRow(
                     it,
-                    UserAuditTrailRepo.AuditAction.FORGOT_PASSWORD_EMAIL,
+                    UserAuditTrailRepo.AuditAction.RESET_PASSWORD_EMAIL,
                     "some.user!audit-test.com",
                     null,
                     "requestId2",

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/RegistrationServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/RegistrationServiceTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertTrue
 class RegistrationServiceTest {
     private val deltaConfig = DeltaConfig.fromEnv()
     private val authServiceConfig = AuthServiceConfig("http://localhost", null)
-    private val registrationSetPasswordTokenService = mockk<RegistrationSetPasswordTokenService>()
+    private val setPasswordTokenService = mockk<SetPasswordTokenService>()
     private val emailService = mockk<EmailService>()
     private val userService = mockk<UserService>()
     private val userLookupService = mockk<UserLookupService>()
@@ -28,8 +28,7 @@ class RegistrationServiceTest {
         deltaConfig,
         EmailConfig.fromEnv(),
         LDAPConfig("testInvalidUrl", "", "", "", "", "", "", "", ""),
-        authServiceConfig,
-        registrationSetPasswordTokenService,
+        setPasswordTokenService,
         emailService,
         userService,
         userLookupService,
@@ -41,7 +40,7 @@ class RegistrationServiceTest {
         coEvery { userLookupService.userExists(any()) } returns false
         coEvery { groupService.addUserToGroup(any(), any()) } just runs
         coEvery { userService.createUser(any()) } just runs
-        coEvery { registrationSetPasswordTokenService.createToken(any()) } returns "token"
+        coEvery { setPasswordTokenService.createToken(any()) } returns "token"
     }
 
     @Test
@@ -55,7 +54,7 @@ class RegistrationServiceTest {
         coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaUser) }
         coVerify(exactly = 1) { groupService.addUserToGroup(any(), groupName(orgCode)) }
         coVerify(exactly = 3) { groupService.addUserToGroup(any(), any()) }
-        coVerify(exactly = 1) { registrationSetPasswordTokenService.createToken(any()) }
+        coVerify(exactly = 1) { setPasswordTokenService.createToken(any()) }
         assertTrue(registrationResult is RegistrationService.UserCreated)
     }
 
@@ -71,7 +70,7 @@ class RegistrationServiceTest {
         coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaUser) }
         coVerify(exactly = 1) { groupService.addUserToGroup(any(), groupName(orgCode)) }
         coVerify(exactly = 3) { groupService.addUserToGroup(any(), any()) }
-        coVerify(exactly = 0) { registrationSetPasswordTokenService.createToken(any()) }
+        coVerify(exactly = 0) { setPasswordTokenService.createToken(any()) }
         assertTrue(registrationResult is RegistrationService.SSOUserCreated)
     }
 
@@ -86,7 +85,7 @@ class RegistrationServiceTest {
         assertTrue(registrationResult is RegistrationService.UserAlreadyExists)
         coVerify(exactly = 0) { userService.createUser(any()) }
         coVerify(exactly = 0) { groupService.addUserToGroup(any(), any()) }
-        coVerify(exactly = 0) { registrationSetPasswordTokenService.createToken(any()) }
+        coVerify(exactly = 0) { setPasswordTokenService.createToken(any()) }
     }
 
     @Test
@@ -101,7 +100,7 @@ class RegistrationServiceTest {
         coVerify(exactly = 1) { groupService.addUserToGroup(any(), groupName(orgCode)) }
         coVerify(exactly = 1) { groupService.addUserToGroup(any(), groupName(anotherOrgCode)) }
         coVerify(exactly = 4) { groupService.addUserToGroup(any(), any()) }
-        coVerify(exactly = 1) { registrationSetPasswordTokenService.createToken(any()) }
+        coVerify(exactly = 1) { setPasswordTokenService.createToken(any()) }
         assertTrue(registrationResult is RegistrationService.UserCreated)
     }
 
@@ -117,7 +116,7 @@ class RegistrationServiceTest {
         coVerify(exactly = 0) { groupService.addUserToGroup(any(), groupName(orgCode)) }
         coVerify(exactly = 1) { groupService.addUserToGroup(any(), groupName(anotherOrgCode)) }
         coVerify(exactly = 3) { groupService.addUserToGroup(any(), any()) }
-        coVerify(exactly = 1) { registrationSetPasswordTokenService.createToken(any()) }
+        coVerify(exactly = 1) { setPasswordTokenService.createToken(any()) }
         assertTrue(registrationResult is RegistrationService.UserCreated)
     }
 

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/UserServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/UserServiceTest.kt
@@ -34,14 +34,16 @@ class UserServiceTest {
     private val modificationItems = slot<Array<ModificationItem>>()
     private val context = mockk<InitialLdapContext>()
     private val contextBlock = slot<(InitialLdapContext) -> Unit>()
-    private val userCN = userEmail.replace("@", "!")
+    private val userCN = LDAPConfig.emailToCN(userEmail)
     private val userDN = String.format(deltaUserDnFormat, userCN)
 
     @Before
     fun setupMocks() {
         modificationItems.clear()
         contextBlock.clear()
-        coEvery { ldapServiceUserBind.useServiceUserBind(capture(contextBlock)) } coAnswers { contextBlock.captured(context) }
+        coEvery { ldapServiceUserBind.useServiceUserBind(capture(contextBlock)) } coAnswers {
+            contextBlock.captured(context)
+        }
         coEvery { context.createSubcontext(userDN, capture(container)) } coAnswers { nothing }
         coEvery { context.modifyAttributes(userDN, capture(modificationItems)) } coAnswers { nothing }
     }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/service/EmailServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/service/EmailServiceTest.kt
@@ -1,0 +1,116 @@
+package uk.gov.communities.delta.service
+
+import io.ktor.test.dispatcher.*
+import io.mockk.*
+import jakarta.mail.Authenticator
+import jakarta.mail.PasswordAuthentication
+import org.junit.Before
+import org.junit.Test
+import uk.gov.communities.delta.auth.config.AuthServiceConfig
+import uk.gov.communities.delta.auth.config.DeltaConfig
+import uk.gov.communities.delta.auth.config.EmailConfig
+import uk.gov.communities.delta.auth.repositories.EmailRepository
+import uk.gov.communities.delta.auth.services.EmailContacts
+import uk.gov.communities.delta.auth.services.EmailService
+import uk.gov.communities.delta.auth.services.UserAuditService
+import uk.gov.communities.delta.helper.testLdapUser
+import java.util.*
+
+class EmailServiceTest {
+
+    private val authenticator: Authenticator = object : Authenticator() {
+        override fun getPasswordAuthentication(): PasswordAuthentication {
+            return PasswordAuthentication("", "")
+        }
+    }
+    private val userAuditService = mockk<UserAuditService>()
+    private val emailRepository = mockk<EmailRepository>()
+    private val emailConfig = EmailConfig(
+        Properties(),
+        authenticator,
+        "from@test.com",
+        "FromName",
+        "replyTo@test.com",
+        "ReplyToName"
+    )
+    private val emailService = EmailService(
+        emailConfig,
+        DeltaConfig("http://delta", 10, ""),
+        AuthServiceConfig("http://authservice", null),
+        userAuditService,
+        emailRepository
+    )
+
+    @Test
+    fun testSendAlreadyAUserEmail() = testSuspend {
+        emailService.sendAlreadyAUserEmail(
+            "userFirstName",
+            "userCN",
+            EmailContacts("test@email.com", "Test Contact", emailConfig)
+        ).apply {
+            verify(exactly = 1) {
+                emailRepository.sendEmail("already-a-user", any(), any(), any())
+            }
+        }
+
+    }
+
+    @Test
+    fun testSendSetPasswordEmail() = testSuspend {
+        emailService.sendSetPasswordEmail(testLdapUser(email = "test@user.com"), "token", mockk()).apply {
+            verify(exactly = 1) {
+                emailRepository.sendEmail("new-user", any(), any(), any())
+            }
+            coVerify(exactly = 1) { userAuditService.setPasswordEmailAudit(testLdapUser().cn, any()) }
+        }
+    }
+
+    @Test
+    fun testSendNoUserEmail() = testSuspend {
+        emailService.sendNoUserEmail("test@email.com").apply {
+            verify(exactly = 1) {
+                emailRepository.sendEmail("no-user-account", any(), any(), any())
+            }
+        }
+    }
+
+    @Test
+    fun testSendNotYetEnabledEmail() = testSuspend {
+        emailService.sendNotYetEnabledEmail(testLdapUser(email = "test@user.com"), "token", mockk()).apply {
+            verify(exactly = 1) {
+                emailRepository.sendEmail("not-yet-enabled-user", any(), any(), any())
+            }
+            coVerify(exactly = 1) { userAuditService.setPasswordEmailAudit(testLdapUser().cn, any()) }
+        }
+    }
+
+    @Test
+    fun testPasswordNeverSetEmail() = testSuspend {
+        emailService.sendPasswordNeverSetEmail(testLdapUser(email = "test@user.com"), "token", mockk()).apply {
+            verify(exactly = 1) {
+                emailRepository.sendEmail("password-never-set", any(), any(), any())
+            }
+            coVerify(exactly = 1) { userAuditService.setPasswordEmailAudit(testLdapUser().cn, any()) }
+        }
+
+    }
+
+    @Test
+    fun testSendResetPasswordEmail() = testSuspend {
+        emailService.sendResetPasswordEmail(testLdapUser(email = "test@user.com"), "token", mockk()).apply {
+            verify(exactly = 1) {
+                emailRepository.sendEmail("reset-password", any(), any(), any())
+            }
+            coVerify(exactly = 1) { userAuditService.resetPasswordEmailAudit(testLdapUser().cn, any()) }
+        }
+
+    }
+
+    @Before
+    fun resetMocks() {
+        clearAllMocks()
+        every { emailRepository.sendEmail(any(), any(), any(), any()) } just runs
+        coEvery { userAuditService.setPasswordEmailAudit(any(), any()) } just runs
+        coEvery { userAuditService.resetPasswordEmailAudit(any(), any()) } just runs
+    }
+}

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/service/EmailServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/service/EmailServiceTest.kt
@@ -60,7 +60,7 @@ class EmailServiceTest {
 
     @Test
     fun testSendSelfSetPasswordEmail() = testSuspend {
-        emailService.sendSetPasswordEmail(testLdapUser(email = "test@user.com"), "token", false, mockk()).apply {
+        emailService.sendSetPasswordEmail(testLdapUser(email = "test@user.com"), "token", null, mockk()).apply {
             verify(exactly = 1) {
                 emailRepository.sendEmail("new-user", any(), any(), any())
             }
@@ -71,8 +71,10 @@ class EmailServiceTest {
     @Test
     fun testSendAdminSetPasswordEmail() = testSuspend {
         val call = mockk<ApplicationCall>()
-        coEvery { call.principal<OAuthSession>()!!.userCn } returns "adminUserCn"
-        emailService.sendSetPasswordEmail(testLdapUser(email = "test@user.com"), "token", true, call).apply {
+        val adminSession = mockk<OAuthSession>()
+        coEvery { call.principal<OAuthSession>() } returns adminSession
+        coEvery { adminSession.userCn } returns "adminUserCn"
+        emailService.sendSetPasswordEmail(testLdapUser(email = "test@user.com"), "token", adminSession, call).apply {
             verify(exactly = 1) {
                 emailRepository.sendEmail("new-user", any(), any(), any())
             }
@@ -118,7 +120,7 @@ class EmailServiceTest {
 
     @Test
     fun testSendSelfResetPasswordEmail() = testSuspend {
-        emailService.sendResetPasswordEmail(testLdapUser(email = "test@user.com"), "token", false, mockk()).apply {
+        emailService.sendResetPasswordEmail(testLdapUser(email = "test@user.com"), "token", null, mockk()).apply {
             verify(exactly = 1) {
                 emailRepository.sendEmail("reset-password", any(), any(), any())
             }
@@ -129,8 +131,10 @@ class EmailServiceTest {
     @Test
     fun testSendAdminResetPasswordEmail() = testSuspend {
         val call = mockk<ApplicationCall>()
-        coEvery { call.principal<OAuthSession>()!!.userCn } returns "adminUserCn"
-        emailService.sendResetPasswordEmail(testLdapUser(email = "test@user.com"), "token", true, call).apply {
+        val adminSession = mockk<OAuthSession>()
+        coEvery { call.principal<OAuthSession>() } returns adminSession
+        coEvery { adminSession.userCn } returns "adminUserCn"
+        emailService.sendResetPasswordEmail(testLdapUser(email = "test@user.com"), "token", adminSession, call).apply {
             verify(exactly = 1) {
                 emailRepository.sendEmail("reset-password", any(), any(), any())
             }


### PR DESCRIPTION
Set up delta to send the activation and reset password emails triggered by admins through the auth service. Did some refactoring of emails related code. Added tests.

Delta PR to follow shortly.
Splitting the work for the ticket into 2 PRs so this is only the first step in the HLD from the ticket.

Testing: Lots done locally and tests written
Risks: If emails don't send correctly then it could cause an increase in support issues and/or confusion
Documentation: Ticket and this PR (no major changes to the user)