### PR TITLE
DT-277 Use AD string representation of GUID

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/LdapRepository.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/LdapRepository.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 import org.jetbrains.annotations.Blocking
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.config.LDAPConfig
-import uk.gov.communities.delta.auth.utils.toUUID
+import uk.gov.communities.delta.auth.utils.toActiveDirectoryGUIDString
 import java.lang.Integer.parseInt
 import java.util.*
 import javax.naming.Context
@@ -101,7 +101,7 @@ class LdapRepository(
         }
         val javaUUIDObjectGuid = when (objectGUIDMode) {
             ObjectGUIDMode.OLD_MANGLED -> null
-            ObjectGUIDMode.NEW_JAVA_UUID_STRING -> attributes.getNewModeObjectGuid().toString()
+            ObjectGUIDMode.NEW_JAVA_UUID_STRING -> attributes.getNewModeObjectGuidString()
         }
 
         val memberOfGroupCNs = memberOfGroupDNs.mapNotNull {
@@ -154,9 +154,9 @@ fun Attributes.getMangledDeltaObjectGUID(): String {
     return guidStringToUse.toByteArray().toHexString().trimStart { it == '0' }
 }
 
-fun Attributes.getNewModeObjectGuid(): UUID {
+fun Attributes.getNewModeObjectGuidString(): String {
     val objectGuid = get("objectGUID").get() as ByteArray
-    return objectGuid.toUUID()
+    return objectGuid.toActiveDirectoryGUIDString()
 }
 
 @Serializable
@@ -172,8 +172,7 @@ data class LdapUser(
     val accountEnabled: Boolean,
     // Exactly one of these should be populated
     val mangledDeltaObjectGuid: String?,
-    // Text representation of the user's objectGUID bytes interpreted as a Java UUID,
-    // note that this is different to what Active Directory displays in the Attribute Editor, see UUIDUtils.kt
+    // Text representation of the user's objectGUID
     val javaUUIDObjectGuid: String?,
     val telephone: String?,
     val mobile: String?,

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/tasks/UpdateUserGUIDMap.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/tasks/UpdateUserGUIDMap.kt
@@ -68,7 +68,7 @@ class UpdateUserGUIDMap(
             pageSize = 200,
         ) {
             val cn = it.get("cn").get() as String
-            val objectGuid = it.getNewModeObjectGuid().toString()
+            val objectGuid = it.getNewModeObjectGuidString()
             UserGuid(cn, objectGuid)
         }
         ctx.close()

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/utils/UUIDUtils.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/utils/UUIDUtils.kt
@@ -3,26 +3,15 @@ package uk.gov.communities.delta.auth.utils
 import java.nio.ByteBuffer
 import java.util.*
 
-fun ByteArray.toUUID(): UUID {
-    if (size != 16) {
-        throw IllegalArgumentException("UUID must be 16 bytes")
-    }
-    // https://www.baeldung.com/java-byte-array-to-uuid#convert-byte-array-to-uuid
-    val buffer = ByteBuffer.wrap(this)
-    val high = buffer.getLong()
-    val low = buffer.getLong()
-    return UUID(high, low)
-}
-
 // Microsoft use a mixed-endian text representation of GUIDs.
-// Whilst we use the normal text representation in this service we keep this function as a debugging aid and documentation.
 // https://en.wikipedia.org/wiki/Universally_unique_identifier#Encoding
 // > For example, 00112233-4455-6677-8899-aabbccddeeff is encoded as the bytes 33 22 11 00 55 44 77 66 88 99 aa bb cc dd ee ff.[19][20]
 @OptIn(ExperimentalStdlibApi::class)
-fun UUID.toActiveDirectoryGUIDString(): String {
-    val bytes = ByteBuffer.wrap(ByteArray(16))
-    bytes.putLong(mostSignificantBits)
-    bytes.putLong(leastSignificantBits)
+fun ByteArray.toActiveDirectoryGUIDString(): String {
+    if (size != 16) {
+        throw IllegalArgumentException("GUID must be 16 bytes")
+    }
+    val bytes = ByteBuffer.wrap(this)
 
     val byteOrder = listOf(3, 2, 1, 0, -1, 5, 4, -1, 7, 6, -1, 8, 9, -1, 10, 11, 12, 13, 14, 15)
     val sb = StringBuilder(36)

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/utils/UUIDUtilsTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/utils/UUIDUtilsTest.kt
@@ -2,7 +2,6 @@ package uk.gov.communities.delta.utils
 
 import org.junit.Test
 import uk.gov.communities.delta.auth.utils.toActiveDirectoryGUIDString
-import uk.gov.communities.delta.auth.utils.toUUID
 import kotlin.test.assertEquals
 
 
@@ -14,9 +13,7 @@ class UUIDUtilsTest {
         val bytes = hex.chunked(2)
             .map { it.toInt(16).toByte() }
             .toByteArray()
-        val uuid = bytes.toUUID()
 
-        assertEquals("01078e38-ba10-db44-8896-7f28f9837210", uuid.toString());
-        assertEquals("388e0701-10ba-44db-8896-7f28f9837210", uuid.toActiveDirectoryGUIDString())
+        assertEquals("388e0701-10ba-44db-8896-7f28f9837210", bytes.toActiveDirectoryGUIDString())
     }
 }


### PR DESCRIPTION
Looking at your comment in AdUser.java in Delta @hugh-emerson, I think you're right that the byte representation is different and that using ADs string representation gets a "correct" UUID in that the version number is in the right place.

I couldn't find any super clear documentation on this, and I don't think it matters too much, but may as well switch.