### PR TITLE
Migration to update old audit actions

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/UserAuditTrailRepo.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/UserAuditTrailRepo.kt
@@ -10,6 +10,7 @@ import java.sql.Timestamp
 
 class UserAuditTrailRepo {
     enum class AuditAction(val action: String) {
+        // Modifying or removing an existing action requires a database migration to update old records
         FORM_LOGIN("form_login"),
         SSO_LOGIN("sso_login"),
         RESET_PASSWORD_EMAIL("reset_password_email"),

--- a/auth-service/src/main/resources/db/migration/V7__audit_action_update.sql
+++ b/auth-service/src/main/resources/db/migration/V7__audit_action_update.sql
@@ -1,0 +1,11 @@
+UPDATE user_audit
+SET action = 'user_created_by_self_register'
+WHERE action = 'self_register';
+
+UPDATE user_audit
+SET action = 'reset_password_email'
+WHERE action = 'forgot_password_email';
+
+UPDATE user_audit
+SET action = 'user_created_by_sso'
+WHERE action = 'sso_user_created';


### PR DESCRIPTION
Currently `getAuditForUser` requires all the actions to be in the enum. This is why we couldn't load the audit for a user in a support ticket earlier today.