### PR TITLE
MSD-70408: use trimStart because ByteArray.toHexString ignores number…

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/LdapRepository.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/LdapRepository.kt
@@ -131,11 +131,7 @@ class LdapRepository(
         val importedGuid = get("imported-guid")?.get() as String?
         val guidStringToUse = importedGuid ?: (get("objectGUID").get() as String)
 
-        val hexFormat = HexFormat {
-            number.removeLeadingZeros = true
-        }
-
-        return guidStringToUse.toByteArray().toHexString(hexFormat)
+        return guidStringToUse.toByteArray().toHexString().trimStart { it == '0' }
     }
 }
 


### PR DESCRIPTION
… format