### PR TITLE
Remove extra error handling on password reset

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaResetPasswordController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaResetPasswordController.kt
@@ -126,14 +126,8 @@ class DeltaResetPasswordController(
                 logger.atInfo().addKeyValue("userCN", tokenResult.userCN)
                     .log("Reset password form submitted with valid token")
                 val userDN = String.format(ldapConfig.deltaUserDnFormat, tokenResult.userCN)
-                try {
-                    userService.resetPassword(userDN, newPassword)
-                    logger.atInfo().addKeyValue("userCN", tokenResult.userCN).log("Password reset")
-                } catch (e: Exception) {
-                    logger.atError().addKeyValue("UserDN", userDN).addKeyValue("userCN", tokenResult.userCN)
-                        .log("Error resetting password for user", e)
-                    throw e
-                }
+                userService.resetPassword(userDN, newPassword)
+                logger.atInfo().addKeyValue("userCN", tokenResult.userCN).log("Password reset")
                 userAuditService.resetPasswordAudit(userCN, call)
                 call.respondRedirect("/delta/reset-password/success")
             }


### PR DESCRIPTION
Tiny change.

`UserService::resetPassword` already has some error handling built in. Logging and rethrowing doesn't add much here and was adding noise to error logs for expected issues like disabled users that are already correctly logged at warn level.