### PR TITLE
Dt 610 2

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -88,15 +88,16 @@ class Injection(
         ldapServiceUserBind,
         ldapRepository,
     )
-    private val userService = UserService(ldapServiceUserBind, userLookupService)
-    private val accessGroupsService = AccessGroupsService(ldapServiceUserBind, ldapConfig)
-    private val groupService = GroupService(ldapServiceUserBind, ldapConfig)
-    private val emailRepository = EmailRepository(emailConfig)
 
     val dbPool = DbPool(databaseConfig)
 
     val userAuditTrailRepo = UserAuditTrailRepo()
     val userAuditService = UserAuditService(userAuditTrailRepo, dbPool)
+
+    private val userService = UserService(ldapServiceUserBind, userLookupService, userAuditService)
+    private val accessGroupsService = AccessGroupsService(ldapServiceUserBind, ldapConfig)
+    private val groupService = GroupService(ldapServiceUserBind, ldapConfig, userAuditService)
+    private val emailRepository = EmailRepository(emailConfig)
 
     val setPasswordTokenService = SetPasswordTokenService(dbPool, TimeSource.System)
     val resetPasswordTokenService = ResetPasswordTokenService(dbPool, TimeSource.System)
@@ -266,5 +267,17 @@ class Injection(
     fun fetchUserAuditController() = FetchUserAuditController(
         userLookupService,
         userAuditService,
+    )
+
+    fun adminUserCreationController() = AdminUserCreationController(
+        ldapConfig,
+        deltaConfig,
+        azureADSSOConfig,
+        emailConfig,
+        userLookupService,
+        userService,
+        groupService,
+        emailService,
+        setPasswordTokenService,
     )
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
@@ -199,13 +199,19 @@ fun Route.internalRoutes(injection: Injection) {
     val refreshUserInfoController = injection.refreshUserInfoController()
     val fetchUserAuditController = injection.fetchUserAuditController()
     val adminEmailController = injection.adminEmailController()
+    val adminUserCreationController = injection.adminUserCreationController()
 
     route("/auth-internal") {
         serviceUserRoutes(generateSAMLTokenController)
 
         oauthTokenRoute(oauthTokenController)
 
-        bearerTokenRoutes(refreshUserInfoController, adminEmailController, fetchUserAuditController)
+        bearerTokenRoutes(
+            refreshUserInfoController,
+            adminEmailController,
+            fetchUserAuditController,
+            adminUserCreationController
+        )
     }
 }
 
@@ -219,6 +225,7 @@ fun Route.bearerTokenRoutes(
     refreshUserInfoController: RefreshUserInfoController,
     adminEmailController: AdminEmailController,
     fetchUserAuditController: FetchUserAuditController,
+    adminUserCreationController: AdminUserCreationController,
 ) {
     authenticate(CLIENT_HEADER_AUTH_NAME, strategy = AuthenticationStrategy.Required) {
         authenticate(OAUTH_ACCESS_BEARER_TOKEN_AUTH_NAME, strategy = AuthenticationStrategy.Required) {
@@ -229,6 +236,9 @@ fun Route.bearerTokenRoutes(
             }
             route("/bearer/user-audit") {
                 fetchUserAuditController.route(this)
+            }
+            route("/bearer/create-user") {
+                adminUserCreationController.route(this)
             }
             route("/bearer/email") {
                 adminEmailController.route(this)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/DeltaConfig.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/DeltaConfig.kt
@@ -7,8 +7,8 @@ class DeltaConfig(
     val rateLimit: Int,
     val masterStoreBaseNoAuth: String,
 ) {
-    val datamartDeltaUser = "datamart-delta-user"
-    val datamartDeltaReportUsers = "datamart-delta-report-users"
+    val datamartDeltaUser = LDAPConfig.DATAMART_DELTA_PREFIX + "user"
+    val datamartDeltaReportUsers = LDAPConfig.DATAMART_DELTA_PREFIX + "report-users"
 
     companion object {
         fun fromEnv() = DeltaConfig(

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSSOLoginController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSSOLoginController.kt
@@ -93,18 +93,13 @@ class DeltaSSOLoginController(
             val registrationResult = registrationService.register(
                 registration,
                 organisationService.findAllByDomain(emailToDomain(email)),
-                ssoUser = true
+                call,
+                ssoClient,
             )
             if (registrationResult !is RegistrationService.SSOUserCreated) {
                 logger.error("Error creating SSO User, result was {}", registrationResult.toString())
                 throw Exception("Error creating SSO User")
             }
-            userAuditService.ssoUserCreatedAudit(
-                registrationResult.userCN,
-                registration.azureObjectId!!,
-                ssoClient,
-                call
-            )
             user = lookupUserInAd(email)!!
         }
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaUserRegistrationController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaUserRegistrationController.kt
@@ -135,7 +135,7 @@ class DeltaUserRegistrationController(
 
             val registration = Registration(firstName, lastName, emailAddress)
             val registrationResult = try {
-                registrationService.register(registration, organisations)
+                registrationService.register(registration, organisations, call)
             } catch (e: Exception) {
                 logger.error(
                     "Error registering user with  name: {} {}, email address: {}",
@@ -145,9 +145,6 @@ class DeltaUserRegistrationController(
                     e
                 )
                 throw e
-            }
-            if (registrationResult is RegistrationService.UserCreated) {
-                userAuditService.userSelfRegisterAudit(registrationResult.userCN, call)
             }
             try {
                 registrationService.sendRegistrationEmail(registrationResult, call)
@@ -187,7 +184,7 @@ class DeltaUserRegistrationController(
     private suspend fun ApplicationCall.respondToResult(registrationResult: RegistrationService.RegistrationResult) {
         return when (registrationResult) {
             is RegistrationService.UserCreated -> {
-                respondSuccessPage(registrationResult.registration.emailAddress)
+                respondSuccessPage(registrationResult.user.mail)
             }
 
             is RegistrationService.SSOUserCreated -> {
@@ -195,7 +192,7 @@ class DeltaUserRegistrationController(
             }
 
             is RegistrationService.UserAlreadyExists -> {
-                respondSuccessPage(registrationResult.registration.emailAddress)
+                respondSuccessPage(registrationResult.user.mail)
             }
 
             is RegistrationService.RegistrationFailure -> {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminEmailController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminEmailController.kt
@@ -35,7 +35,7 @@ class AdminEmailController(
             logger.atError().addKeyValue("userCNToSendEmailTo", receivingUser.cn)
                 .log("User already enabled on activation email request")
             throw ApiError(
-                HttpStatusCode.ExpectationFailed,
+                HttpStatusCode.BadRequest,
                 "already_enabled",
                 "User already enabled on activation email request",
                 "User already enabled"
@@ -46,7 +46,7 @@ class AdminEmailController(
             logger.atError().addKeyValue("userCNToSendEmailTo", receivingUser.cn)
                 .log("Trying to send activation email to SSO User")
             throw ApiError(
-                HttpStatusCode.ExpectationFailed,
+                HttpStatusCode.BadRequest,
                 "no_emails_to_sso_users",
                 "Trying to send activation email to SSO User",
                 "SSO user - account is automatically activated, can be enabled using the Enable Access button"
@@ -59,14 +59,14 @@ class AdminEmailController(
         } catch (e: Exception) {
             logger.atError().addKeyValue("userCNToSendEmailTo", receivingUser.cn).log("Failed to send activation email")
             throw ApiError(
-                HttpStatusCode.ExpectationFailed,
+                HttpStatusCode.InternalServerError,
                 "email_failure",
                 "Failed to send activation email",
                 "Failed to send activation email"
             )
         }
         logger.atInfo().addKeyValue("userCNToSendEmailTo", receivingUser.cn).log("New activation email sent")
-        return call.respondText("New activation email sent")
+        return call.respond(mapOf("message" to "New activation email sent successfully"))
     }
 
     private suspend fun adminSendResetPasswordEmail(call: ApplicationCall) {
@@ -77,7 +77,7 @@ class AdminEmailController(
         if (!receivingUser.accountEnabled) {
             logger.atError().addKeyValue("userCNToSendEmailTo", receivingUser.cn).log("User not enabled")
             throw ApiError(
-                HttpStatusCode.ExpectationFailed,
+                HttpStatusCode.BadRequest,
                 "not_enabled",
                 "User not enabled on reset password email request",
                 "User not enabled"
@@ -88,7 +88,7 @@ class AdminEmailController(
             logger.atError().addKeyValue("userCNToSendEmailTo", receivingUser.cn)
                 .log("Trying to send reset password to SSO User")
             throw ApiError(
-                HttpStatusCode.ExpectationFailed,
+                HttpStatusCode.BadRequest,
                 "no_emails_to_sso_users",
                 "Trying to send reset password email to SSO User",
                 "SSO user - account doesn't have a password"
@@ -101,14 +101,14 @@ class AdminEmailController(
         } catch (e: Exception) {
             logger.atError().addKeyValue("userCNToSendEmailTo", receivingUser.cn).log("Failed to send email")
             throw ApiError(
-                HttpStatusCode.ExpectationFailed,
+                HttpStatusCode.InternalServerError,
                 "email_failure",
                 "Failed to send reset password email",
                 "Failed to send reset password email"
             )
         }
         logger.atInfo().addKeyValue("userCNToSendEmailTo", receivingUser.cn).log("Reset password email sent")
-        return call.respondText("Reset password email sent")
+        return call.respond(mapOf("message" to "Reset password email sent successfully"))
     }
 
     private suspend fun getUsersFromCall(call: ApplicationCall): Array<LdapUser> {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminUserCreationController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminUserCreationController.kt
@@ -1,0 +1,148 @@
+package uk.gov.communities.delta.auth.controllers.internal
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import org.slf4j.LoggerFactory
+import uk.gov.communities.delta.auth.config.AzureADSSOConfig
+import uk.gov.communities.delta.auth.config.DeltaConfig
+import uk.gov.communities.delta.auth.config.EmailConfig
+import uk.gov.communities.delta.auth.config.LDAPConfig
+import uk.gov.communities.delta.auth.plugins.ApiError
+import uk.gov.communities.delta.auth.services.*
+
+class AdminUserCreationController(
+    private val ldapConfig: LDAPConfig,
+    private val deltaConfig: DeltaConfig,
+    private val ssoConfig: AzureADSSOConfig,
+    private val emailConfig: EmailConfig,
+    private val userLookupService: UserLookupService,
+    private val userService: UserService,
+    private val groupService: GroupService,
+    private val emailService: EmailService,
+    private val setPasswordTokenService: SetPasswordTokenService,
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    fun route(route: Route) {
+        route.post { createUser(call) }
+    }
+
+    private suspend fun createUser(call: ApplicationCall) {
+        // Get calling user from call
+        val session = call.principal<OAuthSession>()!!
+        val callingUser = userLookupService.lookupUserByCn(session.userCn)
+
+        // Authenticate calling user
+        val adminGroupCN = LDAPConfig.DATAMART_DELTA_PREFIX + "admin"
+        if (!callingUser.memberOfCNs.any { adminGroupCN == it }) {
+            throw ApiError(
+                HttpStatusCode.Forbidden,
+                "forbidden",
+                "User trying to create a new user is not an admin",
+                "You do not have the permissions to create a user"
+            )
+        }
+
+        val jsonString = call.receiveText()
+        val deltaUserDetails = ObjectMapper().readValue(jsonString, UserService.DeltaUserDetails::class.java)
+
+        val ssoClient = ssoConfig.ssoClients.firstOrNull {
+            it.required && deltaUserDetails.email.lowercase().endsWith(it.emailDomain)
+        }
+        val adUser = UserService.ADUser(
+            ldapConfig,
+            deltaUserDetails,
+            ssoClient,
+        )
+
+        if (userLookupService.userExists(adUser.cn)) {
+            logger.atWarn().addKeyValue("email", adUser.mail).addKeyValue("UserDN", adUser.dn)
+                .log("User being made by admin already exists")
+            throw ApiError(
+                HttpStatusCode.ExpectationFailed,
+                "user_already_exists",
+                "User already exists upon creation by admin",
+                "A user with this username already exists, you can edit that user via the users page"
+            )
+        }
+        try {
+            userService.createUser(adUser, ssoClient, session, call)
+        } catch (e: Exception) {
+            logger.atError().addKeyValue("UserDN", adUser.dn).log("Error creating user", e)
+            throw ApiError(
+                HttpStatusCode.ExpectationFailed,
+                "error_creating_user",
+                "Error creating user",
+                "An error occurred while creating the user, please try again"
+            )
+        }
+        logger.atInfo().addKeyValue("UserDN", adUser.dn).log("User successfully created")
+        try {
+            groupService.addUserToGroup(adUser, deltaConfig.datamartDeltaUser, call, session)
+            deltaUserDetails.organisations.forEach { orgCode: String ->
+                groupService.addUserToGroup(
+                    adUser,
+                    String.format("%s-%s", deltaConfig.datamartDeltaUser, orgCode),
+                    call,
+                    session
+                )
+            }
+            deltaUserDetails.accessGroups.forEach { accessGroup ->
+                groupService.addUserToGroup(adUser, accessGroup, call, session)
+            }
+            deltaUserDetails.accessGroupDelegates.forEach { accessGroupDelegate ->
+                groupService.addUserToGroup(adUser, accessGroupDelegate, call, session)
+            }
+            deltaUserDetails.accessGroupOrganisations.forEach { (accessGroup, organisations) ->
+                organisations.forEach { orgCode ->
+                    groupService.addUserToGroup(adUser, String.format("%s-%s", accessGroup, orgCode), call, session)
+                }
+            }
+            deltaUserDetails.roles.forEach { role ->
+                groupService.addUserToGroup(adUser, role, call, session)
+                deltaUserDetails.organisations.forEach { orgCode ->
+                    groupService.addUserToGroup(adUser, String.format("%s-%s", role, orgCode), call, session)
+                }
+            }
+        } catch (e: Exception) {
+            logger.atError().addKeyValue("UserDN", adUser.dn).log("Error adding user to groups", e)
+            throw ApiError(
+                HttpStatusCode.ExpectationFailed,
+                "error_adding_user_to_groups",
+                "Error adding user to groups",
+                "The user was created but the details were not saved correctly, please find and edit the user to have the desired details."
+            )
+        }
+        logger.atInfo().addKeyValue("UserDN", adUser.dn).log("User successfully added to all desired groups")
+
+        if (ssoClient != null) {
+            logger.atInfo().addKeyValue("UserDN", adUser.dn).log("SSO user created by admin, no email sent")
+            return call.respondText("SSO user created, no email has been sent to the user since emails aren't sent to SSO users")
+        }
+        try {
+            emailService.sendSetPasswordEmail(
+                adUser.givenName,
+                setPasswordTokenService.createToken(adUser.cn),
+                adUser.cn,
+                call.principal<OAuthSession>()!!,
+                EmailContacts(adUser.mail, adUser.getDisplayName(), emailConfig),
+                call
+            )
+        } catch (e: Exception) {
+            throw ApiError(
+                HttpStatusCode.ExpectationFailed,
+                "error_sending_email",
+                "Error sending new user email",
+                "The user was made successfully but the activation email failed to send, please find the user and send a new activation email"
+            )
+        }
+
+        return call.respondText("User created successfully")
+    }
+}

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminUserCreationController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminUserCreationController.kt
@@ -123,7 +123,7 @@ class AdminUserCreationController(
 
         if (ssoClient?.required == true) {
             logger.atInfo().addKeyValue("UserDN", adUser.dn).log("SSO user created by admin, no email sent")
-            return call.respond(mapOf("message" to "SSO user created, no email has been sent to the user since emails aren't sent to SSO users"))
+            return call.respond(mapOf("message" to "User created. Single Sign On (SSO) is enabled for this user based on their email domain. The account has been activated automatically, no email has been sent."))
         }
         try {
             emailService.sendSetPasswordEmail(

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/UserAuditTrailRepo.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/UserAuditTrailRepo.kt
@@ -16,8 +16,11 @@ class UserAuditTrailRepo {
         SET_PASSWORD_EMAIL("set_password_email"),
         RESET_PASSWORD("reset_password"),
         SET_PASSWORD("set_password"),
-        SELF_REGISTER("self_register"),
-        SSO_USER_CREATED("sso_user_created"),
+        USER_CREATED_BY_SELF_REGISTER("user_created_by_self_register"),
+        USER_CREATED_BY_SSO("user_created_by_sso"),
+        USER_CREATED_BY_ADMIN("user_created_by_admin"),
+        SSO_USER_CREATED_BY_ADMIN("sso_user_created_by_admin"),
+        USER_UPDATE("user_update"),
         ;
 
         companion object {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/saml/SAMLTokenService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/saml/SAMLTokenService.kt
@@ -10,6 +10,7 @@ import org.opensaml.saml.saml2.core.*
 import org.opensaml.saml.saml2.core.impl.*
 import org.opensaml.security.x509.BasicX509Credential
 import org.slf4j.LoggerFactory
+import uk.gov.communities.delta.auth.config.LDAPConfig
 import uk.gov.communities.delta.auth.repositories.LdapUser
 import uk.gov.communities.delta.auth.utils.timed
 import java.io.StringWriter
@@ -34,7 +35,7 @@ class SAMLTokenService {
                 initialiseOpenSaml()
             }
             try {
-                val roles = user.memberOfCNs.filter { it.startsWith("datamart-delta-") }
+                val roles = user.memberOfCNs.filter { it.startsWith(LDAPConfig.DATAMART_DELTA_PREFIX) }
                 val assertion = makeAssertionElement(user.cn, roles, validFrom, validTo)
 
                 // This block of code reportedly comes from MarkLogic support, though we no longer have access to the original ticket

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/EmailService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/EmailService.kt
@@ -1,7 +1,6 @@
 package uk.gov.communities.delta.auth.services
 
 import io.ktor.server.application.*
-import io.ktor.server.auth.*
 import jakarta.mail.Address
 import jakarta.mail.internet.InternetAddress
 import kotlinx.coroutines.Dispatchers
@@ -58,7 +57,12 @@ class EmailService(
         logger.atInfo().addKeyValue("userCN", userCN).log("Sent already-a-user email")
     }
 
-    suspend fun sendSetPasswordEmail(user: LdapUser, token: String, triggeringAdminSession: OAuthSession?, call: ApplicationCall) {
+    suspend fun sendSetPasswordEmail(
+        user: LdapUser,
+        token: String,
+        triggeringAdminSession: OAuthSession?,
+        call: ApplicationCall
+    ) {
         sendSetPasswordEmail(
             user.firstName,
             token,

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/EmailService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/EmailService.kt
@@ -95,7 +95,7 @@ class EmailService(
                 )
             )
         )
-        if (triggeringAdminSession != null) userAuditService.adminResendActivationEmailAudit(
+        if (triggeringAdminSession != null) userAuditService.adminSetPasswordEmailAudit(
             userCN,
             triggeringAdminSession.userCn,
             call

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/GroupService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/GroupService.kt
@@ -61,11 +61,11 @@ class GroupService(
     }
 
     private suspend fun auditAddingUserToGroup(userCN :String, groupCN: String, triggeringAdminSession: OAuthSession?, call: ApplicationCall) {
-        val auditData = Json.encodeToString(GroupAuditData(groupCN))
+        val auditData = Json.encodeToString(AddedGroupAuditData(groupCN))
         if (triggeringAdminSession != null)
             userAuditService.userUpdateByAdminAudit(userCN, triggeringAdminSession.userCn, call, auditData)
         else
-            userAuditService.userUpdateAudit(userCN, call)
+            userAuditService.userUpdateAudit(userCN, call, auditData)
     }
 
     private suspend fun addGroupToAD(adGroup: ADGroup) {
@@ -95,5 +95,5 @@ class GroupService(
     }
 
     @Serializable
-    private data class GroupAuditData(val groupCN: String)
+    private data class AddedGroupAuditData(val addedGroupCN: String)
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/GroupService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/GroupService.kt
@@ -1,5 +1,9 @@
 package uk.gov.communities.delta.auth.services
 
+import io.ktor.server.application.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.config.LDAPConfig
 import javax.naming.NameNotFoundException
@@ -8,6 +12,7 @@ import javax.naming.directory.*
 class GroupService(
     private val ldapServiceUserBind: LdapServiceUserBind,
     private val ldapConfig: LDAPConfig,
+    private val userAuditService: UserAuditService,
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -35,7 +40,12 @@ class GroupService(
         }
     }
 
-    suspend fun addUserToGroup(adUser: UserService.ADUser, groupCN: String) {
+    suspend fun addUserToGroup(
+        adUser: UserService.ADUser,
+        groupCN: String,
+        call: ApplicationCall,
+        triggeringAdminSession: OAuthSession? = null,
+    ) {
         val groupDN = ldapConfig.groupDnFormat.format(groupCN)
 
         if (!groupExists(groupDN)) {
@@ -47,6 +57,15 @@ class GroupService(
             it.modifyAttributes(groupDN, modificationItems)
             logger.atInfo().addKeyValue("UserDN", adUser.dn).log("User added to group with dn {}", groupDN)
         }
+        auditAddingUserToGroup(adUser.cn, groupCN, triggeringAdminSession, call)
+    }
+
+    private suspend fun auditAddingUserToGroup(userCN :String, groupCN: String, triggeringAdminSession: OAuthSession?, call: ApplicationCall) {
+        val auditData = Json.encodeToString(GroupAuditData(groupCN))
+        if (triggeringAdminSession != null)
+            userAuditService.userUpdateByAdminAudit(userCN, triggeringAdminSession.userCn, call, auditData)
+        else
+            userAuditService.userUpdateAudit(userCN, call)
     }
 
     private suspend fun addGroupToAD(adGroup: ADGroup) {
@@ -74,4 +93,7 @@ class GroupService(
             return String.format(ldapConfig.groupDnFormat, cn)
         }
     }
+
+    @Serializable
+    private data class GroupAuditData(val groupCN: String)
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
@@ -1,7 +1,9 @@
 package uk.gov.communities.delta.auth.services
 
 import io.ktor.server.application.*
+import io.ktor.server.auth.*
 import org.slf4j.LoggerFactory
+import uk.gov.communities.delta.auth.config.AzureADSSOClient
 import uk.gov.communities.delta.auth.config.DeltaConfig
 import uk.gov.communities.delta.auth.config.EmailConfig
 import uk.gov.communities.delta.auth.config.LDAPConfig
@@ -17,9 +19,9 @@ class RegistrationService(
     private val groupService: GroupService,
 ) {
     sealed class RegistrationResult
-    class UserCreated(val registration: Registration, val token: String, val userCN: String) : RegistrationResult()
+    class UserCreated(val user: UserService.ADUser, val token: String) : RegistrationResult()
     class SSOUserCreated(val userCN: String) : RegistrationResult()
-    class UserAlreadyExists(val registration: Registration, val userCN: String) : RegistrationResult()
+    class UserAlreadyExists(val user: UserService.ADUser) : RegistrationResult()
     class RegistrationFailure(val exception: Exception) : RegistrationResult()
 
     // Previously users could be datamart users but not delta users, at migration we only transferred over users who
@@ -32,33 +34,36 @@ class RegistrationService(
     suspend fun register(
         registration: Registration,
         organisations: List<Organisation>,
-        ssoUser: Boolean = false,
+        call: ApplicationCall,
+        ssoClient: AzureADSSOClient? = null,
+        azureObjectId: String? = null,
     ): RegistrationResult {
-        val adUser = UserService.ADUser(registration, ssoUser, ldapConfig)
+        val adUser = UserService.ADUser(ldapConfig, registration, ssoClient)
+
         if (userLookupService.userExists(adUser.cn)) {
             logger.atWarn().addKeyValue("UserDN", adUser.dn).log("User tried to register but user already exists")
-            return UserAlreadyExists(registration, adUser.cn)
+            return UserAlreadyExists(adUser)
         }
         try {
-            userService.createUser(adUser)
-            addUserToDefaultGroups(adUser)
-            addUserToOrganisations(adUser, organisations)
+            userService.createUser(adUser, ssoClient, call.principal<OAuthSession>(), call, azureObjectId)
+            addUserToDefaultGroups(adUser, call)
+            addUserToOrganisations(adUser, organisations, call)
         } catch (e: Exception) {
             logger.atError().addKeyValue("UserDN", adUser.dn).log("Error creating user", e)
             return RegistrationFailure(e)
         }
 
         logger.atInfo().addKeyValue("UserDN", adUser.dn).log("User successfully created")
-        return if (ssoUser)
+        return if (ssoClient != null)
             SSOUserCreated(adUser.cn)
         else
-            UserCreated(registration, setPasswordTokenService.createToken(adUser.cn), adUser.cn)
+            UserCreated(adUser, setPasswordTokenService.createToken(adUser.cn))
     }
 
-    private suspend fun addUserToDefaultGroups(adUser: UserService.ADUser) {
+    private suspend fun addUserToDefaultGroups(adUser: UserService.ADUser, call: ApplicationCall) {
         try {
-            groupService.addUserToGroup(adUser, deltaConfig.datamartDeltaReportUsers)
-            groupService.addUserToGroup(adUser, deltaConfig.datamartDeltaUser)
+            groupService.addUserToGroup(adUser, deltaConfig.datamartDeltaReportUsers, call)
+            groupService.addUserToGroup(adUser, deltaConfig.datamartDeltaUser, call)
             logger.atInfo().addKeyValue("UserDN", adUser.dn).log("User added to default groups")
         } catch (e: Exception) {
             logger.atError().addKeyValue("UserDN", adUser.dn).log("Error adding user to default groups", e)
@@ -70,14 +75,19 @@ class RegistrationService(
         return String.format("%s-%s", deltaConfig.datamartDeltaUser, orgCode)
     }
 
-    private suspend fun addUserToOrganisations(adUser: UserService.ADUser, organisations: List<Organisation>) {
+    private suspend fun addUserToOrganisations(
+        adUser: UserService.ADUser,
+        organisations: List<Organisation>,
+        call: ApplicationCall
+    ) {
         logger.atInfo().addKeyValue("UserDN", adUser.dn).log("Adding user to domain organisations")
         try {
             organisations.forEach {
                 if (!it.retired) {
                     groupService.addUserToGroup(
                         adUser,
-                        organisationUserGroup(it.code)
+                        organisationUserGroup(it.code),
+                        call
                     )
                     logger.atInfo().addKeyValue("UserDN", adUser.dn)
                         .log("Added user to domain organisation with code {}", it.code)
@@ -92,10 +102,10 @@ class RegistrationService(
         logger.atInfo().addKeyValue("UserDN", adUser.dn).log("User added to domain organisations")
     }
 
-    private fun getRegistrationEmailContacts(registration: Registration): EmailContacts {
+    private fun getEmailContacts(adUser: UserService.ADUser): EmailContacts {
         return EmailContacts(
-            registration.emailAddress,
-            registration.firstName + " " + registration.lastName,
+            adUser.mail,
+            adUser.getDisplayName(),
             emailConfig
         )
     }
@@ -104,11 +114,11 @@ class RegistrationService(
         when (registrationResult) {
             is UserCreated -> {
                 emailService.sendSetPasswordEmail(
-                    registrationResult.registration.firstName,
+                    registrationResult.user.givenName,
                     registrationResult.token,
-                    registrationResult.userCN,
+                    registrationResult.user.cn,
                     null,
-                    getRegistrationEmailContacts(registrationResult.registration),
+                    getEmailContacts(registrationResult.user),
                     call,
                 )
             }
@@ -119,9 +129,9 @@ class RegistrationService(
 
             is UserAlreadyExists -> {
                 emailService.sendAlreadyAUserEmail(
-                    registrationResult.registration.firstName,
-                    registrationResult.userCN,
-                    getRegistrationEmailContacts(registrationResult.registration),
+                    registrationResult.user.givenName,
+                    registrationResult.user.cn,
+                    getEmailContacts(registrationResult.user),
                 )
             }
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
@@ -54,7 +54,7 @@ class RegistrationService(
         }
 
         logger.atInfo().addKeyValue("UserDN", adUser.dn).log("User successfully created")
-        return if (ssoClient != null)
+        return if (ssoClient?.required == true)
             SSOUserCreated(adUser.cn)
         else
             UserCreated(adUser, setPasswordTokenService.createToken(adUser.cn))

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditService.kt
@@ -25,8 +25,6 @@ class UserAuditService(private val userAuditTrailRepo: UserAuditTrailRepo, priva
         }
     }
 
-    val userFormLoginAudit = insertAnonSimpleAuditRowFun(UserAuditTrailRepo.AuditAction.FORM_LOGIN)
-
     suspend fun userSSOLoginAudit(
         userCn: String,
         ssoClient: AzureADSSOClient,
@@ -41,6 +39,7 @@ class UserAuditService(private val userAuditTrailRepo: UserAuditTrailRepo, priva
         )
     }
 
+    val userFormLoginAudit = insertAnonSimpleAuditRowFun(UserAuditTrailRepo.AuditAction.FORM_LOGIN)
     val resetPasswordEmailAudit = insertAnonSimpleAuditRowFun(UserAuditTrailRepo.AuditAction.RESET_PASSWORD_EMAIL)
     val adminResetPasswordEmailAudit = insertSimpleAuditRowFun(UserAuditTrailRepo.AuditAction.RESET_PASSWORD_EMAIL)
     val setPasswordEmailAudit = insertAnonSimpleAuditRowFun(UserAuditTrailRepo.AuditAction.SET_PASSWORD_EMAIL)
@@ -53,7 +52,7 @@ class UserAuditService(private val userAuditTrailRepo: UserAuditTrailRepo, priva
     val userCreatedBySSOAudit = insertAnonDetailedAuditRowFun(UserAuditTrailRepo.AuditAction.USER_CREATED_BY_SSO)
     val ssoUserCreatedByAdminAudit = insertDetailedAuditRowFun(UserAuditTrailRepo.AuditAction.SSO_USER_CREATED_BY_ADMIN)
     val userUpdateByAdminAudit = insertDetailedAuditRowFun(UserAuditTrailRepo.AuditAction.USER_UPDATE)
-    val userUpdateAudit = insertAnonSimpleAuditRowFun(UserAuditTrailRepo.AuditAction.USER_UPDATE)
+    val userUpdateAudit = insertAnonDetailedAuditRowFun(UserAuditTrailRepo.AuditAction.USER_UPDATE)
 
     private fun insertAnonSimpleAuditRowFun(auditAction: UserAuditTrailRepo.AuditAction): suspend (String, ApplicationCall) -> Unit {
         return { userCn: String, call: ApplicationCall ->

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserService.kt
@@ -1,6 +1,11 @@
 package uk.gov.communities.delta.auth.services
 
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.ktor.server.application.*
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.slf4j.LoggerFactory
+import uk.gov.communities.delta.auth.config.AzureADSSOClient
 import uk.gov.communities.delta.auth.config.LDAPConfig
 import uk.gov.communities.delta.auth.controllers.external.ResetPasswordException
 import uk.gov.communities.delta.auth.utils.randomBase64
@@ -10,31 +15,100 @@ import javax.naming.directory.*
 class UserService(
     private val ldapServiceUserBind: LdapServiceUserBind,
     private val userLookupService: UserLookupService,
+    private val userAuditService: UserAuditService,
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    suspend fun createUser(adUser: ADUser) {
+    suspend fun createUser(
+        adUser: ADUser,
+        ssoClient: AzureADSSOClient?,
+        triggeringAdminSession: OAuthSession?,
+        call: ApplicationCall,
+        azureUserObjectId: String? = null,
+    ) {
         try {
             addUserToAD(adUser)
         } catch (e: Exception) {
             logger.atError().addKeyValue("UserDN", adUser.dn).log("Error creating user", e)
             throw e
         }
+        auditUserCreation(adUser.cn, ssoClient, triggeringAdminSession, call, getAuditData(adUser), azureUserObjectId)
+    }
+
+    private suspend fun auditUserCreation(
+        userCN: String,
+        ssoClient: AzureADSSOClient?,
+        triggeringAdminSession: OAuthSession?,
+        call: ApplicationCall,
+        auditData: MutableMap<String, String>,
+        azureUserObjectId: String?,
+    ) {
+        if (ssoClient != null) {
+            auditData["ssoClientInternalId"] = ssoClient.internalId
+            if (azureUserObjectId != null) auditData["azureObjectId"] = azureUserObjectId
+        }
+        val encodedAuditData = Json.encodeToString(auditData)
+        if (triggeringAdminSession != null) {
+            if (ssoClient != null) userAuditService.ssoUserCreatedByAdminAudit(
+                userCN,
+                triggeringAdminSession.userCn,
+                call,
+                encodedAuditData
+            )
+            else userAuditService.userCreatedByAdminAudit(userCN, triggeringAdminSession.userCn, call, encodedAuditData)
+        } else if (ssoClient != null) userAuditService.userCreatedBySSOAudit(
+            userCN,
+            call,
+            encodedAuditData
+        ) else userAuditService.userSelfRegisterAudit(userCN, call, encodedAuditData)
+    }
+
+    private fun getAuditData(adUser: ADUser): MutableMap<String, String> {
+        val auditData = mutableMapOf<String, String>()
+        auditData["userPrincipalName"] = adUser.userPrincipalName
+        auditData["cn"] = adUser.cn
+        auditData["sn"] = adUser.sn
+        auditData["givenName"] = adUser.givenName
+        auditData["mail"] = adUser.mail
+        auditData["st"] = adUser.notificationStatus
+        auditData["userAccountControl"] = adUser.userAccountControl
+
+        if (adUser.comment != null) auditData["comment"] = adUser.comment!!
+        if (adUser.telephone != null) auditData["telephoneNumber"] = adUser.telephone!!
+        if (adUser.mobile != null) auditData["mobile"] = adUser.mobile!!
+        if (adUser.reasonForAccess != null) auditData["description"] = adUser.reasonForAccess!!
+        if (adUser.position != null) auditData["title"] = adUser.position!!
+
+        auditData["HasPassword"] = (adUser.password != null).toString()
+
+        return auditData
+    }
+
+    private fun getAttributes(adUser: ADUser): Attributes {
+        val attributes: Attributes = BasicAttributes()
+        attributes.put(adUser.objClasses)
+        attributes.put(BasicAttribute("userPrincipalName", adUser.userPrincipalName))
+        attributes.put(BasicAttribute("cn", adUser.cn))
+        attributes.put(BasicAttribute("sn", adUser.sn))
+        attributes.put(BasicAttribute("givenName", adUser.givenName))
+        attributes.put(BasicAttribute("mail", adUser.mail))
+        attributes.put(BasicAttribute("st", adUser.notificationStatus))
+        attributes.put(BasicAttribute("userAccountControl", adUser.userAccountControl))
+
+        if (adUser.comment != null) attributes.put(BasicAttribute("comment", adUser.comment))
+        if (adUser.telephone != null) attributes.put(BasicAttribute("telephoneNumber", adUser.telephone))
+        if (adUser.mobile != null) attributes.put(BasicAttribute("mobile", adUser.mobile))
+        if (adUser.reasonForAccess != null) attributes.put(BasicAttribute("description", adUser.reasonForAccess))
+        if (adUser.position != null) attributes.put(BasicAttribute("title", adUser.position))
+
+        if (adUser.password != null) attributes.put(ADUser.getPasswordAttribute(adUser.password!!))
+
+        return attributes
     }
 
     private suspend fun addUserToAD(adUser: ADUser) {
-        val container: Attributes = BasicAttributes()
-        container.put(adUser.objClasses)
-        container.put(BasicAttribute("userPrincipalName", adUser.userPrincipalName))
-        container.put(BasicAttribute("cn", adUser.cn))
-        container.put(BasicAttribute("sn", adUser.sn))
-        container.put(BasicAttribute("givenName", adUser.givenName))
-        container.put(BasicAttribute("mail", adUser.mail))
-        container.put(BasicAttribute("st", adUser.st))
-        container.put(BasicAttribute("userAccountControl", adUser.userAccountControl))
-        if (adUser.password != null) container.put(ADUser.getPasswordAttribute(adUser.password!!))
-        if (adUser.comment != null) container.put(BasicAttribute("comment", adUser.comment))
+        val container = getAttributes(adUser)
 
         val enabled = adUser.userAccountControl == ADUser.accountFlags(true)
         if (enabled && adUser.password == null) {
@@ -94,18 +168,78 @@ class UserService(
         }
     }
 
-    class ADUser(registration: Registration, ssoUser: Boolean, private val ldapConfig: LDAPConfig) {
-        var cn: String = LDAPConfig.emailToCN(registration.emailAddress)
-        var givenName: String = registration.firstName
-        var sn: String = registration.lastName
-        var mail: String = registration.emailAddress
-        var userAccountControl: String = accountFlags(ssoUser)
-        var dn: String = cnToDN(cn)
-        var userPrincipalName: String = cnToPrincipalName(cn)
-        var st: String = "active"
-        var objClasses = objClasses()
-        var password = if (ssoUser) randomBase64(18) else null
-        var comment = if (ssoUser) "Created via SSO" else null
+    class ADUser {
+        var ldapConfig: LDAPConfig
+            private set
+        var cn: String
+            private set
+        var givenName: String
+            private set
+        var sn: String
+            private set
+        var mail: String
+            private set
+        var userAccountControl: String
+            private set
+        var dn: String
+            private set
+        var userPrincipalName: String
+            private set
+        var notificationStatus: String
+            private set
+        var password: String? = null
+            private set
+        var comment: String? = null
+            private set
+        var telephone: String? = null
+            private set
+        var mobile: String? = null
+            private set
+        var reasonForAccess: String? = null
+            private set
+        var position: String? = null
+            private set
+        var objClasses: Attribute = objClasses()
+
+        constructor(ldapConfig: LDAPConfig, registration: Registration, ssoClient: AzureADSSOClient?) {
+            val ssoUser = ssoClient != null
+            this.ldapConfig = ldapConfig
+            this.cn = LDAPConfig.emailToCN(registration.emailAddress)
+            this.givenName = registration.firstName
+            this.sn = registration.lastName
+            this.mail = registration.emailAddress
+            this.userAccountControl = accountFlags(ssoUser)
+            this.dn = cnToDN(cn)
+            this.userPrincipalName = cnToPrincipalName(cn)
+            this.notificationStatus = "active"
+            this.password = if (ssoUser) randomBase64(18) else null
+            this.comment = if (ssoUser) "Created via SSO" else null
+        }
+
+        constructor(
+            ldapConfig: LDAPConfig,
+            deltaUserDetails: DeltaUserDetails,
+            ssoClient: AzureADSSOClient?,
+        ) {
+            val ssoUser = ssoClient != null
+            this.ldapConfig = ldapConfig
+            this.cn = LDAPConfig.emailToCN(deltaUserDetails.email)
+            this.givenName = deltaUserDetails.firstName
+            this.sn = deltaUserDetails.lastName
+            this.mail = deltaUserDetails.email
+            this.userAccountControl = accountFlags(ssoUser)
+            this.dn = cnToDN(cn)
+            this.userPrincipalName = cnToPrincipalName(cn)
+            this.notificationStatus = "active"
+            this.password = if (ssoUser) randomBase64(18) else null
+            this.comment = if (deltaUserDetails.comment.isNullOrEmpty()) null else deltaUserDetails.comment
+            this.telephone = if (deltaUserDetails.telephone.isNullOrEmpty()) null else deltaUserDetails.telephone
+            this.mobile = if (deltaUserDetails.mobile.isNullOrEmpty()) null else deltaUserDetails.mobile
+            this.position = if (deltaUserDetails.position.isNullOrEmpty()) null else deltaUserDetails.position
+            this.reasonForAccess =
+                if (deltaUserDetails.reasonForAccess.isNullOrEmpty()) null else deltaUserDetails.reasonForAccess
+
+        }
 
         private fun objClasses(): Attribute {
             val objClasses: Attribute = BasicAttribute("objectClass")
@@ -122,6 +256,10 @@ class UserService(
 
         private fun cnToPrincipalName(cn: String): String {
             return String.format("%s@%s", cn, ldapConfig.domainRealm)
+        }
+
+        fun getDisplayName(): String {
+            return this.givenName + this.sn
         }
 
         companion object {
@@ -148,4 +286,24 @@ class UserService(
             }
         }
     }
+
+    data class DeltaUserDetails(
+        @JsonProperty("id") val id: String,
+        @JsonProperty("enabled") val enabled: Boolean,
+        @JsonProperty("email") val email: String,
+        @JsonProperty("lastName") val lastName: String,
+        @JsonProperty("firstName") val firstName: String,
+        @JsonProperty("telephone") val telephone: String?,
+        @JsonProperty("mobile") val mobile: String?,
+        @JsonProperty("position") val position: String?,
+        @JsonProperty("reasonForAccess") val reasonForAccess: String?,
+        @JsonProperty("accessGroups") val accessGroups: Array<String>,
+        @JsonProperty("accessGroupDelegates") val accessGroupDelegates: Array<String>,
+        @JsonProperty("accessGroupOrganisations") val accessGroupOrganisations: Map<String, Array<String>>,
+        @JsonProperty("roles") val roles: Array<String>,
+        @JsonProperty("externalRoles") val externalRoles: Array<String>,
+        @JsonProperty("organisations") val organisations: Array<String>,
+        @JsonProperty("comment") val comment: String?,
+        @JsonProperty("classificationType") val classificationType: String?,
+    )
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserService.kt
@@ -1,7 +1,8 @@
 package uk.gov.communities.delta.auth.services
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import io.ktor.server.application.*
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.slf4j.LoggerFactory
@@ -75,11 +76,11 @@ class UserService(
         auditData["st"] = adUser.notificationStatus
         auditData["userAccountControl"] = adUser.userAccountControl
 
-        if (adUser.comment != null) auditData["comment"] = adUser.comment!!
-        if (adUser.telephone != null) auditData["telephoneNumber"] = adUser.telephone!!
-        if (adUser.mobile != null) auditData["mobile"] = adUser.mobile!!
-        if (adUser.reasonForAccess != null) auditData["description"] = adUser.reasonForAccess!!
-        if (adUser.position != null) auditData["title"] = adUser.position!!
+        adUser.comment?.let { auditData["comment"] = it }
+        adUser.telephone?.let { auditData["telephoneNumber"] = it }
+        adUser.mobile?.let { auditData["mobile"] = it }
+        adUser.reasonForAccess?.let { auditData["description"] = it }
+        adUser.position?.let { auditData["title"] = it }
 
         auditData["HasPassword"] = (adUser.password != null).toString()
 
@@ -97,13 +98,13 @@ class UserService(
         attributes.put(BasicAttribute("st", adUser.notificationStatus))
         attributes.put(BasicAttribute("userAccountControl", adUser.userAccountControl))
 
-        if (adUser.comment != null) attributes.put(BasicAttribute("comment", adUser.comment))
-        if (adUser.telephone != null) attributes.put(BasicAttribute("telephoneNumber", adUser.telephone))
-        if (adUser.mobile != null) attributes.put(BasicAttribute("mobile", adUser.mobile))
-        if (adUser.reasonForAccess != null) attributes.put(BasicAttribute("description", adUser.reasonForAccess))
-        if (adUser.position != null) attributes.put(BasicAttribute("title", adUser.position))
+        adUser.comment?.let { attributes.put(BasicAttribute("comment",it)) }
+        adUser.telephone?.let { attributes.put(BasicAttribute("telephoneNumber",it)) }
+        adUser.mobile?.let { attributes.put(BasicAttribute("mobile",it)) }
+        adUser.reasonForAccess?.let { attributes.put(BasicAttribute("description",it)) }
+        adUser.position?.let { attributes.put(BasicAttribute("title",it)) }
 
-        if (adUser.password != null) attributes.put(ADUser.getPasswordAttribute(adUser.password!!))
+        adUser.password?.let { attributes.put(ADUser.getPasswordAttribute(it)) }
 
         return attributes
     }
@@ -260,7 +261,7 @@ class UserService(
         }
 
         fun getDisplayName(): String {
-            return this.givenName + this.sn
+            return "${this.givenName} ${this.sn}"
         }
 
         companion object {
@@ -288,23 +289,24 @@ class UserService(
         }
     }
 
+    @Serializable
     data class DeltaUserDetails(
-        @JsonProperty("id") val id: String, //Not used anywhere yet
-        @JsonProperty("enabled") val enabled: Boolean, //Always false for user creation - not used anywhere yet
-        @JsonProperty("email") val email: String,
-        @JsonProperty("lastName") val lastName: String,
-        @JsonProperty("firstName") val firstName: String,
-        @JsonProperty("telephone") val telephone: String?,
-        @JsonProperty("mobile") val mobile: String?,
-        @JsonProperty("position") val position: String?,
-        @JsonProperty("reasonForAccess") val reasonForAccess: String?,
-        @JsonProperty("accessGroups") val accessGroups: Array<String>,
-        @JsonProperty("accessGroupDelegates") val accessGroupDelegates: Array<String>,
-        @JsonProperty("accessGroupOrganisations") val accessGroupOrganisations: Map<String, Array<String>>,
-        @JsonProperty("roles") val roles: Array<String>,
-        @JsonProperty("externalRoles") val externalRoles: Array<String>, //Not used anywhere yet
-        @JsonProperty("organisations") val organisations: Array<String>,
-        @JsonProperty("comment") val comment: String?,
-        @JsonProperty("classificationType") val classificationType: String?, //Not used anywhere yet
+        @SerialName("id") val id: String, //Not used anywhere yet
+        @SerialName("enabled") val enabled: Boolean, //Always false for user creation - not used anywhere yet
+        @SerialName("email") val email: String,
+        @SerialName("lastName") val lastName: String,
+        @SerialName("firstName") val firstName: String,
+        @SerialName("telephone") val telephone: String? = null,
+        @SerialName("mobile") val mobile: String? = null,
+        @SerialName("position") val position: String? = null,
+        @SerialName("reasonForAccess") val reasonForAccess: String? = null,
+        @SerialName("accessGroups") val accessGroups: Array<String>,
+        @SerialName("accessGroupDelegates") val accessGroupDelegates: Array<String>,
+        @SerialName("accessGroupOrganisations") val accessGroupOrganisations: Map<String, Array<String>>,
+        @SerialName("roles") val roles: Array<String>,
+        @SerialName("externalRoles") val externalRoles: Array<String>, //Not used anywhere yet
+        @SerialName("organisations") val organisations: Array<String>,
+        @SerialName("comment") val comment: String? = null,
+        @SerialName("classificationType") val classificationType: String? = null, //Not used anywhere yet
     )
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserService.kt
@@ -44,20 +44,21 @@ class UserService(
         auditData: MutableMap<String, String>,
         azureUserObjectId: String?,
     ) {
-        if (ssoClient != null) {
-            auditData["ssoClientInternalId"] = ssoClient.internalId
+        val ssoUser = ssoClient?.required == true
+        if (ssoUser) {
+            auditData["ssoClientInternalId"] = ssoClient!!.internalId
             if (azureUserObjectId != null) auditData["azureObjectId"] = azureUserObjectId
         }
         val encodedAuditData = Json.encodeToString(auditData)
         if (triggeringAdminSession != null) {
-            if (ssoClient != null) userAuditService.ssoUserCreatedByAdminAudit(
+            if (ssoUser) userAuditService.ssoUserCreatedByAdminAudit(
                 userCN,
                 triggeringAdminSession.userCn,
                 call,
                 encodedAuditData
             )
             else userAuditService.userCreatedByAdminAudit(userCN, triggeringAdminSession.userCn, call, encodedAuditData)
-        } else if (ssoClient != null) userAuditService.userCreatedBySSOAudit(
+        } else if (ssoUser) userAuditService.userCreatedBySSOAudit(
             userCN,
             call,
             encodedAuditData
@@ -202,7 +203,7 @@ class UserService(
         var objClasses: Attribute = objClasses()
 
         constructor(ldapConfig: LDAPConfig, registration: Registration, ssoClient: AzureADSSOClient?) {
-            val ssoUser = ssoClient != null
+            val ssoUser = ssoClient?.required ?: false
             this.ldapConfig = ldapConfig
             this.cn = LDAPConfig.emailToCN(registration.emailAddress)
             this.givenName = registration.firstName
@@ -221,7 +222,7 @@ class UserService(
             deltaUserDetails: DeltaUserDetails,
             ssoClient: AzureADSSOClient?,
         ) {
-            val ssoUser = ssoClient != null
+            val ssoUser = ssoClient?.required ?: false
             this.ldapConfig = ldapConfig
             this.cn = LDAPConfig.emailToCN(deltaUserDetails.email)
             this.givenName = deltaUserDetails.firstName
@@ -288,8 +289,8 @@ class UserService(
     }
 
     data class DeltaUserDetails(
-        @JsonProperty("id") val id: String,
-        @JsonProperty("enabled") val enabled: Boolean,
+        @JsonProperty("id") val id: String, //Not used anywhere yet
+        @JsonProperty("enabled") val enabled: Boolean, //Always false for user creation - not used anywhere yet
         @JsonProperty("email") val email: String,
         @JsonProperty("lastName") val lastName: String,
         @JsonProperty("firstName") val firstName: String,
@@ -301,9 +302,9 @@ class UserService(
         @JsonProperty("accessGroupDelegates") val accessGroupDelegates: Array<String>,
         @JsonProperty("accessGroupOrganisations") val accessGroupOrganisations: Map<String, Array<String>>,
         @JsonProperty("roles") val roles: Array<String>,
-        @JsonProperty("externalRoles") val externalRoles: Array<String>,
+        @JsonProperty("externalRoles") val externalRoles: Array<String>, //Not used anywhere yet
         @JsonProperty("organisations") val organisations: Array<String>,
         @JsonProperty("comment") val comment: String?,
-        @JsonProperty("classificationType") val classificationType: String?,
+        @JsonProperty("classificationType") val classificationType: String?, //Not used anywhere yet
     )
 }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEmailControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEmailControllerTest.kt
@@ -266,6 +266,7 @@ class AdminEmailControllerTest {
                             mockk(relaxed = true),
                             controller,
                             mockk(relaxed = true),
+                            mockk(relaxed = true),
                         )
                     }
                 }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminUserCreationControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminUserCreationControllerTest.kt
@@ -1,9 +1,11 @@
 package uk.gov.communities.delta.controllers
 
 import io.ktor.client.*
+import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.auth.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
@@ -13,6 +15,8 @@ import jakarta.mail.Authenticator
 import jakarta.mail.PasswordAuthentication
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 import org.apache.commons.lang3.builder.EqualsBuilder
 import org.junit.*
 import uk.gov.communities.delta.auth.bearerTokenRoutes
@@ -36,10 +40,11 @@ class AdminUserCreationControllerTest {
     @Test
     fun testAdminCreateUser() = testSuspend {
         testClient.post("/bearer/create-user") {
+            contentType(ContentType.Application.Json)
+            setBody(getUserDetailsJson(NEW_STANDARD_USER_EMAIL))
             headers {
                 append("Authorization", "Bearer ${adminSession.authToken}")
                 append("Delta-Client", "${client.clientId}:${client.clientSecret}")
-                setBody(getUserDetailsJsonString(NEW_STANDARD_USER_EMAIL))
             }
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
@@ -61,7 +66,7 @@ class AdminUserCreationControllerTest {
                     any()
                 )
             }
-            assertEquals("User created successfully", bodyAsText())
+            assertEquals("{\"message\":\"User created successfully\"}", bodyAsText())
         }
     }
 
@@ -71,6 +76,8 @@ class AdminUserCreationControllerTest {
         Assert.assertThrows(NameNotFoundException::class.java) {
             runBlocking {
                 testClient.post("/bearer/create-user") {
+                    contentType(ContentType.Application.Json)
+                    setBody(getUserDetailsJson(NEW_STANDARD_USER_EMAIL))
                     headers {
                         append("Authorization", "Bearer ${adminSession.authToken}")
                         append("Delta-Client", "${client.clientId}:${client.clientSecret}")
@@ -89,7 +96,8 @@ class AdminUserCreationControllerTest {
                         append("Authorization", "Bearer ${userSession.authToken}")
                         append("Delta-Client", "${client.clientId}:${client.clientSecret}")
                     }
-                    parameter("text", "testing testing")
+                    contentType(ContentType.Application.Json)
+                    setBody(getUserDetailsJson(NEW_STANDARD_USER_EMAIL))
                 }
             }
         }.apply {
@@ -100,10 +108,11 @@ class AdminUserCreationControllerTest {
     @Test
     fun testAdminCreateSSOUser() = testSuspend {
         testClient.post("/bearer/create-user") {
+            contentType(ContentType.Application.Json)
+            setBody(getUserDetailsJson(NEW_SSO_USER_EMAIL))
             headers {
                 append("Authorization", "Bearer ${adminSession.authToken}")
                 append("Delta-Client", "${client.clientId}:${client.clientSecret}")
-                setBody(getUserDetailsJsonString(NEW_SSO_USER_EMAIL))
             }
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
@@ -117,7 +126,7 @@ class AdminUserCreationControllerTest {
             verifyCorrectGroupsAdded()
             coVerify(exactly = 0) { emailService.sendSetPasswordEmail(any(), any(), any(), any(), any(), any()) }
             assertEquals(
-                "SSO user created, no email has been sent to the user since emails aren't sent to SSO users",
+                "{\"message\":\"SSO user created, no email has been sent to the user since emails aren't sent to SSO users\"}",
                 bodyAsText()
             )
         }
@@ -126,10 +135,11 @@ class AdminUserCreationControllerTest {
     @Test
     fun testAdminCreateNotRequiredSSOUser() = testSuspend {
         testClient.post("/bearer/create-user") {
+            contentType(ContentType.Application.Json)
+            setBody(getUserDetailsJson(NEW_NOT_REQUIRED_SSO_USER))
             headers {
                 append("Authorization", "Bearer ${adminSession.authToken}")
                 append("Delta-Client", "${client.clientId}:${client.clientSecret}")
-                setBody(getUserDetailsJsonString(NEW_NOT_REQUIRED_SSO_USER))
             }
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
@@ -151,7 +161,7 @@ class AdminUserCreationControllerTest {
                     any()
                 )
             }
-            assertEquals("User created successfully", bodyAsText())
+            assertEquals("{\"message\":\"User created successfully\"}", bodyAsText())
         }
     }
 
@@ -160,10 +170,11 @@ class AdminUserCreationControllerTest {
         Assert.assertThrows(ApiError::class.java) {
             runBlocking {
                 testClient.post("/bearer/create-user") {
+                    contentType(ContentType.Application.Json)
+                    setBody(getUserDetailsJson(OLD_STANDARD_USER_EMAIL))
                     headers {
                         append("Authorization", "Bearer ${adminSession.authToken}")
                         append("Delta-Client", "${client.clientId}:${client.clientSecret}")
-                        setBody(getUserDetailsJsonString(OLD_STANDARD_USER_EMAIL))
                     }
                 }
             }
@@ -179,10 +190,11 @@ class AdminUserCreationControllerTest {
         Assert.assertThrows(ApiError::class.java) {
             runBlocking {
                 testClient.post("/bearer/create-user") {
+                    contentType(ContentType.Application.Json)
+                    setBody(getUserDetailsJson(NEW_STANDARD_USER_EMAIL))
                     headers {
                         append("Authorization", "Bearer ${adminSession.authToken}")
                         append("Delta-Client", "${client.clientId}:${client.clientSecret}")
-                        setBody(getUserDetailsJsonString(NEW_STANDARD_USER_EMAIL))
                     }
                 }
             }
@@ -197,10 +209,11 @@ class AdminUserCreationControllerTest {
         Assert.assertThrows(ApiError::class.java) {
             runBlocking {
                 testClient.post("/bearer/create-user") {
+                    contentType(ContentType.Application.Json)
+                    setBody(getUserDetailsJson(NEW_STANDARD_USER_EMAIL))
                     headers {
                         append("Authorization", "Bearer ${adminSession.authToken}")
                         append("Delta-Client", "${client.clientId}:${client.clientSecret}")
-                        setBody(getUserDetailsJsonString(NEW_STANDARD_USER_EMAIL))
                     }
                 }
             }
@@ -215,10 +228,11 @@ class AdminUserCreationControllerTest {
         Assert.assertThrows(ApiError::class.java) {
             runBlocking {
                 testClient.post("/bearer/create-user") {
+                    contentType(ContentType.Application.Json)
+                    setBody(getUserDetailsJson(NEW_STANDARD_USER_EMAIL))
                     headers {
                         append("Authorization", "Bearer ${adminSession.authToken}")
                         append("Delta-Client", "${client.clientId}:${client.clientSecret}")
-                        setBody(getUserDetailsJsonString(NEW_STANDARD_USER_EMAIL))
                     }
                 }
             }
@@ -293,8 +307,9 @@ class AdminUserCreationControllerTest {
         private val adminSession = OAuthSession(1, adminUser.cn, client, "adminAccessToken", Instant.now(), "trace")
         private val userSession = OAuthSession(1, regularUser.cn, client, "userAccessToken", Instant.now(), "trace")
 
-        private fun getUserDetailsJsonString(email: String): String {
-            return "{\"id\":\"\"," +
+        private fun getUserDetailsJson(email: String): JsonElement {
+            return Json.parseToJsonElement(
+                "{\"id\":\"\"," +
                     "\"enabled\":false," +
                     "\"email\":\"$email\"," +
                     "\"lastName\":\"testLast\"," +
@@ -309,9 +324,8 @@ class AdminUserCreationControllerTest {
                     "\"externalRoles\":[]," +
                     "\"organisations\":[\"orgCode1\", \"orgCode2\"]," +
                     "\"comment\":\"test comment\"}"
+            )
         }
-
-//        {"id":"","enabled":false,"email":"test65@test610.com","lastName":"test dt610","firstName":"phoebe","telephone":"4564563","mobile":"2452345","position":"","accessGroups":["datamart-delta-abcdef","datamart-delta-aga-test-grant"],"accessGroupDelegates":["datamart-delta-abcdef","datamart-delta-aga-test-grant"],"accessGroupOrganisations":{"datamart-delta-abcdef":["pw-org-36616"]},"roles":["datamart-delta-setup-managers"],"externalRoles":[],"organisations":["pw-org-36616"],"comment":""}
 
         private fun getDeltaUserDetails(email: String): UserService.DeltaUserDetails {
             return UserService.DeltaUserDetails(
@@ -447,6 +461,9 @@ class AdminUserCreationControllerTest {
             }
 
             testClient = testApp.createClient {
+                install(ContentNegotiation) {
+                    json()
+                }
                 followRedirects = false
             }
         }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminUserCreationControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminUserCreationControllerTest.kt
@@ -1,0 +1,460 @@
+package uk.gov.communities.delta.controllers
+
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.auth.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import io.ktor.test.dispatcher.*
+import io.mockk.*
+import jakarta.mail.Authenticator
+import jakarta.mail.PasswordAuthentication
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.apache.commons.lang3.builder.EqualsBuilder
+import org.junit.*
+import uk.gov.communities.delta.auth.bearerTokenRoutes
+import uk.gov.communities.delta.auth.config.*
+import uk.gov.communities.delta.auth.controllers.internal.AdminUserCreationController
+import uk.gov.communities.delta.auth.plugins.ApiError
+import uk.gov.communities.delta.auth.plugins.configureSerialization
+import uk.gov.communities.delta.auth.security.CLIENT_HEADER_AUTH_NAME
+import uk.gov.communities.delta.auth.security.OAUTH_ACCESS_BEARER_TOKEN_AUTH_NAME
+import uk.gov.communities.delta.auth.security.clientHeaderAuth
+import uk.gov.communities.delta.auth.services.*
+import uk.gov.communities.delta.helper.testLdapUser
+import uk.gov.communities.delta.helper.testServiceClient
+import java.time.Instant
+import java.util.*
+import javax.naming.NameNotFoundException
+import kotlin.test.assertEquals
+
+class AdminUserCreationControllerTest {
+
+    @Test
+    fun testAdminCreateUser() = testSuspend {
+        testClient.post("/bearer/create-user") {
+            headers {
+                append("Authorization", "Bearer ${adminSession.authToken}")
+                append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+                setBody(getUserDetailsJsonString(NEW_STANDARD_USER_EMAIL))
+            }
+        }.apply {
+            assertEquals(HttpStatusCode.OK, status)
+            coVerify(exactly = 1) { userService.createUser(any(), null, adminSession, any()) }
+            val expectedUser = UserService.ADUser(
+                ldapConfig,
+                getDeltaUserDetails(NEW_STANDARD_USER_EMAIL),
+                null
+            )
+            assertCapturedUserIsAsExpected(expectedUser)
+            verifyCorrectGroupsAdded()
+            coVerify(exactly = 1) {
+                emailService.sendSetPasswordEmail(
+                    expectedUser.givenName,
+                    any(),
+                    expectedUser.cn,
+                    adminSession,
+                    any(),
+                    any()
+                )
+            }
+            assertEquals("User created successfully", bodyAsText())
+        }
+    }
+
+    @Test
+    fun testUserMakingRequestNotExisting() = testSuspend {
+        coEvery { userLookupService.lookupUserByCn(adminUser.cn) } throws NameNotFoundException()
+        Assert.assertThrows(NameNotFoundException::class.java) {
+            runBlocking {
+                testClient.post("/bearer/create-user") {
+                    headers {
+                        append("Authorization", "Bearer ${adminSession.authToken}")
+                        append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testNonAdminMakingRequest() = testSuspend {
+        Assert.assertThrows(ApiError::class.java) {
+            runBlocking {
+                testClient.post("/bearer/create-user") {
+                    headers {
+                        append("Authorization", "Bearer ${userSession.authToken}")
+                        append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+                    }
+                    parameter("text", "testing testing")
+                }
+            }
+        }.apply {
+            assertEquals("forbidden", errorCode)
+        }
+    }
+
+    @Test
+    fun testAdminCreateSSOUser() = testSuspend {
+        testClient.post("/bearer/create-user") {
+            headers {
+                append("Authorization", "Bearer ${adminSession.authToken}")
+                append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+                setBody(getUserDetailsJsonString(NEW_SSO_USER_EMAIL))
+            }
+        }.apply {
+            assertEquals(HttpStatusCode.OK, status)
+            coVerify(exactly = 1) { userService.createUser(any(), requiredSSOClient, adminSession, any()) }
+            val expectedUser = UserService.ADUser(
+                ldapConfig,
+                getDeltaUserDetails(NEW_SSO_USER_EMAIL),
+                requiredSSOClient
+            )
+            assertCapturedUserIsAsExpected(expectedUser, false)
+            verifyCorrectGroupsAdded()
+            coVerify(exactly = 0) { emailService.sendSetPasswordEmail(any(), any(), any(), any(), any(), any()) }
+            assertEquals(
+                "SSO user created, no email has been sent to the user since emails aren't sent to SSO users",
+                bodyAsText()
+            )
+        }
+    }
+
+    @Test
+    fun testAdminCreateNotRequiredSSOUser() = testSuspend {
+        testClient.post("/bearer/create-user") {
+            headers {
+                append("Authorization", "Bearer ${adminSession.authToken}")
+                append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+                setBody(getUserDetailsJsonString(NEW_NOT_REQUIRED_SSO_USER))
+            }
+        }.apply {
+            assertEquals(HttpStatusCode.OK, status)
+            coVerify(exactly = 1) { userService.createUser(any(), notRequiredSSOClient, adminSession, any()) }
+            val expectedUser = UserService.ADUser(
+                ldapConfig,
+                getDeltaUserDetails(NEW_NOT_REQUIRED_SSO_USER),
+                notRequiredSSOClient
+            )
+            assertCapturedUserIsAsExpected(expectedUser)
+            verifyCorrectGroupsAdded()
+            coVerify(exactly = 1) {
+                emailService.sendSetPasswordEmail(
+                    expectedUser.givenName,
+                    any(),
+                    expectedUser.cn,
+                    adminSession,
+                    any(),
+                    any()
+                )
+            }
+            assertEquals("User created successfully", bodyAsText())
+        }
+    }
+
+    @Test
+    fun testAdminCreateAlreadyExistingUser() = testSuspend {
+        Assert.assertThrows(ApiError::class.java) {
+            runBlocking {
+                testClient.post("/bearer/create-user") {
+                    headers {
+                        append("Authorization", "Bearer ${adminSession.authToken}")
+                        append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+                        setBody(getUserDetailsJsonString(OLD_STANDARD_USER_EMAIL))
+                    }
+                }
+            }
+        }.apply {
+            assertEquals("user_already_exists", errorCode)
+            coVerify(exactly = 0) { userService.createUser(any(), any(), any(), any()) }
+        }
+    }
+
+    @Test
+    fun testErrorHandlingDuringCreation() = testSuspend {
+        coEvery { userService.createUser(any(), any(), any(), any()) } throws Exception()
+        Assert.assertThrows(ApiError::class.java) {
+            runBlocking {
+                testClient.post("/bearer/create-user") {
+                    headers {
+                        append("Authorization", "Bearer ${adminSession.authToken}")
+                        append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+                        setBody(getUserDetailsJsonString(NEW_STANDARD_USER_EMAIL))
+                    }
+                }
+            }
+        }.apply {
+            assertEquals("error_creating_user", errorCode)
+        }
+    }
+
+    @Test
+    fun testErrorHandlingDuringAddingToGroup() = testSuspend {
+        coEvery { groupService.addUserToGroup(any(), any(), any(), any()) } throws Exception()
+        Assert.assertThrows(ApiError::class.java) {
+            runBlocking {
+                testClient.post("/bearer/create-user") {
+                    headers {
+                        append("Authorization", "Bearer ${adminSession.authToken}")
+                        append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+                        setBody(getUserDetailsJsonString(NEW_STANDARD_USER_EMAIL))
+                    }
+                }
+            }
+        }.apply {
+            assertEquals("error_adding_user_to_groups", errorCode)
+        }
+    }
+
+    @Test
+    fun testErrorHandlingDuringEmailSending() = testSuspend {
+        coEvery { emailService.sendSetPasswordEmail(any(), any(), any(), any(), any(), any()) } throws Exception()
+        Assert.assertThrows(ApiError::class.java) {
+            runBlocking {
+                testClient.post("/bearer/create-user") {
+                    headers {
+                        append("Authorization", "Bearer ${adminSession.authToken}")
+                        append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+                        setBody(getUserDetailsJsonString(NEW_STANDARD_USER_EMAIL))
+                    }
+                }
+            }
+        }.apply {
+            assertEquals("error_sending_email", errorCode)
+        }
+    }
+
+    @Before
+    fun resetMocks() {
+        user.clear()
+        clearAllMocks()
+        coEvery {
+            oauthSessionService.retrieveFomAuthToken(
+                adminSession.authToken,
+                client
+            )
+        } answers { adminSession }
+        coEvery {
+            oauthSessionService.retrieveFomAuthToken(
+                userSession.authToken,
+                client
+            )
+        } answers { userSession }
+        coEvery { userLookupService.lookupUserByCn(adminUser.cn) } returns adminUser
+        coEvery { userLookupService.lookupUserByCn(regularUser.cn) } returns regularUser
+        coEvery { userLookupService.userExists(LDAPConfig.emailToCN(NEW_STANDARD_USER_EMAIL)) } returns false
+        coEvery { userLookupService.userExists(LDAPConfig.emailToCN(NEW_SSO_USER_EMAIL)) } returns false
+        coEvery { userLookupService.userExists(LDAPConfig.emailToCN(NEW_NOT_REQUIRED_SSO_USER)) } returns false
+        coEvery { userLookupService.userExists(LDAPConfig.emailToCN(OLD_STANDARD_USER_EMAIL)) } returns true
+        coEvery { userLookupService.userExists(LDAPConfig.emailToCN(OLD_SSO_USER_EMAIL)) } returns true
+        coEvery { userLookupService.userExists(LDAPConfig.emailToCN(OLD_NOT_REQUIRED_SSO_USER)) } returns true
+        coEvery { userService.createUser(capture(user), any(), any(), any()) } just runs
+        coEvery { groupService.addUserToGroup(any(), any(), any(), any()) } just runs
+        coEvery { emailService.sendSetPasswordEmail(any(), any(), any(), any(), any(), any()) } just runs
+        coEvery { setPasswordTokenService.createToken(any()) } returns "passwordToken"
+    }
+
+    companion object {
+        private lateinit var testApp: TestApplication
+        private lateinit var testClient: HttpClient
+        private lateinit var controller: AdminUserCreationController
+
+        private val oauthSessionService = mockk<OAuthSessionService>()
+
+        private val ldapConfig = LDAPConfig("testInvalidUrl", "", "", "", "", "", "", "", "")
+        private val deltaConfig = DeltaConfig.fromEnv()
+        private val requiredSSOClient = AzureADSSOClient("dev", "", "", "", "@required.sso.domain", required = true)
+        private val notRequiredSSOClient =
+            AzureADSSOClient("dev", "", "", "", "@not.required.sso.domain", required = false)
+
+        private val ssoConfig =
+            AzureADSSOConfig(listOf(requiredSSOClient, notRequiredSSOClient))
+        private val authenticator: Authenticator = object : Authenticator() {
+            override fun getPasswordAuthentication(): PasswordAuthentication {
+                return PasswordAuthentication("", "")
+            }
+        }
+        private val emailConfig = EmailConfig(Properties(), authenticator, "", "", "", "")
+        private val userLookupService = mockk<UserLookupService>()
+        private val userService = mockk<UserService>()
+        private val groupService = mockk<GroupService>()
+        private val emailService = mockk<EmailService>()
+        private val setPasswordTokenService = mockk<SetPasswordTokenService>()
+
+        private val user = slot<UserService.ADUser>()
+
+        private val client = testServiceClient()
+        private val adminUser = testLdapUser(cn = "admin", memberOfCNs = listOf("datamart-delta-admin"))
+        private val regularUser = testLdapUser(cn = "user", memberOfCNs = emptyList())
+
+        private val adminSession = OAuthSession(1, adminUser.cn, client, "adminAccessToken", Instant.now(), "trace")
+        private val userSession = OAuthSession(1, regularUser.cn, client, "userAccessToken", Instant.now(), "trace")
+
+        private fun getUserDetailsJsonString(email: String): String {
+            return "{\"id\":\"\"," +
+                    "\"enabled\":false," +
+                    "\"email\":\"$email\"," +
+                    "\"lastName\":\"testLast\"," +
+                    "\"firstName\":\"testFirst\"," +
+                    "\"telephone\":\"0123456789\"," +
+                    "\"mobile\":\"0987654321\"," +
+                    "\"position\":\"test position\"," +
+                    "\"accessGroups\":[\"datamart-delta-access-group-2\",\"datamart-delta-access-group-1\"]," +
+                    "\"accessGroupDelegates\":[\"datamart-delta-access-group-2\"]," +
+                    "\"accessGroupOrganisations\":{\"datamart-delta-access-group-2\":[\"orgCode1\", \"orgCode2\"]}," +
+                    "\"roles\":[\"datamart-delta-role-1\",\"datamart-delta-role-2\"]," +
+                    "\"externalRoles\":[]," +
+                    "\"organisations\":[\"orgCode1\", \"orgCode2\"]," +
+                    "\"comment\":\"test comment\"}"
+        }
+
+//        {"id":"","enabled":false,"email":"test65@test610.com","lastName":"test dt610","firstName":"phoebe","telephone":"4564563","mobile":"2452345","position":"","accessGroups":["datamart-delta-abcdef","datamart-delta-aga-test-grant"],"accessGroupDelegates":["datamart-delta-abcdef","datamart-delta-aga-test-grant"],"accessGroupOrganisations":{"datamart-delta-abcdef":["pw-org-36616"]},"roles":["datamart-delta-setup-managers"],"externalRoles":[],"organisations":["pw-org-36616"],"comment":""}
+
+        private fun getDeltaUserDetails(email: String): UserService.DeltaUserDetails {
+            return UserService.DeltaUserDetails(
+                "",
+                false,
+                email,
+                "testLast",
+                "testFirst",
+                "0123456789",
+                "0987654321",
+                "test position",
+                null,
+                arrayOf("datamart-delta-access-group-2", "datamart-delta-access-group-1"),
+                arrayOf("datamart-delta-access-group-2"),
+                mapOf("datamart-delta-access-group-2" to arrayOf("orgCode1", "orgCode2")),
+                arrayOf("datamart-delta-role-1", "datamart-delta-role-2"),
+                emptyArray(),
+                arrayOf("orgCode1", "orgCode2"),
+                "test comment",
+                null
+            )
+        }
+
+        private fun verifyCorrectGroupsAdded() {
+            coVerify(exactly = 1) { groupService.addUserToGroup(any(), "datamart-delta-user", any(), adminSession) }
+            coVerify(exactly = 1) {
+                groupService.addUserToGroup(any(), "datamart-delta-user-orgCode1", any(), adminSession)
+            }
+            coVerify(exactly = 1) {
+                groupService.addUserToGroup(any(), "datamart-delta-user-orgCode2", any(), adminSession)
+            }
+            coVerify(exactly = 1) {
+                groupService.addUserToGroup(any(), "datamart-delta-access-group-2", any(), adminSession)
+            }
+            coVerify(exactly = 1) {
+                groupService.addUserToGroup(any(), "datamart-delta-access-group-2-orgCode1", any(), adminSession)
+            }
+            coVerify(exactly = 1) {
+                groupService.addUserToGroup(any(), "datamart-delta-access-group-2-orgCode2", any(), adminSession)
+            }
+            coVerify(exactly = 1) {
+                groupService.addUserToGroup(any(), "datamart-delta-access-group-1", any(), adminSession)
+            }
+            coVerify(exactly = 1) {
+                groupService.addUserToGroup(any(), "datamart-delta-delegate-access-group-2", any(), adminSession)
+            }
+            coVerify(exactly = 1) { groupService.addUserToGroup(any(), "datamart-delta-role-2", any(), adminSession) }
+            coVerify(exactly = 1) {
+                groupService.addUserToGroup(any(), "datamart-delta-role-2-orgCode1", any(), adminSession)
+            }
+            coVerify(exactly = 1) {
+                groupService.addUserToGroup(any(), "datamart-delta-role-2-orgCode2", any(), adminSession)
+            }
+            coVerify(exactly = 1) { groupService.addUserToGroup(any(), "datamart-delta-role-1", any(), adminSession) }
+            coVerify(exactly = 1) {
+                groupService.addUserToGroup(any(), "datamart-delta-role-1-orgCode1", any(), adminSession)
+            }
+            coVerify(exactly = 1) {
+                groupService.addUserToGroup(any(), "datamart-delta-role-1-orgCode2", any(), adminSession)
+            }
+            coVerify(exactly = 14) { groupService.addUserToGroup(any(), any(), any(), any()) }
+        }
+
+        private fun assertCapturedUserIsAsExpected(
+            expectedUser: UserService.ADUser,
+            includePasswordInCheck: Boolean = true
+        ) {
+            if (includePasswordInCheck) assertTrue(EqualsBuilder.reflectionEquals(expectedUser, user.captured))
+            else assertTrue(EqualsBuilder.reflectionEquals(expectedUser, user.captured, "password"))
+            // If the above line is failing the below lines can be used to give a more comprehensible failure
+            // assertEquals(expectedUser.ldapConfig, user.captured.ldapConfig)
+            // assertEquals(expectedUser.cn, user.captured.cn)
+            // assertEquals(expectedUser.givenName, user.captured.givenName)
+            // assertEquals(expectedUser.sn, user.captured.sn)
+            // assertEquals(expectedUser.mail, user.captured.mail)
+            // assertEquals(expectedUser.userAccountControl, user.captured.userAccountControl)
+            // assertEquals(expectedUser.dn, user.captured.dn)
+            // assertEquals(expectedUser.userPrincipalName, user.captured.userPrincipalName)
+            // assertEquals(expectedUser.notificationStatus, user.captured.notificationStatus)
+            // if (includePasswordInCheck) assertEquals(expectedUser.password, user.captured.password)
+            // assertEquals(expectedUser.comment, user.captured.comment)
+            // assertEquals(expectedUser.telephone, user.captured.telephone)
+            // assertEquals(expectedUser.mobile, user.captured.mobile)
+            // assertEquals(expectedUser.reasonForAccess, user.captured.reasonForAccess)
+            // assertEquals(expectedUser.position, user.captured.position)
+            // assertEquals(expectedUser.objClasses, user.captured.objClasses)
+        }
+
+        private const val NEW_STANDARD_USER_EMAIL = "new.user@test.com"
+        private const val NEW_SSO_USER_EMAIL = "new.user@required.sso.domain"
+        private const val NEW_NOT_REQUIRED_SSO_USER = "new.user@not.required.sso.domain"
+        private const val OLD_STANDARD_USER_EMAIL = "old.user@test.com"
+        private const val OLD_SSO_USER_EMAIL = "old.user@required.sso.domain"
+        private const val OLD_NOT_REQUIRED_SSO_USER = "old.user@not.required.sso.domain"
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            controller = AdminUserCreationController(
+                ldapConfig,
+                deltaConfig,
+                ssoConfig,
+                emailConfig,
+                userLookupService,
+                userService,
+                groupService,
+                emailService,
+                setPasswordTokenService
+            )
+
+            testApp = TestApplication {
+                application {
+                    configureSerialization()
+                    authentication {
+                        bearer(OAUTH_ACCESS_BEARER_TOKEN_AUTH_NAME) {
+                            realm = "auth-service"
+                            authenticate { oauthSessionService.retrieveFomAuthToken(it.token, client) }
+                        }
+                        clientHeaderAuth(CLIENT_HEADER_AUTH_NAME) {
+                            headerName = "Delta-Client"
+                            clients = listOf(testServiceClient())
+                        }
+                    }
+                    routing {
+                        bearerTokenRoutes(
+                            mockk(relaxed = true),
+                            mockk(relaxed = true),
+                            mockk(relaxed = true),
+                            controller,
+                        )
+                    }
+                }
+            }
+
+            testClient = testApp.createClient {
+                followRedirects = false
+            }
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDown() {
+            testApp.stop()
+        }
+    }
+}

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminUserCreationControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminUserCreationControllerTest.kt
@@ -126,7 +126,7 @@ class AdminUserCreationControllerTest {
             verifyCorrectGroupsAdded()
             coVerify(exactly = 0) { emailService.sendSetPasswordEmail(any(), any(), any(), any(), any(), any()) }
             assertEquals(
-                "{\"message\":\"SSO user created, no email has been sent to the user since emails aren't sent to SSO users\"}",
+                "{\"message\":\"User created. Single Sign On (SSO) is enabled for this user based on their email domain. The account has been activated automatically, no email has been sent.\"}",
                 bodyAsText()
             )
         }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaUserRegistrationControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaUserRegistrationControllerTest.kt
@@ -50,17 +50,15 @@ class DeltaUserRegistrationControllerTest {
 
     @Test
     fun testRegistrationForNewStandardUser() = testSuspend {
-        coEvery { userAuditService.userSelfRegisterAudit(cnStart + standardDomain, any()) } returns Unit
         coEvery { userLookupService.userExists(cnStart + standardDomain) } returns false
         testClient.submitForm(
             url = "/register",
             formParameters = correctFormParameters(emailStart + standardDomain)
         ).apply {
-            coVerify(exactly = 1) { userService.createUser(any()) }
-            coVerify(exactly = 1) { userAuditService.userSelfRegisterAudit(cnStart + standardDomain, any()) }
-            coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaReportUsers) }
-            coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaUser) }
-            coVerify(exactly = 1) { groupService.addUserToGroup(any(), groupName(orgCode)) }
+            coVerify(exactly = 1) { userService.createUser(any(), null, null, any()) }
+            coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaReportUsers, any()) }
+            coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaUser, any()) }
+            coVerify(exactly = 1) { groupService.addUserToGroup(any(), groupName(orgCode), any()) }
             assertSuccessPageRedirect(status, headers, emailStart + standardDomain)
             coVerify(exactly = 1) {
                 emailService.sendSetPasswordEmail(
@@ -87,7 +85,7 @@ class DeltaUserRegistrationControllerTest {
                 append("confirmEmailAddress", "differentUser@example.com")
             }
         ).apply {
-            coVerify(exactly = 0) { userService.createUser(any()) }
+            coVerify(exactly = 0) { userService.createUser(any(), any(), any(), any()) }
             assertFormPage(bodyAsText(), status)
             assertContains(bodyAsText(), "Email addresses do not match")
         }
@@ -100,7 +98,7 @@ class DeltaUserRegistrationControllerTest {
             url = "/register",
             formParameters = correctFormParameters(emailStart + standardDomain)
         ).apply {
-            coVerify(exactly = 0) { userService.createUser(any()) }
+            coVerify(exactly = 0) { userService.createUser(any(), any(), any(), any()) }
             assertFormPage(bodyAsText(), status)
             assertContains(bodyAsText(), "Email address domain not recognised")
         }
@@ -113,7 +111,7 @@ class DeltaUserRegistrationControllerTest {
             url = "/register",
             formParameters = correctFormParameters("notAn@EmailStringcom")
         ).apply {
-            coVerify(exactly = 0) { userService.createUser(any()) }
+            coVerify(exactly = 0) { userService.createUser(any(), any(), any(), any()) }
             assertFormPage(bodyAsText(), status)
             assertContains(bodyAsText(), "Email address must be a valid email address")
         }
@@ -126,7 +124,7 @@ class DeltaUserRegistrationControllerTest {
             url = "/register",
             formParameters = correctFormParameters(emailStart + standardDomain)
         ).apply {
-            coVerify(exactly = 0) { userService.createUser(any()) }
+            coVerify(exactly = 0) { userService.createUser(any(), any(), any(), any()) }
             assertSuccessPageRedirect(status, headers, emailStart + standardDomain)
             coVerify(exactly = 1) { emailService.sendAlreadyAUserEmail(any(), any(), any()) }
         }
@@ -156,17 +154,15 @@ class DeltaUserRegistrationControllerTest {
 
     @Test
     fun testRegistrationOfNewNotRequiredSSOUser() = testSuspend {
-        coEvery { userAuditService.userSelfRegisterAudit(cnStart + notRequiredDomain, any()) } just runs
         coEvery { userLookupService.userExists(cnStart + notRequiredDomain) } returns false
         testClient.submitForm(
             url = "/register",
             formParameters = correctFormParameters(emailStart + notRequiredDomain)
         ).apply {
-            coVerify(exactly = 1) { userService.createUser(any()) }
-            coVerify(exactly = 1) { userAuditService.userSelfRegisterAudit(cnStart + notRequiredDomain, any()) }
-            coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaReportUsers) }
-            coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaUser) }
-            coVerify(exactly = 1) { groupService.addUserToGroup(any(), groupName(orgCode)) }
+            coVerify(exactly = 1) { userService.createUser(any(), null, null, any()) }
+            coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaReportUsers, any()) }
+            coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaUser, any()) }
+            coVerify(exactly = 1) { groupService.addUserToGroup(any(), groupName(orgCode), any()) }
             assertSuccessPageRedirect(status, headers, emailStart + notRequiredDomain)
             coVerify(exactly = 1) {
                 emailService.sendSetPasswordEmail(
@@ -188,7 +184,7 @@ class DeltaUserRegistrationControllerTest {
             url = "/register",
             formParameters = correctFormParameters(emailStart + notRequiredDomain)
         ).apply {
-            coVerify(exactly = 0) { userService.createUser(any()) }
+            coVerify(exactly = 0) { userService.createUser(any(), any(), any(), any()) }
             assertSuccessPageRedirect(status, headers, emailStart + notRequiredDomain)
             coVerify(exactly = 1) { emailService.sendAlreadyAUserEmail("Test", cnStart + notRequiredDomain, any()) }
         }
@@ -203,7 +199,7 @@ class DeltaUserRegistrationControllerTest {
             url = "/register",
             formParameters = correctFormParameters(emailStart + notRequiredDomain)
         ).apply {
-            coVerify(exactly = 0) { userService.createUser(any()) }
+            coVerify(exactly = 0) { userService.createUser(any(), any(), any(), any()) }
             coVerify(exactly = 0) { emailService.sendSetPasswordEmail(any(), any(), any(), any()) }
             assertFormPage(bodyAsText(), status)
             assertContains(bodyAsText(), "Email address domain not recognised")
@@ -247,8 +243,8 @@ class DeltaUserRegistrationControllerTest {
     fun resetMocks() {
         clearAllMocks()
         coEvery { organisationService.findAllByDomain(any()) } returns listOf(Organisation(orgCode, "Test org"))
-        coEvery { userService.createUser(any()) } just runs
-        coEvery { groupService.addUserToGroup(any(), any()) } just runs
+        coEvery { userService.createUser(any(), any(), any(), any()) } just runs
+        coEvery { groupService.addUserToGroup(any(), any(), any()) } just runs
         coEvery { setPasswordTokenService.createToken(any()) } returns "token"
         coEvery { emailService.sendAlreadyAUserEmail(any(), any(), any()) } just runs
         coEvery { emailService.sendSetPasswordEmail(any(), any(), any(), null, any(), any()) } just runs

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/FetchUserAuditControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/FetchUserAuditControllerTest.kt
@@ -18,6 +18,7 @@ import org.junit.BeforeClass
 import org.junit.Test
 import uk.gov.communities.delta.auth.bearerTokenRoutes
 import uk.gov.communities.delta.auth.controllers.internal.AdminEmailController
+import uk.gov.communities.delta.auth.controllers.internal.AdminUserCreationController
 import uk.gov.communities.delta.auth.controllers.internal.FetchUserAuditController
 import uk.gov.communities.delta.auth.controllers.internal.RefreshUserInfoController
 import uk.gov.communities.delta.auth.plugins.configureSerialization
@@ -196,7 +197,8 @@ class FetchUserAuditControllerTest {
                         bearerTokenRoutes(
                             mockk<RefreshUserInfoController>(relaxed = true),
                             mockk<AdminEmailController>(relaxed = true),
-                            controller
+                            controller,
+                            mockk<AdminUserCreationController>(relaxed = true),
                         )
                     }
                 }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/RefreshUserInfoControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/RefreshUserInfoControllerTest.kt
@@ -18,6 +18,7 @@ import org.junit.BeforeClass
 import org.junit.Test
 import uk.gov.communities.delta.auth.bearerTokenRoutes
 import uk.gov.communities.delta.auth.controllers.internal.AdminEmailController
+import uk.gov.communities.delta.auth.controllers.internal.AdminUserCreationController
 import uk.gov.communities.delta.auth.controllers.internal.FetchUserAuditController
 import uk.gov.communities.delta.auth.controllers.internal.RefreshUserInfoController
 import uk.gov.communities.delta.auth.plugins.configureSerialization
@@ -128,6 +129,7 @@ class RefreshUserInfoControllerTest {
                             controller,
                             adminEmailController,
                             mockk<FetchUserAuditController>(relaxed = true),
+                            mockk<AdminUserCreationController>(relaxed = true),
                         )
                     }
                 }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/RegistrationServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/RegistrationServiceTest.kt
@@ -1,10 +1,12 @@
 package uk.gov.communities.delta.security
 
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
 import io.ktor.test.dispatcher.*
 import io.mockk.*
 import org.junit.Before
 import org.junit.Test
-import uk.gov.communities.delta.auth.config.AuthServiceConfig
+import uk.gov.communities.delta.auth.config.AzureADSSOClient
 import uk.gov.communities.delta.auth.config.DeltaConfig
 import uk.gov.communities.delta.auth.config.EmailConfig
 import uk.gov.communities.delta.auth.config.LDAPConfig
@@ -13,12 +15,13 @@ import kotlin.test.assertTrue
 
 class RegistrationServiceTest {
     private val deltaConfig = DeltaConfig.fromEnv()
-    private val authServiceConfig = AuthServiceConfig("http://localhost", null)
     private val setPasswordTokenService = mockk<SetPasswordTokenService>()
     private val emailService = mockk<EmailService>()
     private val userService = mockk<UserService>()
     private val userLookupService = mockk<UserLookupService>()
     private val groupService = mockk<GroupService>()
+    private val call = mockk<ApplicationCall>()
+    private val ssoClient = mockk<AzureADSSOClient>()
     private val orgCode = "E12345"
     private val userCN = "user!example.com"
     private val anotherOrgCode = orgCode + "2"
@@ -38,9 +41,10 @@ class RegistrationServiceTest {
     @Before
     fun setup() {
         coEvery { userLookupService.userExists(any()) } returns false
-        coEvery { groupService.addUserToGroup(any(), any()) } just runs
-        coEvery { userService.createUser(any()) } just runs
+        coEvery { groupService.addUserToGroup(any(), any(), any()) } just runs
+        coEvery { userService.createUser(any(), any(), any(), any()) } just runs
         coEvery { setPasswordTokenService.createToken(any()) } returns "token"
+        coEvery { call.principal<OAuthSession>() } returns null
     }
 
     @Test
@@ -48,12 +52,13 @@ class RegistrationServiceTest {
         val registrationResult = registrationService.register(
             Registration("Test", "User", "user@example.com"),
             listOf(Organisation(orgCode, "Test org")),
+            call,
         )
-        coVerify(exactly = 1) { userService.createUser(any()) }
-        coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaReportUsers) }
-        coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaUser) }
-        coVerify(exactly = 1) { groupService.addUserToGroup(any(), groupName(orgCode)) }
-        coVerify(exactly = 3) { groupService.addUserToGroup(any(), any()) }
+        coVerify(exactly = 1) { userService.createUser(any(), null, null, call) }
+        coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaReportUsers, any()) }
+        coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaUser, any()) }
+        coVerify(exactly = 1) { groupService.addUserToGroup(any(), groupName(orgCode), any()) }
+        coVerify(exactly = 3) { groupService.addUserToGroup(any(), any(), any()) }
         coVerify(exactly = 1) { setPasswordTokenService.createToken(any()) }
         assertTrue(registrationResult is RegistrationService.UserCreated)
     }
@@ -63,13 +68,14 @@ class RegistrationServiceTest {
         val registrationResult = registrationService.register(
             Registration("Test", "User", "user@example.com"),
             listOf(Organisation(orgCode, "Test org")),
-            true
+            call,
+            ssoClient
         )
-        coVerify(exactly = 1) { userService.createUser(any()) }
-        coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaReportUsers) }
-        coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaUser) }
-        coVerify(exactly = 1) { groupService.addUserToGroup(any(), groupName(orgCode)) }
-        coVerify(exactly = 3) { groupService.addUserToGroup(any(), any()) }
+        coVerify(exactly = 1) { userService.createUser(any(), ssoClient, null, call) }
+        coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaReportUsers, any()) }
+        coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaUser, any()) }
+        coVerify(exactly = 1) { groupService.addUserToGroup(any(), groupName(orgCode), any()) }
+        coVerify(exactly = 3) { groupService.addUserToGroup(any(), any(), any()) }
         coVerify(exactly = 0) { setPasswordTokenService.createToken(any()) }
         assertTrue(registrationResult is RegistrationService.SSOUserCreated)
     }
@@ -80,11 +86,12 @@ class RegistrationServiceTest {
         val registrationResult = registrationService.register(
             Registration("Test", "User", "user@example.com"),
             listOf(Organisation(orgCode, "Test org")),
-            true
+            call,
+            ssoClient
         )
         assertTrue(registrationResult is RegistrationService.UserAlreadyExists)
-        coVerify(exactly = 0) { userService.createUser(any()) }
-        coVerify(exactly = 0) { groupService.addUserToGroup(any(), any()) }
+        coVerify(exactly = 0) { userService.createUser(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { groupService.addUserToGroup(any(), any(), any()) }
         coVerify(exactly = 0) { setPasswordTokenService.createToken(any()) }
     }
 
@@ -93,13 +100,14 @@ class RegistrationServiceTest {
         val registrationResult = registrationService.register(
             Registration("Test", "User", "user@example.com"),
             listOf(Organisation(orgCode, "Test org"), Organisation(anotherOrgCode, name = "Another org")),
+            call,
         )
-        coVerify(exactly = 1) { userService.createUser(any()) }
-        coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaReportUsers) }
-        coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaUser) }
-        coVerify(exactly = 1) { groupService.addUserToGroup(any(), groupName(orgCode)) }
-        coVerify(exactly = 1) { groupService.addUserToGroup(any(), groupName(anotherOrgCode)) }
-        coVerify(exactly = 4) { groupService.addUserToGroup(any(), any()) }
+        coVerify(exactly = 1) { userService.createUser(any(), null, null, call) }
+        coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaReportUsers, any()) }
+        coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaUser, any()) }
+        coVerify(exactly = 1) { groupService.addUserToGroup(any(), groupName(orgCode), any()) }
+        coVerify(exactly = 1) { groupService.addUserToGroup(any(), groupName(anotherOrgCode), any()) }
+        coVerify(exactly = 4) { groupService.addUserToGroup(any(), any(), any()) }
         coVerify(exactly = 1) { setPasswordTokenService.createToken(any()) }
         assertTrue(registrationResult is RegistrationService.UserCreated)
     }
@@ -109,13 +117,14 @@ class RegistrationServiceTest {
         val registrationResult = registrationService.register(
             Registration("Test", "User", "user@example.com"),
             listOf(retiredOrganisation, Organisation(anotherOrgCode, name = "Another org")),
+            call,
         )
-        coVerify(exactly = 1) { userService.createUser(any()) }
-        coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaReportUsers) }
-        coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaUser) }
-        coVerify(exactly = 0) { groupService.addUserToGroup(any(), groupName(orgCode)) }
-        coVerify(exactly = 1) { groupService.addUserToGroup(any(), groupName(anotherOrgCode)) }
-        coVerify(exactly = 3) { groupService.addUserToGroup(any(), any()) }
+        coVerify(exactly = 1) { userService.createUser(any(), null, null, call) }
+        coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaReportUsers, any()) }
+        coVerify(exactly = 1) { groupService.addUserToGroup(any(), deltaConfig.datamartDeltaUser, any()) }
+        coVerify(exactly = 0) { groupService.addUserToGroup(any(), groupName(orgCode), any()) }
+        coVerify(exactly = 1) { groupService.addUserToGroup(any(), groupName(anotherOrgCode), any()) }
+        coVerify(exactly = 3) { groupService.addUserToGroup(any(), any(), any()) }
         coVerify(exactly = 1) { setPasswordTokenService.createToken(any()) }
         assertTrue(registrationResult is RegistrationService.UserCreated)
     }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/UserServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/UserServiceTest.kt
@@ -4,6 +4,9 @@ import io.ktor.server.application.*
 import io.ktor.test.dispatcher.*
 import io.mockk.*
 import kotlinx.coroutines.runBlocking
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.not
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -12,10 +15,12 @@ import uk.gov.communities.delta.auth.config.LDAPConfig
 import uk.gov.communities.delta.auth.controllers.external.ResetPasswordException
 import uk.gov.communities.delta.auth.services.*
 import uk.gov.communities.delta.helper.testLdapUser
+import java.time.Instant
 import javax.naming.directory.Attributes
 import javax.naming.directory.DirContext
 import javax.naming.directory.ModificationItem
 import javax.naming.ldap.InitialLdapContext
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
 class UserServiceTest {
@@ -34,40 +39,214 @@ class UserServiceTest {
     private val userCN = LDAPConfig.emailToCN(userEmail)
     private val userDN = String.format(deltaUserDnFormat, userCN)
     private val call = mockk<ApplicationCall>()
-    private val ssoClient = mockk<AzureADSSOClient>()
+    private val requiredSSOClient = mockk<AzureADSSOClient>()
+    private val notRequiredSSOClient = mockk<AzureADSSOClient>()
+    private val auditData = slot<String>()
+    private val adminSession =
+        OAuthSession(1, "adminUserCN", mockk(relaxed = true), "adminAccessToken", Instant.now(), "trace")
 
     @Before
     fun setupMocks() {
         modificationItems.clear()
+        container.clear()
         contextBlock.clear()
+        auditData.clear()
         coEvery { ldapServiceUserBind.useServiceUserBind(capture(contextBlock)) } coAnswers {
             contextBlock.captured(context)
         }
         coEvery { context.createSubcontext(userDN, capture(container)) } coAnswers { nothing }
         coEvery { context.modifyAttributes(userDN, capture(modificationItems)) } coAnswers { nothing }
-        coEvery { userAuditService.userCreatedBySSOAudit(any(), call, any()) } coAnswers { nothing }
-        coEvery { userAuditService.userSelfRegisterAudit(any(), call, any()) } just runs
-        coEvery { ssoClient.internalId } returns "abc-123"
+        coEvery { requiredSSOClient.internalId } returns "abc-123"
+        coEvery { requiredSSOClient.required } returns true
+        coEvery { notRequiredSSOClient.internalId } returns "xyz-987"
+        coEvery { notRequiredSSOClient.required } returns false
+        coEvery { userAuditService.userSelfRegisterAudit(userCN, call, capture(auditData)) } just runs
+        coEvery { userAuditService.userCreatedBySSOAudit(userCN, call, capture(auditData)) } just runs
+        coEvery {
+            userAuditService.ssoUserCreatedByAdminAudit(
+                userCN,
+                adminSession.userCn,
+                call,
+                capture(auditData)
+            )
+        } just runs
+        coEvery {
+            userAuditService.userCreatedByAdminAudit(
+                userCN,
+                adminSession.userCn,
+                call,
+                capture(auditData)
+            )
+        } just runs
     }
 
     @Test
-    fun testSuccessfulCreateStandardUser() = testSuspend {
+    fun testCreateStandardUser() = testSuspend {
         userService.createUser(UserService.ADUser(ldapConfig, registration, null), null, null, call)
         verify(exactly = 1) { context.createSubcontext(userDN, any()) }
         // User has normal and disabled account
         assertEquals<String>("514", container.captured.get("userAccountControl").get() as String)
         // User has no password set yet
         assert(container.captured.get("unicodePwd") == null)
+        assertContains(auditData.captured, "\"givenName\":\"${registration.firstName}\"")
+        assertContains(auditData.captured, "\"sn\":\"${registration.lastName}\"")
+        assertContains(auditData.captured, "\"mail\":\"${registration.emailAddress}\"")
+        assertThat(auditData.captured, not(containsString("\"ssoClientInternalId\"")))
+        assertThat(auditData.captured, not(containsString("\"azureObjectId\"")))
     }
 
     @Test
-    fun testSuccessfulCreateSSOUser() = testSuspend {
-        userService.createUser(UserService.ADUser(ldapConfig, registration, ssoClient), ssoClient, null, call)
+    fun testCreateStandardUserWithAllDetails() = testSuspend {
+        val userDetails = UserService.DeltaUserDetails(
+            "",
+            false,
+            userEmail,
+            "testLast",
+            "testFirst",
+            "0123456789",
+            "0987654321",
+            "test position",
+            null,
+            arrayOf("datamart-delta-access-group-2", "datamart-delta-access-group-1"),
+            arrayOf("datamart-delta-access-group-2"),
+            mapOf("datamart-delta-access-group-2" to arrayOf("orgCode1", "orgCode2")),
+            arrayOf("datamart-delta-role-1", "datamart-delta-role-2"),
+            emptyArray(),
+            arrayOf("orgCode1", "orgCode2"),
+            "test comment",
+            null
+        )
+        userService.createUser(UserService.ADUser(ldapConfig, userDetails, null), null, null, call)
+        verify(exactly = 1) { context.createSubcontext(userDN, any()) }
+        // User has normal and disabled account
+        assertEquals<String>("514", container.captured.get("userAccountControl").get() as String)
+        // User has no password set yet
+        assert(container.captured.get("unicodePwd") == null)
+        assertContains(auditData.captured, "\"givenName\":\"${userDetails.firstName}\"")
+        assertContains(auditData.captured, "\"sn\":\"${userDetails.lastName}\"")
+        assertContains(auditData.captured, "\"mail\":\"${userDetails.email}\"")
+        assertContains(auditData.captured, "\"title\":\"${userDetails.position}\"")
+        assertThat(auditData.captured, not(containsString("\"ssoClientInternalId\"")))
+        assertThat(auditData.captured, not(containsString("\"azureObjectId\"")))
+        // Check that reasonForAccess is not audited (blank in input data)
+        assertThat(auditData.captured, not(containsString("description")))
+    }
+
+    @Test
+    fun testAdminCreateStandardUser() = testSuspend {
+        userService.createUser(UserService.ADUser(ldapConfig, registration, null), null, adminSession, call)
+        verify(exactly = 1) { context.createSubcontext(userDN, any()) }
+        // User has normal and disabled account
+        assertEquals<String>("514", container.captured.get("userAccountControl").get() as String)
+        // User has no password set yet
+        assert(container.captured.get("unicodePwd") == null)
+        assertContains(auditData.captured, "\"givenName\":\"${registration.firstName}\"")
+        assertContains(auditData.captured, "\"sn\":\"${registration.lastName}\"")
+        assertContains(auditData.captured, "\"mail\":\"${registration.emailAddress}\"")
+        assertThat(auditData.captured, not(containsString("\"ssoClientInternalId\"")))
+        assertThat(auditData.captured, not(containsString("\"azureObjectId\"")))
+    }
+
+    @Test
+    fun testCreateSSOUser() = testSuspend {
+        userService.createUser(
+            UserService.ADUser(ldapConfig, registration, requiredSSOClient),
+            requiredSSOClient,
+            null,
+            call
+        )
         verify(exactly = 1) { context.createSubcontext(userDN, any()) }
         // User has normal and enabled account
         assertEquals<String>("512", container.captured.get("userAccountControl").get() as String)
         // User has had a password set at account creation
         assert(container.captured.get("unicodePwd").get() as ByteArray? != null)
+        assertContains(auditData.captured, "\"givenName\":\"${registration.firstName}\"")
+        assertContains(auditData.captured, "\"sn\":\"${registration.lastName}\"")
+        assertContains(auditData.captured, "\"mail\":\"${registration.emailAddress}\"")
+        assertContains(auditData.captured, "\"ssoClientInternalId\":\"${requiredSSOClient.internalId}\"")
+        assertThat(auditData.captured, not(containsString("\"azureObjectId\"")))
+    }
+
+    @Test
+    fun testAdminCreateSSOUser() = testSuspend {
+        userService.createUser(
+            UserService.ADUser(ldapConfig, registration, requiredSSOClient),
+            requiredSSOClient,
+            adminSession,
+            call
+        )
+        verify(exactly = 1) { context.createSubcontext(userDN, any()) }
+        // User has normal and enabled account
+        assertEquals<String>("512", container.captured.get("userAccountControl").get() as String)
+        // User has had a password set at account creation
+        assert(container.captured.get("unicodePwd").get() as ByteArray? != null)
+        assertContains(auditData.captured, "\"givenName\":\"${registration.firstName}\"")
+        assertContains(auditData.captured, "\"sn\":\"${registration.lastName}\"")
+        assertContains(auditData.captured, "\"mail\":\"${registration.emailAddress}\"")
+        assertContains(auditData.captured, "\"ssoClientInternalId\":\"${requiredSSOClient.internalId}\"")
+        assertThat(auditData.captured, not(containsString("\"azureObjectId\"")))
+    }
+
+    @Test
+    fun testAdminCreateSSOUserWithAzureObjectID() = testSuspend {
+        val azureObjectId = "azureObjectId"
+        userService.createUser(
+            UserService.ADUser(ldapConfig, registration, requiredSSOClient),
+            requiredSSOClient,
+            adminSession,
+            call,
+            azureObjectId
+        )
+        verify(exactly = 1) { context.createSubcontext(userDN, any()) }
+        // User has normal and enabled account
+        assertEquals<String>("512", container.captured.get("userAccountControl").get() as String)
+        // User has had a password set at account creation
+        assert(container.captured.get("unicodePwd").get() as ByteArray? != null)
+        assertContains(auditData.captured, "\"givenName\":\"${registration.firstName}\"")
+        assertContains(auditData.captured, "\"sn\":\"${registration.lastName}\"")
+        assertContains(auditData.captured, "\"mail\":\"${registration.emailAddress}\"")
+        assertContains(auditData.captured, "\"ssoClientInternalId\":\"${requiredSSOClient.internalId}\"")
+        assertContains(auditData.captured, "\"azureObjectId\":\"${azureObjectId}\"")
+    }
+
+    @Test
+    fun testCreateNotRequiredSSOUser() = testSuspend {
+        userService.createUser(
+            UserService.ADUser(ldapConfig, registration, notRequiredSSOClient),
+            notRequiredSSOClient,
+            null,
+            call
+        )
+        verify(exactly = 1) { context.createSubcontext(userDN, any()) }
+        // User has normal and disabled account
+        assertEquals<String>("514", container.captured.get("userAccountControl").get() as String)
+        // User has no password set yet
+        assert(container.captured.get("unicodePwd") == null)
+        assertContains(auditData.captured, "\"givenName\":\"${registration.firstName}\"")
+        assertContains(auditData.captured, "\"sn\":\"${registration.lastName}\"")
+        assertContains(auditData.captured, "\"mail\":\"${registration.emailAddress}\"")
+        assertThat(auditData.captured, not(containsString("\"ssoClientInternalId\"")))
+        assertThat(auditData.captured, not(containsString("\"azureObjectId\"")))
+    }
+
+    @Test
+    fun testAdminCreateNotRequiredSSOUser() = testSuspend {
+        userService.createUser(
+            UserService.ADUser(ldapConfig, registration, notRequiredSSOClient),
+            notRequiredSSOClient,
+            adminSession,
+            call
+        )
+        verify(exactly = 1) { context.createSubcontext(userDN, any()) }
+        // User has normal and disabled account
+        assertEquals<String>("514", container.captured.get("userAccountControl").get() as String)
+        // User has no password set yet
+        assert(container.captured.get("unicodePwd") == null)
+        assertContains(auditData.captured, "\"givenName\":\"${registration.firstName}\"")
+        assertContains(auditData.captured, "\"sn\":\"${registration.lastName}\"")
+        assertContains(auditData.captured, "\"mail\":\"${registration.emailAddress}\"")
+        assertThat(auditData.captured, not(containsString("\"ssoClientInternalId\"")))
+        assertThat(auditData.captured, not(containsString("\"azureObjectId\"")))
     }
 
     @Test
@@ -107,7 +286,7 @@ class UserServiceTest {
 
     @Test
     fun testPasswordCreation() = testSuspend {
-        val adUser = UserService.ADUser(ldapConfig, registration, ssoClient)
+        val adUser = UserService.ADUser(ldapConfig, registration, requiredSSOClient)
         assertEquals(18 * 8 / 6, adUser.password!!.length)
     }
 }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/service/EmailServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/service/EmailServiceTest.kt
@@ -79,7 +79,7 @@ class EmailServiceTest {
                 emailRepository.sendEmail("new-user", any(), any(), any())
             }
             coVerify(exactly = 1) {
-                userAuditService.adminResendActivationEmailAudit(
+                userAuditService.adminSetPasswordEmailAudit(
                     testLdapUser().cn,
                     "adminUserCn",
                     any()
@@ -154,7 +154,7 @@ class EmailServiceTest {
         every { emailRepository.sendEmail(any(), any(), any(), any()) } just runs
         coEvery { userAuditService.setPasswordEmailAudit(any(), any()) } just runs
         coEvery { userAuditService.resetPasswordEmailAudit(any(), any()) } just runs
-        coEvery { userAuditService.adminResendActivationEmailAudit(any(), any(), any()) } just runs
+        coEvery { userAuditService.adminSetPasswordEmailAudit(any(), any(), any()) } just runs
         coEvery { userAuditService.adminResetPasswordEmailAudit(any(), any(), any()) } just runs
     }
 }


### PR DESCRIPTION
Pull request 2 of 3 for this ticket 🤞 
From HLD: 
2. Create User:
- Create endpoint in auth service and send request to it upon clicking "Save" button
- Authenticate user triggering the request as above
- Create user as with registration (with more fields)
- Add audit logs
- Send activation email to relevant user (and audit log this)
- Handle errors or success and communicate those back to delta

Delta passes the already validated user details to the auth service. Auth service then validates the request (but not the data) and makes the request(s) to AD to make the user. Auth service audits this user creation. Auth service sends activation email to user (thus delta will no longer send any activation emails). Auth service responds to Delta or sends a (hopefully better than before) error message which delta displays. Delta repo PR to come soon.

Testing: I have testing this lots locally (using test ad) and have added tests to the code as well
Risks: There are a few nichenesses to the delta code and places where it handles data that in all my tests have been blank (e.g. external roles) - I have investigated any of these that I have found and believe they are not relevant but it is possible I missed something, in this case I think the outcome would be that a user would be unable to do something they expected to at which point they would hopefully raise a support ticket allowing us to know about the issue, fix it (manually or not) and correct the code -> only a very small risk of major impact
Documentation: Ticket and this PR (and eventually the delta PR), if there is any other place I should document this please let me know!)