### PR TITLE
DT-920 Improve validation when creating and updating users as admin

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -125,6 +125,7 @@ class Injection(
     val ssoOAuthClientProviderLookupService =
         SSOOAuthClientProviderLookupService(azureADSSOConfig, ssoLoginStateService)
     val microsoftGraphService = MicrosoftGraphService()
+    val deltaUserDetailsRequestMapper = DeltaUserPermissionsRequestMapper(organisationService, accessGroupsService)
     val meterRegistry =
         if (authServiceConfig.metricsNamespace.isNullOrEmpty()) SimpleMeterRegistry() else CloudWatchMeterRegistry(
             object : CloudWatchConfig {
@@ -281,12 +282,14 @@ class Injection(
         groupService,
         emailService,
         setPasswordTokenService,
+        deltaUserDetailsRequestMapper,
     )
 
     fun adminEditUserController() = AdminEditUserController(
         userLookupService,
         userService,
         groupService,
+        deltaUserDetailsRequestMapper,
     )
 
     fun adminGetUserController() = AdminGetUserController(

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/DeltaUserDetailsRequest.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/DeltaUserDetailsRequest.kt
@@ -1,0 +1,121 @@
+package uk.gov.communities.delta.auth.controllers.internal
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import uk.gov.communities.delta.auth.config.LDAPConfig
+import uk.gov.communities.delta.auth.services.*
+
+class DeltaUserPermissionsRequestMapper(
+    private val organisationService: OrganisationService,
+    private val accessGroupsService: AccessGroupsService,
+) {
+
+    suspend fun deltaRequestToUserPermissions(userDetailsRequest: DeltaUserDetailsRequest): DeltaUserPermissions {
+        return coroutineScope {
+            val allOrganisations = async { organisationService.findAllNamesAndCodes() }
+            val allAccessGroups = async { accessGroupsService.getAllAccessGroups() }
+            DeltaUserPermissions.fromUserDetailsRequest(
+                userDetailsRequest,
+                allAccessGroups.await().associateBy { it.name },
+                allOrganisations.await().associateBy { it.code },
+            )
+        }
+    }
+}
+
+data class DeltaUserPermissions(
+    val organisations: Set<OrganisationNameAndCode>,
+    val roles: Set<DeltaSystemRole>,
+    val accessGroups: Set<UserAccessGroup>,
+) {
+    data class UserAccessGroup(val name: String, val organisationIds: List<String>, val isDelegate: Boolean)
+
+    companion object {
+        class BadInput(message: String) : Exception(message)
+
+        fun fromUserDetailsRequest(
+            userDetailsRequest: DeltaUserDetailsRequest,
+            allAccessGroups: Map<String, AccessGroup>,
+            allOrganisations: Map<String, OrganisationNameAndCode>,
+        ): DeltaUserPermissions {
+            val organisations = userDetailsRequest.organisations.map {
+                allOrganisations[it] ?: throw BadInput("Unknown organisation $it")
+            }.toSet()
+
+            val roles = userDetailsRequest.roles.map {
+                DeltaSystemRole.fromString(it.removePrefix(LDAPConfig.DATAMART_DELTA_PREFIX))
+                    ?: throw BadInput("Invalid system role $it")
+            }.toSet()
+
+            // Access groups must all exist
+            userDetailsRequest.accessGroups.forEach {
+                if (allAccessGroups[it.removePrefix(LDAPConfig.DATAMART_DELTA_PREFIX)] == null) throw BadInput(
+                    "Unknown access group $it"
+                )
+            }
+            // Keys of the (access group -> organisations) map must all be in the access groups list
+            val prefixedAccessGroupNamesSet = userDetailsRequest.accessGroups.toSet()
+            userDetailsRequest.accessGroupOrganisations.forEach { entry ->
+                if (!prefixedAccessGroupNamesSet.contains(entry.key)) throw BadInput("Access group in organisation map but not list ${entry.key}")
+            }
+            // User must be a member of all delegated access groups
+            userDetailsRequest.accessGroupDelegates.find { !prefixedAccessGroupNamesSet.contains(it) }
+                ?.let { throw BadInput("Cannot be delegate of access group $it without being a member") }
+
+            val accessGroups = userDetailsRequest.accessGroups.map { prefixedAccessGroupName ->
+                val accessGroupOrganisations = userDetailsRequest.accessGroupOrganisations[prefixedAccessGroupName]
+                accessGroupOrganisations?.find { agOrg -> !organisations.any { agOrg == it.code } }?.let {
+                    throw BadInput("Cannot be member of organisation $it for access group $prefixedAccessGroupName as not member of organisation")
+                }
+                UserAccessGroup(
+                    prefixedAccessGroupName.removePrefix(LDAPConfig.DATAMART_DELTA_PREFIX),
+                    accessGroupOrganisations ?: emptyList(),
+                    userDetailsRequest.accessGroupDelegates.contains(prefixedAccessGroupName)
+                )
+            }.toSet()
+
+            return DeltaUserPermissions(organisations, roles + DeltaSystemRole.USER, accessGroups)
+        }
+    }
+
+    fun getADGroupCNs(): List<String> {
+        if (!roles.contains(DeltaSystemRole.USER)) throw Exception("Cannot generate groups list for user that doesn't have the USER system role")
+        val groups = mutableListOf<String>()
+        accessGroups.forEach { accessGroup ->
+            groups.add(accessGroup.name)
+            accessGroup.organisationIds.forEach { groups.add("${accessGroup.name}-$it") }
+            if (accessGroup.isDelegate) groups.add("delegate-${accessGroup.name}")
+        }
+        roles.forEach { role ->
+            groups.add(role.adRoleName)
+            organisations.forEach { org ->
+                groups.add("${role.adRoleName}-${org.code}")
+            }
+        }
+        return groups.map { LDAPConfig.DATAMART_DELTA_PREFIX + it }
+    }
+}
+
+@Serializable
+data class DeltaUserDetailsRequest(
+    @SerialName("id") val id: String, //This is the username in email form
+    @SerialName("enabled") val enabled: Boolean, //Always false for user creation - not used anywhere yet
+    @SerialName("email") val email: String,
+    @SerialName("lastName") val lastName: String,
+    @SerialName("firstName") val firstName: String,
+    @SerialName("telephone") val telephone: String? = null,
+    @SerialName("mobile") val mobile: String? = null,
+    @SerialName("position") val position: String? = null,
+    @SerialName("reasonForAccess") val reasonForAccess: String? = null,
+    // All prefixed with datamart-delta
+    @SerialName("accessGroups") val accessGroups: List<String>,
+    @SerialName("accessGroupDelegates") val accessGroupDelegates: List<String>,
+    @SerialName("accessGroupOrganisations") val accessGroupOrganisations: Map<String, List<String>>,
+    @SerialName("roles") val roles: List<String>,
+    @SerialName("externalRoles") val externalRoles: List<String>, //Not used anywhere yet - S151 Officer related
+    @SerialName("organisations") val organisations: List<String>,
+    @SerialName("comment") val comment: String? = null,
+    @SerialName("classificationType") val classificationType: String? = null, //Not used anywhere yet
+)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/EditUserDetailsController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/EditUserDetailsController.kt
@@ -30,7 +30,7 @@ class EditUserDetailsController(
         logger.atInfo().log("Updating details for user {}", session.userCn)
 
         // TODO 694 do we want not to receive this whole object? only a few things are listed as updatable
-        val updatedDeltaUserDetails = call.receive<UserService.DeltaUserDetails>()
+        val updatedDeltaUserDetails = call.receive<DeltaUserDetailsRequest>()
 
         val modifications = getModifications(callingUser, updatedDeltaUserDetails)
 
@@ -40,7 +40,7 @@ class EditUserDetailsController(
     // TODO 694 in this and the below there is duplicated code from the admin edit user controller
     private fun getModifications(
         currentUser: LdapUser,
-        newUser: UserService.DeltaUserDetails
+        newUser: DeltaUserDetailsRequest
     ): Array<ModificationItem> {
         var modifications = arrayOf<ModificationItem>()
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/MemberOfToDeltaRolesMapper.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/MemberOfToDeltaRolesMapper.kt
@@ -216,6 +216,7 @@ enum class DeltaSystemRole(val adRoleName: String, val classification: DeltaSyst
 
     companion object {
         val ROLE_NAME_MAP = DeltaSystemRole.entries.associateBy { it.adRoleName }
+        fun fromString(str: String) = ROLE_NAME_MAP[str]
     }
 }
 

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaUserDetailsRequestTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaUserDetailsRequestTest.kt
@@ -1,0 +1,146 @@
+package uk.gov.communities.delta.controllers
+
+import uk.gov.communities.delta.auth.controllers.internal.DeltaUserDetailsRequest
+import uk.gov.communities.delta.auth.controllers.internal.DeltaUserPermissions
+import uk.gov.communities.delta.auth.services.AccessGroup
+import uk.gov.communities.delta.auth.services.DeltaSystemRole
+import uk.gov.communities.delta.auth.services.OrganisationNameAndCode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DeltaUserDetailsRequestTest {
+    @Test
+    fun testGetGroupsFromUserDetails() {
+        val permissions = DeltaUserPermissions(
+            setOf(OrganisationNameAndCode("orgCode1", "Org 1"), OrganisationNameAndCode("orgCode2", "Org 2")),
+            setOf(DeltaSystemRole.USER, DeltaSystemRole.DATA_PROVIDERS),
+            setOf(
+                DeltaUserPermissions.UserAccessGroup("access-group-1", emptyList(), false),
+                DeltaUserPermissions.UserAccessGroup("access-group-2", listOf("orgCode1", "orgCode2"), true),
+            )
+        )
+        val groups = permissions.getADGroupCNs()
+        val expectedGroups = listOf(
+            "datamart-delta-user",
+            "datamart-delta-access-group-1",
+            "datamart-delta-access-group-2",
+            "datamart-delta-delegate-access-group-2",
+            "datamart-delta-access-group-2-orgCode1",
+            "datamart-delta-access-group-2-orgCode2",
+            "datamart-delta-data-providers",
+            "datamart-delta-data-providers-orgCode1",
+            "datamart-delta-data-providers-orgCode2",
+            "datamart-delta-user-orgCode1",
+            "datamart-delta-user-orgCode2",
+        )
+        assertEquals(expectedGroups.sorted(), groups.sorted())
+    }
+
+    private val exampleRequest = DeltaUserDetailsRequest(
+        "user@example.com",
+        false,
+        "user@example.com",
+        "testLast",
+        "testFirst",
+        "0123456789",
+        "0987654321",
+        "test position",
+        null,
+        listOf("datamart-delta-access-group-1", "datamart-delta-access-group-2"),
+        listOf("datamart-delta-access-group-2"),
+        mapOf("datamart-delta-access-group-2" to listOf("orgCode1", "orgCode2")),
+        listOf("datamart-delta-data-providers"),
+        emptyList(),
+        listOf("orgCode1", "orgCode2"),
+        "test comment",
+        null
+    )
+
+    private val organisations = listOf(
+        OrganisationNameAndCode("orgCode1", "Org 1"),
+        OrganisationNameAndCode("orgCode2", "Org 2"),
+        OrganisationNameAndCode("orgCode3", "Org 3"),
+    )
+
+    @Suppress("BooleanLiteralArgument")
+    private val accessGroups = listOf(
+        AccessGroup("access-group-1", "STATS", "access group 1", false, false),
+        AccessGroup("access-group-2", "STATS", "access group 2", false, false),
+        AccessGroup("access-group-3", "STATS", "access group 3", false, false),
+    )
+
+    @Test
+    fun testMapsRequestToPermissions() {
+        val result = DeltaUserPermissions.fromUserDetailsRequest(
+            exampleRequest,
+            accessGroups.associateBy { it.name },
+            organisations.associateBy { it.code }
+        )
+
+        assertEquals(
+            DeltaUserPermissions(
+                setOf(OrganisationNameAndCode("orgCode1", "Org 1"), OrganisationNameAndCode("orgCode2", "Org 2")),
+                setOf(DeltaSystemRole.DATA_PROVIDERS, DeltaSystemRole.USER),
+                setOf(
+                    DeltaUserPermissions.UserAccessGroup("access-group-1", emptyList(), false),
+                    DeltaUserPermissions.UserAccessGroup("access-group-2", listOf("orgCode1", "orgCode2"), true)
+                )
+            ),
+            result
+        )
+    }
+
+    @Test(expected = DeltaUserPermissions.Companion.BadInput::class)
+    fun testRejectsInvalidAccessGroup() {
+        DeltaUserPermissions.fromUserDetailsRequest(
+            exampleRequest.copy(accessGroups = exampleRequest.accessGroups + "datamart-delta-invalid-group"),
+            accessGroups.associateBy { it.name },
+            organisations.associateBy { it.code }
+        )
+    }
+
+    @Test(expected = DeltaUserPermissions.Companion.BadInput::class)
+    fun testRejectsInvalidSystemRole() {
+        DeltaUserPermissions.fromUserDetailsRequest(
+            exampleRequest.copy(roles = listOf("datamart-delta-invalid-role")),
+            accessGroups.associateBy { it.name },
+            organisations.associateBy { it.code }
+        )
+    }
+
+    @Test(expected = DeltaUserPermissions.Companion.BadInput::class)
+    fun testRejectsInvalidOrganisation() {
+        DeltaUserPermissions.fromUserDetailsRequest(
+            exampleRequest.copy(organisations = exampleRequest.organisations + "invalidOrg"),
+            accessGroups.associateBy { it.name },
+            organisations.associateBy { it.code }
+        )
+    }
+
+    @Test(expected = DeltaUserPermissions.Companion.BadInput::class)
+    fun testRejectsAccessGroupInMapNotList() {
+        DeltaUserPermissions.fromUserDetailsRequest(
+            exampleRequest.copy(accessGroupOrganisations = mapOf("datamart-delta-access-group-3" to emptyList())),
+            accessGroups.associateBy { it.name },
+            organisations.associateBy { it.code }
+        )
+    }
+
+    @Test(expected = DeltaUserPermissions.Companion.BadInput::class)
+    fun testRejectsOrganisationInAccessGroupMapNotMember() {
+        DeltaUserPermissions.fromUserDetailsRequest(
+            exampleRequest.copy(accessGroupOrganisations = mapOf("datamart-delta-access-group-2" to listOf("orgCode3"))),
+            accessGroups.associateBy { it.name },
+            organisations.associateBy { it.code }
+        )
+    }
+
+    @Test(expected = DeltaUserPermissions.Companion.BadInput::class)
+    fun testRejectsDelegateNotMemberOfAccessGroup() {
+        DeltaUserPermissions.fromUserDetailsRequest(
+            exampleRequest.copy(accessGroupDelegates = listOf("datamart-delta-access-group-3")),
+            accessGroups.associateBy { it.name },
+            organisations.associateBy { it.code }
+        )
+    }
+}

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/EditUserAccessGroupsControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/EditUserAccessGroupsControllerTest.kt
@@ -6,8 +6,8 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.auth.*
-import io.ktor.server.testing.*
 import io.ktor.server.routing.*
+import io.ktor.server.testing.*
 import io.ktor.test.dispatcher.*
 import io.mockk.*
 import kotlinx.coroutines.runBlocking
@@ -28,7 +28,7 @@ import java.time.Instant
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-class EditAccessGroupsControllerTest {
+class EditUserAccessGroupsControllerTest {
     @Test
     fun testUserCanUpdateAccessGroups() = testSuspend {
         testClient.post("/access-groups") {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/UserServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/UserServiceTest.kt
@@ -13,6 +13,7 @@ import org.junit.Test
 import uk.gov.communities.delta.auth.config.AzureADSSOClient
 import uk.gov.communities.delta.auth.config.LDAPConfig
 import uk.gov.communities.delta.auth.controllers.external.ResetPasswordException
+import uk.gov.communities.delta.auth.controllers.internal.DeltaUserDetailsRequest
 import uk.gov.communities.delta.auth.services.*
 import uk.gov.communities.delta.helper.testLdapUser
 import java.time.Instant
@@ -45,7 +46,7 @@ class UserServiceTest {
     private val auditData = slot<String>()
     private val adminSession =
         OAuthSession(1, "adminUserCN", mockk(relaxed = true), "adminAccessToken", Instant.now(), "trace", false)
-    private val testUserDetails = UserService.DeltaUserDetails(
+    private val testUserDetails = DeltaUserDetailsRequest(
         userEmail,
         false,
         userEmail,
@@ -55,12 +56,12 @@ class UserServiceTest {
         "0987654321",
         "test position",
         null,
-        arrayOf("datamart-delta-access-group-1", "datamart-delta-access-group-2"),
-        arrayOf("datamart-delta-access-group-2"),
-        mapOf("datamart-delta-access-group-2" to arrayOf("orgCode1", "orgCode2")),
-        arrayOf("datamart-delta-role-1", "datamart-delta-role-2"),
-        emptyArray(),
-        arrayOf("orgCode1", "orgCode2"),
+        listOf("datamart-delta-access-group-1", "datamart-delta-access-group-2"),
+        listOf("datamart-delta-access-group-2"),
+        mapOf("datamart-delta-access-group-2" to listOf("orgCode1", "orgCode2")),
+        listOf("datamart-delta-role-1", "datamart-delta-role-2"),
+        emptyList(),
+        listOf("orgCode1", "orgCode2"),
         "test comment",
         null
     )
@@ -330,28 +331,5 @@ class UserServiceTest {
     fun testPasswordCreation() = testSuspend {
         val adUser = UserService.ADUser(ldapConfig, registration, requiredSSOClient)
         assertEquals(18 * 8 / 6, adUser.password!!.length)
-    }
-
-    @Test
-    fun testGetGroupsFromUserDetails() = testSuspend {
-        val groups = testUserDetails.getGroups()
-        val expectedGroups = arrayOf(
-            "datamart-delta-user",
-            "datamart-delta-access-group-1",
-            "datamart-delta-access-group-2",
-            "datamart-delta-delegate-access-group-2",
-            "datamart-delta-access-group-2-orgCode1",
-            "datamart-delta-access-group-2-orgCode2",
-            "datamart-delta-role-1",
-            "datamart-delta-role-1-orgCode1",
-            "datamart-delta-role-1-orgCode2",
-            "datamart-delta-role-2",
-            "datamart-delta-role-2-orgCode1",
-            "datamart-delta-role-2-orgCode2",
-            "datamart-delta-user-orgCode1",
-            "datamart-delta-user-orgCode2",
-        )
-        expectedGroups.forEach { assertContains(groups, it) }
-        assertEquals(expectedGroups.size, groups.size)
     }
 }


### PR DESCRIPTION
Add validation to check that the roles, organisations and access groups we get from Delta for the admin create/update user endpoints make sense.

I've separated out the `DeltaUserDetailsRequest` as the untrusted input from Delta, and `DeltaUserPermissions` as the validated list of organisations, roles and access groups. There's a new `DeltaUserPermissionsRequestMapper` to convert one to the other which I've left in the controllers folder, but should maybe be a service? We're getting to the point we've got enough classes the very simple package hierarchy doesn't quite work anymore.

I've added a few tests for it, plus the controllers use the real class so their tests cover it a bit too. I've done a quick test of creating and updating users through Delta including a bulk upload, though I haven't tried to be exauhstive.