### PR TITLE
DT-277 Disable UpdateUserGUIDMap job

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/tasks/UpdateUserGUIDMap.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/tasks/UpdateUserGUIDMap.kt
@@ -9,7 +9,9 @@ import javax.naming.directory.SearchControls
 import kotlin.time.Duration.Companion.minutes
 
 /*
- * Update the user_guid_map database table by reading all users from Active Directory in both old and new GUID mode
+ * Update the user_guid_map database table by reading all users from Active Directory in both old and new GUID mode.
+ * The migration to the new GUID format in Delta is now complete so this job is no longer run regularly,
+ * though we'll keep the code and table around for a short while.
  */
 class UpdateUserGUIDMap(
     private val ldapConfig: LDAPConfig,

--- a/terraform/modules/auth_service/schedule.tf
+++ b/terraform/modules/auth_service/schedule.tf
@@ -8,10 +8,6 @@ locals {
       cron     = "10 0 * * ? *" // Ten past midnight
       timezone = "Europe/London"
     }
-    UpdateUserGUIDMap = {
-      cron     = "10 0 * * ? *" // Ten past midnight
-      timezone = "Europe/London"
-    }
   }
 }
 


### PR DESCRIPTION
We could completely delete it, but I'd like to keep the table around for a little while at least just in case we missed anything in the migration.