### PR TITLE
Allow empty password for SSO users

### DIFF
--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaLoginControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaLoginControllerTest.kt
@@ -203,7 +203,6 @@ class DeltaLoginControllerTest {
             url = "/login?response_type=code&client_id=delta-website&state=1234",
             formParameters = parameters {
                 append("username", testUserEmail)
-                append("password", "pass")
             }
         ).apply {
             assertEquals(HttpStatusCode.Found, status)


### PR DESCRIPTION
Mostly useful on staging since there's no button for the Softwire SSO.