### PR TITLE
DT-694 Take list of roles to add and remove

### DIFF
--- a/auth-service/README.md
+++ b/auth-service/README.md
@@ -186,7 +186,7 @@ curl 'http://localhost:8088/auth-internal/bearer/user-audit?cn=delta.admin' \
 curl -X POST 'http://localhost:8088/auth-internal/bearer/roles' \
   --header 'Authorization: Bearer ABC123' \
   --header 'Delta-Client: delta-website-dev:dev-delta-website-client-secret' \
-  -d '{"roles": ["data-providers"]}'
+  -d '{"addToRoles": ["data-providers"], "removeFromRoles": []}'
 ```
 
 ## GOV.UK Frontend

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/EditRolesController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/EditRolesController.kt
@@ -55,7 +55,7 @@ class EditRolesController(
                 rolesToRemove.map { it.adCn() }
         val groupCNsToRemoveFilteredForMembership = groupCNsToRemove.filter { callingUser.memberOfCNs.contains(it) }
 
-        logger.atInfo().log("Granting user ${session.userCn} groups $groupCNsToAdd")
+        logger.atInfo().log("Granting user ${session.userCn} groups $groupCNsToAddFilteredForNonMembership")
         groupCNsToAddFilteredForNonMembership
             .forEach {
                 groupService.addUserToGroup(callingUser.cn, callingUser.dn, it, call, null)

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/EditRolesControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/EditRolesControllerTest.kt
@@ -39,7 +39,7 @@ class EditRolesControllerTest {
                 append("Delta-Client", "${client.clientId}:${client.clientSecret}")
             }
             contentType(ContentType.Application.Json)
-            setBody("{\"roles\": [\"data-providers\"]}")
+            setBody("{\"addToRoles\": [\"data-providers\"], \"removeFromRoles\": [\"data-certifiers\"]}")
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
             coVerify(exactly = 1) { groupService.addUserToGroup(externalUser.cn, externalUser.dn, "datamart-delta-data-providers", any(), null) }
@@ -53,7 +53,7 @@ class EditRolesControllerTest {
     }
 
     @Test
-    fun testExternalUserCannotRequestInternalRole() = testSuspend {
+    fun testExternalUserCannotRequestInternalRole() {
         Assert.assertThrows(ApiError::class.java) {
             runBlocking {
                 testClient.post("/bearer/roles") {
@@ -62,14 +62,13 @@ class EditRolesControllerTest {
                         append("Delta-Client", "${client.clientId}:${client.clientSecret}")
                     }
                     contentType(ContentType.Application.Json)
-                    setBody("{\"roles\": [\"payments-reviewers\"]}")
+                    setBody("{\"addToRoles\": [\"payments-reviewers\"], \"removeFromRoles\": []}")
                 }
             }
         }.apply {
             assertEquals("illegal_role", errorCode)
             assertEquals(HttpStatusCode.Forbidden, statusCode)
-            coVerify(exactly = 0) { groupService.addUserToGroup(any(), any(), any(), any(), any()) }
-            coVerify(exactly = 0) { groupService.removeUserFromGroup(any(), any(), any(), any(), any()) }
+            confirmVerified(groupService)
         }
     }
 
@@ -81,15 +80,75 @@ class EditRolesControllerTest {
                 append("Delta-Client", "${client.clientId}:${client.clientSecret}")
             }
             contentType(ContentType.Application.Json)
-            setBody("{\"roles\": [\"payments-reviewers\"]}")
+            setBody("{\"addToRoles\": [\"payments-reviewers\"], \"removeFromRoles\": [\"data-certifiers\"]}")
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
             coVerify(exactly = 1) { groupService.addUserToGroup(internalUser.cn, internalUser.dn, "datamart-delta-payments-reviewers", any(), null) }
             coVerify(exactly = 1) { groupService.addUserToGroup(internalUser.cn, internalUser.dn, "datamart-delta-payments-reviewers-orgCode1", any(), null) }
             coVerify(exactly = 1) { groupService.addUserToGroup(internalUser.cn, internalUser.dn, "datamart-delta-payments-reviewers-orgCode2", any(), null) }
-            coVerify(exactly = 1) { groupService.removeUserFromGroup(internalUser.cn, internalUser.dn, "datamart-delta-data-certifiers", any(), null) }
-            coVerify(exactly = 1) { groupService.removeUserFromGroup(internalUser.cn, internalUser.dn, "datamart-delta-data-certifiers-orgCode1", any(), null) }
-            coVerify(exactly = 1) { groupService.removeUserFromGroup(internalUser.cn, internalUser.dn, "datamart-delta-data-certifiers-orgCode2", any(), null) }
+            coVerify(exactly = 1) {
+                groupService.removeUserFromGroup(
+                    internalUser.cn,
+                    internalUser.dn,
+                    "datamart-delta-data-certifiers",
+                    any(),
+                    null
+                )
+            }
+            coVerify(exactly = 1) {
+                groupService.removeUserFromGroup(
+                    internalUser.cn,
+                    internalUser.dn,
+                    "datamart-delta-data-certifiers-orgCode1",
+                    any(),
+                    null
+                )
+            }
+            coVerify(exactly = 1) {
+                groupService.removeUserFromGroup(
+                    internalUser.cn,
+                    internalUser.dn,
+                    "datamart-delta-data-certifiers-orgCode2",
+                    any(),
+                    null
+                )
+            }
+            confirmVerified(groupService)
+        }
+    }
+
+    @Test
+    fun testSendingCurrentRolesHasNoEffect() = testSuspend {
+        testClient.post("/bearer/roles") {
+            headers {
+                append("Authorization", "Bearer ${internalUserSession.authToken}")
+                append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+            }
+            contentType(ContentType.Application.Json)
+            setBody("{\"addToRoles\": [\"data-certifiers\"], \"removeFromRoles\": [\"data-providers\"]}")
+        }.apply {
+            assertEquals(HttpStatusCode.OK, status)
+            confirmVerified(groupService)
+        }
+    }
+
+    @Test
+    fun testInternalUserCannotRemoveAdminRole() {
+        Assert.assertThrows(ApiError::class.java) {
+            runBlocking {
+                testClient.post("/bearer/roles") {
+                    headers {
+                        append("Authorization", "Bearer ${internalUserSession.authToken}")
+                        append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+                    }
+                    contentType(ContentType.Application.Json)
+                    setBody("{\"addToRoles\": [\"payments-reviewers\"], \"removeFromRoles\": [\"dataset-admins\"]}")
+                }
+            }
+        }.apply {
+            assertEquals("illegal_role", errorCode)
+            assertEquals("illegal_role (403 Forbidden) Not permitted to remove role dataset-admins", message)
+            assertEquals(HttpStatusCode.Forbidden, statusCode)
             confirmVerified(groupService)
         }
     }
@@ -174,6 +233,8 @@ class EditRolesControllerTest {
                 "datamart-delta-role-1",
                 "datamart-delta-role-1-orgCode1",
                 "datamart-delta-role-1-orgCode2",
+                "datamart-delta-dataset-admins-1",
+                "datamart-delta-dataset-admins-orgCode1",
             ),
             mobile = "0123456789",
             telephone = "0987654321",


### PR DESCRIPTION
Accept a list of roles to add, and a list to remove. This should fix the case where a user has the data certifier (or auditor) role, but doesn't have a certifier/auditor organisation and gets removed from the role because Delta can say which roles it's expecting to get removed.

It's not completely clear that's actually a bug, but it's feels unexpected so let's fix it.

This is a breaking change and requires https://github.com/communitiesuk/delta/pull/1441 to be merged before release.