### PR TITLE
DT-277 Map of old to new user objectGUIDs as table

### DIFF
--- a/auth-service/build.gradle.kts
+++ b/auth-service/build.gradle.kts
@@ -85,7 +85,7 @@ dependencies {
 // Migrations are run by the application on startup, or on first use of the database in Development mode.
 // Extra task to run Flyway migrations without (re)starting the app.
 task("migrate", JavaExec::class) {
-    mainClass.set("uk.gov.communities.delta.auth.services.DbPoolKt")
+    mainClass.set("uk.gov.communities.delta.auth.repositories.DbPoolKt")
     classpath = sourceSets["main"].runtimeClasspath
 }
 

--- a/auth-service/entrypoint.sh
+++ b/auth-service/entrypoint.sh
@@ -7,18 +7,18 @@ function echo_json() {
 
 echo_json "Entrypoint script starting"
 
-if [ -v RUN_TASK ]; then
-    echo_json "RUN_TASK is set, starting task ${RUN_TASK}"
-    java -cp auth-all.jar uk.gov.communities.delta.auth.tasks.RunTaskMainKt
-    echo_json "Task complete, exiting"
-    exit 0
-fi
-
 if [[ -v CA_S3_URL ]]; then
   echo_json "Fetching CA Certificate from ${CA_S3_URL}"
   wget -q "${CA_S3_URL}" -O /tmp/dluhcldapsca.crt
   openssl x509 -inform der -in /tmp/dluhcldapsca.crt -outform pem -out /tmp/dluhcldapsca.pem
   keytool -import -cacerts -alias dluhcldapsca -file /tmp/dluhcldapsca.pem -noprompt -storepass changeit
+fi
+
+if [ -v RUN_TASK ]; then
+    echo_json "RUN_TASK is set, starting task ${RUN_TASK}"
+    java -cp auth-all.jar uk.gov.communities.delta.auth.tasks.RunTaskMainKt
+    echo_json "Task complete, exiting"
+    exit 0
 fi
 
 echo_json "Starting application"

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/tasks/TaskRunner.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/tasks/TaskRunner.kt
@@ -42,8 +42,10 @@ class TaskRunner(private val meterRegistry: MeterRegistry) {
 
         try {
             logger.info("Starting task")
+            val startTime = System.currentTimeMillis()
             task.execute()
-            logger.info("Task complete")
+            val durationMs = System.currentTimeMillis() - startTime
+            logger.atInfo().addKeyValue("durationMs", durationMs).log("Task complete")
             allTasksSuccessCounter.increment()
             taskSpecificSuccessCounter.increment()
         } catch (e: Exception) {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/tasks/UpdateUserGUIDMap.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/tasks/UpdateUserGUIDMap.kt
@@ -1,0 +1,126 @@
+package uk.gov.communities.delta.auth.tasks
+
+import org.jetbrains.annotations.Blocking
+import org.slf4j.LoggerFactory
+import uk.gov.communities.delta.auth.config.LDAPConfig
+import uk.gov.communities.delta.auth.repositories.*
+import java.sql.Connection
+import javax.naming.directory.SearchControls
+import kotlin.time.Duration.Companion.minutes
+
+/*
+ * Update the user_guid_map database table by reading all users from Active Directory in both old and new GUID mode
+ */
+class UpdateUserGUIDMap(
+    private val ldapConfig: LDAPConfig,
+    private val dbPool: DbPool,
+) : AuthServiceTask("UpdateUserGUIDMap") {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    private val searchDn = ldapConfig.deltaUserDnFormat.removePrefix("CN=%s,")
+
+    // Tasks are run separately anyway
+    @Suppress("BlockingMethodInNonBlockingContext")
+    override suspend fun execute() {
+        logger.info("Starting UpdateUserGUIDMap")
+        val oldUserGuids = fetchOldModeUserGuids()
+        logger.info("Read {} users in old mode from AD", oldUserGuids.size)
+        val newUserGuids = fetchNewModeUserGuids()
+        logger.info("Read {} users in new mode from AD", newUserGuids.size)
+
+        val newGuidsMap = newUserGuids.associateBy { it.cn }.mapValues { it.value.guid }
+        val guidMapRows = oldUserGuids.map {
+            UserGuidMapTableRow(
+                it.cn,
+                oldGuid = it.guid,
+                newGuid = newGuidsMap.getOrElse(
+                    it.cn
+                ) { throw RuntimeException("No new GUID found for user " + it.cn) }
+            )
+        }
+        logger.info("All users loaded")
+
+        dbPool.connection().use { conn ->
+            val truncate = conn.prepareStatement("TRUNCATE TABLE user_guid_map")
+            truncate.execute()
+            truncate.close()
+
+            conn.batchInsert(guidMapRows)
+
+            conn.commit()
+        }
+        logger.info("All rows inserted, done")
+    }
+
+    @Blocking
+    private fun fetchOldModeUserGuids(): List<UserGuid> {
+        val oldModeLdapRepository = LdapRepository(ldapConfig, LdapRepository.ObjectGUIDMode.OLD_MANGLED)
+        val ctx = oldModeLdapRepository.bind(
+            ldapConfig.authServiceUserDn,
+            ldapConfig.authServiceUserPassword,
+        )
+        val users = ctx.searchPaged(
+            searchDn,
+            "(objectClass=user)",
+            ldapSearchControls(),
+            pageSize = 200,
+        ) {
+            val cn = it.get("cn").get() as String
+            val mangledObjectGuid = it.getMangledDeltaObjectGUID()
+            UserGuid(cn, mangledObjectGuid)
+        }
+        ctx.close()
+        return users
+    }
+
+    @Blocking
+    private fun fetchNewModeUserGuids(): List<UserGuid> {
+        val oldModeLdapRepository = LdapRepository(ldapConfig, LdapRepository.ObjectGUIDMode.NEW_JAVA_UUID_STRING)
+        val ctx = oldModeLdapRepository.bind(
+            ldapConfig.authServiceUserDn,
+            ldapConfig.authServiceUserPassword,
+        )
+        val searchDn = ldapConfig.deltaUserDnFormat.removePrefix("CN=%s,")
+        val users = ctx.searchPaged(
+            searchDn,
+            "(objectClass=user)",
+            ldapSearchControls(),
+            pageSize = 200,
+        ) {
+            val cn = it.get("cn").get() as String
+            val objectGuid = it.getNewModeObjectGuid().toString()
+            UserGuid(cn, objectGuid)
+        }
+        ctx.close()
+        return users
+    }
+
+    private fun ldapSearchControls(): SearchControls {
+        val searchControls = SearchControls()
+        searchControls.searchScope = SearchControls.ONELEVEL_SCOPE
+        searchControls.timeLimit = 2.minutes.inWholeMilliseconds.toInt()
+        searchControls.returningAttributes = arrayOf("cn", "objectGUID", "imported-guid")
+        return searchControls
+    }
+
+    @Blocking
+    private fun Connection.batchInsert(rows: List<UserGuidMapTableRow>) {
+        for (usersBatch in rows.chunked(100)) {
+            logger.debug("Inserting batch of {}", usersBatch.size)
+            val ps = prepareStatement("INSERT INTO user_guid_map (cn, oldguid, newguid) VALUES (?, ?, ?::UUID)")
+
+            for (user in usersBatch) {
+                ps.setString(1, user.cn)
+                ps.setString(2, user.oldGuid)
+                ps.setString(3, user.newGuid)
+                ps.addBatch()
+                ps.clearParameters()
+            }
+            ps.executeBatch()
+            ps.close()
+        }
+    }
+
+    private data class UserGuid(val cn: String, val guid: String)
+    private data class UserGuidMapTableRow(val cn: String, val oldGuid: String, val newGuid: String)
+}

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/utils/UUIDUtils.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/utils/UUIDUtils.kt
@@ -1,0 +1,36 @@
+package uk.gov.communities.delta.auth.utils
+
+import java.nio.ByteBuffer
+import java.util.*
+
+fun ByteArray.toUUID(): UUID {
+    if (size != 16) {
+        throw IllegalArgumentException("UUID must be 16 bytes")
+    }
+    // https://www.baeldung.com/java-byte-array-to-uuid#convert-byte-array-to-uuid
+    val buffer = ByteBuffer.wrap(this)
+    val high = buffer.getLong()
+    val low = buffer.getLong()
+    return UUID(high, low)
+}
+
+// Microsoft use a mixed-endian text representation of GUIDs.
+// Whilst we use the normal text representation in this service we keep this function as a debugging aid and documentation.
+// https://en.wikipedia.org/wiki/Universally_unique_identifier#Encoding
+// > For example, 00112233-4455-6677-8899-aabbccddeeff is encoded as the bytes 33 22 11 00 55 44 77 66 88 99 aa bb cc dd ee ff.[19][20]
+@OptIn(ExperimentalStdlibApi::class)
+fun UUID.toActiveDirectoryGUIDString(): String {
+    val bytes = ByteBuffer.wrap(ByteArray(16))
+    bytes.putLong(mostSignificantBits)
+    bytes.putLong(leastSignificantBits)
+
+    val byteOrder = listOf(3, 2, 1, 0, -1, 5, 4, -1, 7, 6, -1, 8, 9, -1, 10, 11, 12, 13, 14, 15)
+    val sb = StringBuilder(36)
+    for (b in byteOrder) {
+        sb.append(
+            if (b == -1) '-'
+            else bytes[b].toHexString()
+        )
+    }
+    return sb.toString()
+}

--- a/auth-service/src/main/resources/db/migration/V5__user_guid_map.sql
+++ b/auth-service/src/main/resources/db/migration/V5__user_guid_map.sql
@@ -1,0 +1,6 @@
+CREATE TABLE user_guid_map
+(
+    cn      text NOT NULL PRIMARY KEY,
+    oldGuid text NOT NULL,
+    newGuid uuid NOT NULL UNIQUE
+);

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminGetUserControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminGetUserControllerTest.kt
@@ -188,6 +188,7 @@ class AdminGetUserControllerTest {
                             "\"fullName\":\"Test Surname\"," +
                             "\"accountEnabled\":true," +
                             "\"mangledDeltaObjectGuid\":\"mangled-id\"," +
+                            "\"javaUUIDObjectGuid\":null," +
                             "\"telephone\":\"0987654321\"," +
                             "\"mobile\":\"0123456789\"," +
                             "\"positionInOrganisation\":null," +

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/helper/TestLdapUser.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/helper/TestLdapUser.kt
@@ -13,6 +13,7 @@ fun testLdapUser(
     fullName: String = "Test Surname",
     accountEnabled: Boolean = true,
     mangledDeltaObjectGuid: String = "mangled-id",
+    javaUUIDObjectGuid: String? = null,
     telephone: String? = null,
     mobile: String? = null,
     positionInOrganisation: String? = null,
@@ -21,5 +22,6 @@ fun testLdapUser(
     notificationStatus: String = "active",
 ) = LdapUser(
     dn, cn, memberOfCNs, email, deltaTOTPSecret, firstName, lastName, fullName, accountEnabled,
-    mangledDeltaObjectGuid, telephone, mobile, positionInOrganisation, reasonForAccess, comment, notificationStatus
+    mangledDeltaObjectGuid, javaUUIDObjectGuid, telephone, mobile, positionInOrganisation,
+    reasonForAccess, comment, notificationStatus
 )

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/utils/UUIDUtilsTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/utils/UUIDUtilsTest.kt
@@ -1,0 +1,22 @@
+package uk.gov.communities.delta.utils
+
+import org.junit.Test
+import uk.gov.communities.delta.auth.utils.toActiveDirectoryGUIDString
+import uk.gov.communities.delta.auth.utils.toUUID
+import kotlin.test.assertEquals
+
+
+class UUIDUtilsTest {
+
+    @Test
+    fun testUUIDToString() {
+        val hex = "01078E38BA10DB4488967F28F9837210"
+        val bytes = hex.chunked(2)
+            .map { it.toInt(16).toByte() }
+            .toByteArray()
+        val uuid = bytes.toUUID()
+
+        assertEquals("01078e38-ba10-db44-8896-7f28f9837210", uuid.toString());
+        assertEquals("388e0701-10ba-44db-8896-7f28f9837210", uuid.toActiveDirectoryGUIDString())
+    }
+}

--- a/terraform/modules/auth_service/schedule.tf
+++ b/terraform/modules/auth_service/schedule.tf
@@ -8,6 +8,10 @@ locals {
       cron     = "10 0 * * ? *" // Ten past midnight
       timezone = "Europe/London"
     }
+    UpdateUserGUIDMap = {
+      cron     = "10 0 * * ? *" // Ten past midnight
+      timezone = "Europe/London"
+    }
   }
 }
 


### PR DESCRIPTION
Adds a new overnight job to import all user old and actual objectGUIDs into a table in the auth service.

I'm planning to export it as a CSV and load it into MarkLogic to use for updating the objectGUIDs there. We're not doing anything with the map in the auth service, it's mostly a convenient place to add the script.

The job takes a few seconds on test. It will be longer on prod, but I think <30 seconds still. It loads the full list of users into memory twice, but napkin maths says it should be OK.

One annoying thing is that Active Directory renders GUIDs to strings slightly differently to Java given the same bytes. I'm planning to use the Java representation for the strings in MarkLogic since we're expecting to move away from AD anyway long term.