### PR TITLE
DT-744 Redirect user to error page if old timestamp passed to login

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
@@ -177,8 +177,12 @@ fun Route.deltaLoginRoutes(
     }
 }
 
-fun deltaRouteWithEmail(deltaUrl: String, ssoClientInternalId: String, email: String) =
-    deltaUrl + "/oauth2/authorization/delta-auth?sso-client=${ssoClientInternalId}&expected-email=${email.encodeURLParameter()}"
+fun deltaWebsiteLoginRoute(deltaUrl: String, ssoClientInternalId: String?, email: String?, redirectReason: String?): String {
+    return "$deltaUrl/oauth2/authorization/delta-auth" +
+            mapOf("sso-client" to ssoClientInternalId, "expected-email" to email, "reason" to redirectReason)
+                .mapNotNull { if (it.value != null) "${it.key}=${it.value!!.encodeURLParameter()}" else null }
+                .joinToString(prefix = "?", separator = "&")
+}
 
 fun oauthClientLoginRoute(ssoClientInternalId: String, email: String? = null) =
     if (email == null)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/ClientConfig.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/ClientConfig.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.delta.auth.config
 
 import org.opensaml.security.x509.BasicX509Credential
 import org.slf4j.spi.LoggingEventBuilder
+import uk.gov.communities.delta.auth.deltaWebsiteLoginRoute
 
 open class Client(val clientId: String, val clientSecret: String, val samlCredential: BasicX509Credential) {
     override fun toString(): String {
@@ -18,6 +19,9 @@ class DeltaLoginEnabledClient(
     override fun toString(): String {
         return "Client($clientId, deltaWebsiteUrl=$deltaWebsiteUrl)"
     }
+
+    fun websiteLoginRoute(ssoClientInternalId: String?, email: String?, redirectReason: String?): String =
+        deltaWebsiteLoginRoute(deltaWebsiteUrl, ssoClientInternalId, email, redirectReason)
 }
 
 class ClientConfig(val clients: List<Client>) {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaForgotPasswordController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaForgotPasswordController.kt
@@ -8,7 +8,7 @@ import io.ktor.server.routing.*
 import io.ktor.server.thymeleaf.*
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.config.*
-import uk.gov.communities.delta.auth.deltaRouteWithEmail
+import uk.gov.communities.delta.auth.deltaWebsiteLoginRoute
 import uk.gov.communities.delta.auth.repositories.LdapUser
 import uk.gov.communities.delta.auth.services.*
 import uk.gov.communities.delta.auth.utils.EmailAddressChecker
@@ -61,10 +61,11 @@ class DeltaForgotPasswordController(
             logger.atInfo().addKeyValue("ssoClient", ssoClientMatchingEmailDomain.internalId)
                 .log("Forgot password email matches required SSO domain, redirecting")
             return call.respondRedirect(
-                deltaRouteWithEmail(
+                deltaWebsiteLoginRoute(
                     deltaConfig.deltaWebsiteUrl,
                     ssoClientMatchingEmailDomain.internalId,
-                    emailAddress
+                    emailAddress,
+                    "sso_forgot_password",
                 )
             )
         }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaUserRegistrationController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaUserRegistrationController.kt
@@ -9,7 +9,7 @@ import io.ktor.server.thymeleaf.*
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.config.AzureADSSOConfig
 import uk.gov.communities.delta.auth.config.DeltaConfig
-import uk.gov.communities.delta.auth.deltaRouteWithEmail
+import uk.gov.communities.delta.auth.deltaWebsiteLoginRoute
 import uk.gov.communities.delta.auth.services.*
 import uk.gov.communities.delta.auth.utils.EmailAddressChecker
 import uk.gov.communities.delta.auth.utils.emailToDomain
@@ -124,10 +124,11 @@ class DeltaUserRegistrationController(
             }
             if (ssoClientMatchingEmailDomain != null) {
                 return call.respondRedirect(
-                    deltaRouteWithEmail(
+                    deltaWebsiteLoginRoute(
                         deltaConfig.deltaWebsiteUrl,
                         ssoClientMatchingEmailDomain.internalId,
-                        emailAddress
+                        emailAddress,
+                        "sso_register",
                     )
                 )
             }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/Security.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/Security.kt
@@ -78,7 +78,7 @@ fun AuthenticationConfig.azureAdSingleSignOn(
     oauthHttpClient: HttpClient,
     ssoOAuthClientProviderLookupService: SSOOAuthClientProviderLookupService,
 ) {
-    val logger = LoggerFactory.getLogger("Application.SSO")
+    val logger = LoggerFactory.getLogger("uk.gov.communities.delta.auth.sso")
     oauth(SSO_AZURE_AD_OAUTH_CLIENT) {
         urlProvider = { "${authServiceConfig.serviceUrl}${oauthClientCallbackRoute(parameters["ssoClientId"]!!)}" }
         providerLookup = lookup@{

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaLoginControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaLoginControllerTest.kt
@@ -72,7 +72,7 @@ class DeltaLoginControllerTest {
         }
         testClient.get("/login?response_type=code&client_id=delta-website&state=1234&ts=${now - 2.hours.inWholeSeconds}").apply {
             assertEquals(HttpStatusCode.Found, status)
-            headers["Location"]!!.startsWith(deltaConfig.deltaWebsiteUrl + "/login?error=invalid_state")
+            assertTrue(headers["Location"]!!.startsWith(client.deltaWebsiteUrl + "/oauth2/authorization/delta-auth"))
         }
     }
 

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaLoginControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaLoginControllerTest.kt
@@ -35,6 +35,7 @@ import java.time.Instant
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.hours
 
 
 class DeltaLoginControllerTest {
@@ -59,6 +60,19 @@ class DeltaLoginControllerTest {
         testClient.get("/login?response_type=code&client_id=delta-website&state=1234&sso-client=dev").apply {
             assertEquals(HttpStatusCode.Found, status)
             assertEquals(oauthClientLoginRoute("dev"), headers["Location"], "Should redirect to OAuth route")
+        }
+    }
+
+    @Test
+    fun testLoginPageWithOldTimestampRedirectsToDelta() = testSuspend {
+        val now = System.currentTimeMillis() / 1000
+        testClient.get("/login?response_type=code&client_id=delta-website&state=1234&ts=${now}").apply {
+            assertEquals(HttpStatusCode.OK, status)
+            assertContains(bodyAsText(), "Sign in to DELTA")
+        }
+        testClient.get("/login?response_type=code&client_id=delta-website&state=1234&ts=${now - 2.hours.inWholeSeconds}").apply {
+            assertEquals(HttpStatusCode.Found, status)
+            headers["Location"]!!.startsWith(deltaConfig.deltaWebsiteUrl + "/login?error=invalid_state")
         }
     }
 


### PR DESCRIPTION
This currently redirects to Delta's "Sign-in page expired" page. An alternative would be to redirect to `/oauth2/authorization/delta-auth` and have them bounce straight back to the login page, not sure what's better.