### PR TITLE
Give error message on origin header check

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
@@ -11,6 +11,7 @@ import io.ktor.server.sessions.*
 import io.ktor.util.*
 import kotlinx.serialization.Serializable
 import uk.gov.communities.delta.auth.config.AuthServiceConfig
+import uk.gov.communities.delta.auth.config.DeltaConfig
 import uk.gov.communities.delta.auth.config.Env
 import uk.gov.communities.delta.auth.controllers.external.*
 import uk.gov.communities.delta.auth.controllers.internal.FetchUserAuditController
@@ -37,6 +38,7 @@ fun Application.configureRouting(injection: Injection) {
         internalRoutes(injection)
         externalRoutes(
             injection.authServiceConfig,
+            injection.deltaConfig,
             injection.externalDeltaLoginController(),
             injection.deltaOAuthLoginController(),
             injection.externalDeltaUserRegisterController(),
@@ -55,6 +57,7 @@ fun Route.healthcheckRoute() {
 
 fun Route.externalRoutes(
     serviceConfig: AuthServiceConfig,
+    deltaConfig: DeltaConfig,
     deltaLoginController: DeltaLoginController,
     deltaSSOLoginController: DeltaSSOLoginController,
     deltaUserRegistrationController: DeltaUserRegistrationController,
@@ -79,7 +82,7 @@ fun Route.externalRoutes(
     }
 
     route("/delta") {
-        install(originHeaderCheck(serviceConfig.serviceUrl))
+        install(originHeaderCheck(serviceConfig.serviceUrl, deltaConfig))
         install(BrowserSecurityHeaders)
 
         route("/register") {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/OriginHeaderCheck.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/OriginHeaderCheck.kt
@@ -2,16 +2,20 @@ package uk.gov.communities.delta.auth.plugins
 
 import io.ktor.http.*
 import io.ktor.server.application.*
+import io.ktor.server.plugins.callid.*
 import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.thymeleaf.*
 import org.slf4j.LoggerFactory
+import uk.gov.communities.delta.auth.config.DeltaConfig
 
 private val logger = LoggerFactory.getLogger("uk.gov.communities.delta.auth.plugins.OriginHeaderCheck")
 
 private val safeMethods = listOf(HttpMethod.Get, HttpMethod.Head, HttpMethod.Options)
 
-fun originHeaderCheck(serviceUrl: String) = createRouteScopedPlugin("OriginHeaderCheck") {
-    onCallRespond { call ->
-        if (safeMethods.contains(call.request.httpMethod)) return@onCallRespond
+fun originHeaderCheck(serviceUrl: String, deltaConfig: DeltaConfig) = createRouteScopedPlugin("OriginHeaderCheck") {
+    on(BeforeCall) { call, proceed ->
+        if (safeMethods.contains(call.request.httpMethod)) return@on proceed()
 
         val origin = call.request.headers["Origin"]
         if (origin != serviceUrl) {
@@ -21,9 +25,26 @@ fun originHeaderCheck(serviceUrl: String) = createRouteScopedPlugin("OriginHeade
                 origin,
                 call.request.headers["User-Agent"]
             )
-            throw InvalidOriginException("Origin header validation failed, expected '${serviceUrl}' got '$origin'")
+
+            try {
+                call.respond(
+                    HttpStatusCode.BadRequest,
+                    ThymeleafContent(
+                        "error.html", mapOf(
+                            "deltaUrl" to deltaConfig.deltaWebsiteUrl,
+                            "title" to "DELTA | Error",
+                            "heading" to "Error",
+                            "message" to "Origin header check failed. If you are using Internet Explorer please try another browser.",
+                            "requestId" to call.callId!!,
+                        )
+                    )
+                )
+            } catch (e: Exception) {
+                application.log.error("Exception occurred processing origin header check error page", e)
+                if (!call.response.isCommitted) {
+                    call.respondText("Failed to render error page. Request id ${call.callId}")
+                }
+            }
         }
     }
 }
-
-class InvalidOriginException(message: String) : Exception(message)


### PR DESCRIPTION
This should nudge users away from Internet Explorer without them having to raise a ticket, and mean it stops appearing in the error logs.

We get someone trying to use IE every couple of weeks, but it doesn't seem to support the `Origin` header which we use for CSRF protection.