### PR TITLE
DT-585: use the full postgres CA cert bundle, not just one

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_ci }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_key_ci }}
       AWS_REGION: "eu-west-1"
-      VERSION: "0.6.7"
+      VERSION: "0.6.8"
       REPOSITORY: "delta-auth-service"
       ECR_PATH: "468442790030.dkr.ecr.eu-west-1.amazonaws.com"
     outputs:

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -15,9 +15,7 @@ WORKDIR /app
 RUN yum install wget openssl -y
 
 RUN mkdir -p /root/.postgresql && \
-    wget https://truststore.pki.rds.amazonaws.com/eu-west-1/eu-west-1-bundle.pem -O /tmp/rds.pem && \
-    openssl x509 -outform der -in /tmp/rds.pem -out /root/.postgresql/root.crt && \
-    rm /tmp/rds.pem
+    wget https://truststore.pki.rds.amazonaws.com/eu-west-1/eu-west-1-bundle.pem -O /root/.postgresql/ca-bundle.pem
 
 COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh

--- a/terraform/modules/auth_service/main.tf
+++ b/terraform/modules/auth_service/main.tf
@@ -71,7 +71,7 @@ module "fargate" {
     },
     {
       name  = "DATABASE_URL"
-      value = "jdbc:postgresql://${aws_db_instance.auth_service.endpoint}/auth_service?ssl=true&sslmode=verify-full"
+      value = "jdbc:postgresql://${aws_db_instance.auth_service.endpoint}/auth_service?ssl=true&sslmode=verify-full&sslrootcert=/root/.postgresql/ca-bundle.pem"
     },
     {
       name  = "DATABASE_USER"


### PR DESCRIPTION
`openssl x509` only uses the first cert in the file. 

I've manually deployed to test and updated the test SQL cert. Works fine. I wanted to do it with an env var defined in the Dockerfile originally (so that the path is only referenced in one place) but that didn't seem to have any effect.

Will do the same for keycloak in the delta repo.