### PR TITLE
DT-571 Add is_sso to refresh user info response

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/RefreshUserInfoController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/RefreshUserInfoController.kt
@@ -41,7 +41,7 @@ class RefreshUserInfoController(
             ).map(user.memberOfCNs)
 
             logger.info("Retrieved updated user info")
-            call.respond(UserInfoResponse(user, samlToken.token, roles, samlToken.expiry.epochSecond))
+            call.respond(UserInfoResponse(user, samlToken.token, roles, samlToken.expiry.epochSecond, session.isSso))
         }
     }
 
@@ -52,5 +52,6 @@ class RefreshUserInfoController(
         val saml_token: String,
         val delta_user_roles: MemberOfToDeltaRolesMapper.Roles,
         val expires_at_epoch_second: Long,
+        val is_sso: Boolean,
     )
 }


### PR DESCRIPTION
Without this refreshing user info after updating a role/similar would fail as Delta couldn't parse the response.

The Playwright tests should probably catch this, I'll have a go at adding it.