### PR TITLE
Add memberOf to role mapping to userLookupService

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminGetUserController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminGetUserController.kt
@@ -4,11 +4,9 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import kotlinx.serialization.Serializable
 import org.slf4j.LoggerFactory
-import uk.gov.communities.delta.auth.repositories.LdapUser
 import uk.gov.communities.delta.auth.services.DeltaSystemRole
-import uk.gov.communities.delta.auth.services.MemberOfToDeltaRolesMapper
+import uk.gov.communities.delta.auth.services.LdapUserWithRoles
 import uk.gov.communities.delta.auth.services.UserLookupService
 import javax.naming.NameNotFoundException
 
@@ -29,16 +27,13 @@ class AdminGetUserController(
 
         val cn = call.request.queryParameters["userCn"]!!
         logger.atInfo().log("Getting info for user $cn")
-        val user: UserLookupService.UserWithRoles
+        val user: LdapUserWithRoles
         try {
             user = userLookupService.lookupUserByCNAndLoadRoles(cn)
         } catch (e: NameNotFoundException) {
             logger.warn("User not found $cn")
             return call.respond(HttpStatusCode.NotFound, "User not found")
         }
-        call.respond(UserWithRoles(user.user, user.roles))
+        call.respond(LdapUserWithRoles(user.user, user.roles))
     }
-
-    @Serializable
-    data class UserWithRoles(val user: LdapUser, val roles: MemberOfToDeltaRolesMapper.Roles)
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/EditRolesController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/EditRolesController.kt
@@ -31,35 +31,35 @@ class EditRolesController(
         val session = call.principal<OAuthSession>()!!
         val request = call.receive<DeltaUserRolesRequest>()
 
-        val callingUser = userLookupService.lookupUserByCNAndLoadRoles(session.userCn)
+        val (callingUser, callingUserRoles) = userLookupService.lookupUserByCNAndLoadRoles(session.userCn)
         logger.atInfo().log("Request to update own roles for user ${session.userCn}")
 
-        checkRequestedRolesArePermitted(request, callingUser.user)
+        checkRequestedRolesArePermitted(request, callingUser)
 
-        val systemRoles = callingUser.roles.systemRoles
-        val userOrgs = callingUser.roles.organisations
+        val userSystemRoles = callingUserRoles.systemRoles
+        val userOrganisations = callingUserRoles.organisations
 
-        val rolesToAdd = request.addToRoles.toSet().minus(systemRoles.map { it.role }.toSet())
-        val groupCNsToAdd = rolesToAdd.flatMap { role -> userOrgs.map { org -> role.adCn(org.code) } } +
+        val rolesToAdd = request.addToRoles.toSet().minus(userSystemRoles.map { it.role }.toSet())
+        val groupCNsToAdd = rolesToAdd.flatMap { role -> userOrganisations.map { org -> role.adCn(org.code) } } +
                 rolesToAdd.map { it.adCn() }
-        val groupCNsToAddFilteredForNonMembership = groupCNsToAdd.filter { !callingUser.user.memberOfCNs.contains(it) }
+        val groupCNsToAddFilteredForNonMembership = groupCNsToAdd.filter { !callingUser.memberOfCNs.contains(it) }
 
         val rolesToRemove = request.removeFromRoles
-        val groupCNsToRemove = rolesToRemove.flatMap { role -> userOrgs.map { org -> role.adCn(org.code) } } +
+        val groupCNsToRemove = rolesToRemove.flatMap { role -> userOrganisations.map { org -> role.adCn(org.code) } } +
                 rolesToRemove.map { it.adCn() }
         val groupCNsToRemoveFilteredForMembership =
-            groupCNsToRemove.filter { callingUser.user.memberOfCNs.contains(it) }
+            groupCNsToRemove.filter { callingUser.memberOfCNs.contains(it) }
 
         logger.atInfo().log("Granting user ${session.userCn} groups $groupCNsToAddFilteredForNonMembership")
         groupCNsToAddFilteredForNonMembership
             .forEach {
-                groupService.addUserToGroup(callingUser.user.cn, callingUser.user.dn, it, call, null)
+                groupService.addUserToGroup(callingUser.cn, callingUser.dn, it, call, null)
             }
 
         logger.atInfo().log("Revoking user ${session.userCn} groups $groupCNsToRemoveFilteredForMembership")
         groupCNsToRemoveFilteredForMembership
             .forEach {
-                groupService.removeUserFromGroup(callingUser.user.cn, callingUser.user.dn, it, call, null)
+                groupService.removeUserFromGroup(callingUser.cn, callingUser.dn, it, call, null)
             }
 
         return call.respond(mapOf("message" to "Roles have been updated. Any changes to your roles or access groups will take effect the next time you log in."))

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/MemberOfToDeltaRolesMapper.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/MemberOfToDeltaRolesMapper.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.config.LDAPConfig.Companion.DATAMART_DELTA_PREFIX
+import uk.gov.communities.delta.auth.repositories.LdapUser
 
 typealias MemberOfToDeltaRolesMapperFactory = (
     username: String,
@@ -240,3 +241,6 @@ object DeltaSystemRoleSerializer : KSerializer<DeltaSystemRole> {
  * We should be able to get rid of this distinction at some point, but for now Delta expects it.
  */
 val DELTA_EXTERNAL_ROLES = hashSetOf("section-151-officers")
+
+@Serializable
+data class LdapUserWithRoles(val user: LdapUser, val roles: MemberOfToDeltaRolesMapper.Roles)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserLookupService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserLookupService.kt
@@ -38,7 +38,7 @@ class UserLookupService(
         }
     }
 
-    suspend fun lookupUserByCNAndLoadRoles(cn: String): UserWithRoles = coroutineScope {
+    suspend fun lookupUserByCNAndLoadRoles(cn: String): LdapUserWithRoles = coroutineScope {
         val user = async { lookupUserByCn(cn) }
         val allOrganisations = async { organisationService.findAllNamesAndCodes() }
         val allAccessGroups = async { accessGroupsService.getAllAccessGroups() }
@@ -50,8 +50,6 @@ class UserLookupService(
             allAccessGroups.await()
         ).map(awaitedUser.memberOfCNs)
 
-        UserWithRoles(awaitedUser, roles)
+        LdapUserWithRoles(awaitedUser, roles)
     }
-
-    data class UserWithRoles(val user: LdapUser, val roles: MemberOfToDeltaRolesMapper.Roles)
 }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/helper/MockUserLookupService.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/helper/MockUserLookupService.kt
@@ -2,10 +2,7 @@ package uk.gov.communities.delta.helper
 
 import io.mockk.coEvery
 import uk.gov.communities.delta.auth.repositories.LdapUser
-import uk.gov.communities.delta.auth.services.AccessGroup
-import uk.gov.communities.delta.auth.services.MemberOfToDeltaRolesMapper
-import uk.gov.communities.delta.auth.services.OrganisationNameAndCode
-import uk.gov.communities.delta.auth.services.UserLookupService
+import uk.gov.communities.delta.auth.services.*
 import javax.naming.NameNotFoundException
 
 fun mockUserLookupService(
@@ -25,7 +22,7 @@ fun mockUserLookupService(
                 user.cn
             )
         } coAnswers {
-            UserLookupService.UserWithRoles(
+            LdapUserWithRoles(
                 user,
                 MemberOfToDeltaRolesMapper(
                     user.cn, organisations, accessGroups

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/helper/MockUserLookupService.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/helper/MockUserLookupService.kt
@@ -1,0 +1,36 @@
+package uk.gov.communities.delta.helper
+
+import io.mockk.coEvery
+import uk.gov.communities.delta.auth.repositories.LdapUser
+import uk.gov.communities.delta.auth.services.AccessGroup
+import uk.gov.communities.delta.auth.services.MemberOfToDeltaRolesMapper
+import uk.gov.communities.delta.auth.services.OrganisationNameAndCode
+import uk.gov.communities.delta.auth.services.UserLookupService
+import javax.naming.NameNotFoundException
+
+fun mockUserLookupService(
+    service: UserLookupService,
+    users: List<LdapUser>,
+    organisations: List<OrganisationNameAndCode>,
+    accessGroups: List<AccessGroup>,
+) {
+    coEvery { service.lookupUserByCn(any()) } throws NameNotFoundException()
+    coEvery { service.lookupUserByDN(any()) } throws NameNotFoundException()
+    coEvery { service.lookupUserByCNAndLoadRoles(any()) } throws NameNotFoundException()
+    for (user in users) {
+        coEvery { service.lookupUserByCn(user.cn) } returns user
+        coEvery { service.lookupUserByDN(user.dn) } returns user
+        coEvery {
+            service.lookupUserByCNAndLoadRoles(
+                user.cn
+            )
+        } coAnswers {
+            UserLookupService.UserWithRoles(
+                user,
+                MemberOfToDeltaRolesMapper(
+                    user.cn, organisations, accessGroups
+                ).map(user.memberOfCNs)
+            )
+        }
+    }
+}

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/service/UserLookupServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/service/UserLookupServiceTest.kt
@@ -1,0 +1,76 @@
+package uk.gov.communities.delta.service
+
+import io.ktor.test.dispatcher.*
+import io.mockk.*
+import org.junit.BeforeClass
+import uk.gov.communities.delta.auth.repositories.LdapRepository
+import uk.gov.communities.delta.auth.repositories.LdapUser
+import uk.gov.communities.delta.auth.services.*
+import uk.gov.communities.delta.helper.testLdapUser
+import javax.naming.ldap.InitialLdapContext
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class UserLookupServiceTest {
+
+    @Test
+    fun testLookupUser() = testSuspend {
+        val testUser = testLdapUser()
+        every { ldapRepository.mapUserFromContext(any(), "CN=some!user") } returns testUser
+        val result = userLookupService.lookupUserByCn("some!user")
+        assertTrue { testUser === result }
+    }
+
+    @Test
+    fun testMapUser() = testSuspend {
+        val testUser = testLdapUser(memberOfCNs = listOf("datamart-delta-user", "datamart-delta-user-orgCode1", "datamart-delta-access-group-1"))
+        every { ldapRepository.mapUserFromContext(any(), "CN=some!user") } returns testUser
+
+        val result = userLookupService.lookupUserByCNAndLoadRoles("some!user")
+        assertTrue { testUser === result.user }
+        assertEquals(DeltaSystemRole.USER, result.roles.systemRoles.single().role)
+        assertEquals("orgCode1", result.roles.organisations.single().code)
+        assertEquals("access-group-1", result.roles.accessGroups.single().name)
+    }
+
+    @BeforeTest
+    fun resetMocks() {
+        clearAllMocks()
+        val block = slot<(InitialLdapContext) -> LdapUser>()
+        coEvery { ldapServiceUserBind.useServiceUserBind(capture(block)) } coAnswers { block.invoke(mockk<InitialLdapContext>()) }
+
+        coEvery { organisationService.findAllNamesAndCodes() } returns listOf(
+            OrganisationNameAndCode("orgCode1", "Organisation Name 1"),
+        )
+        coEvery { accessGroupsService.getAllAccessGroups() } returns listOf(
+            AccessGroup("access-group-1", null, null, true, true),
+        )
+    }
+
+    companion object {
+        private lateinit var organisationService: OrganisationService
+        private lateinit var accessGroupsService: AccessGroupsService
+        private lateinit var ldapRepository: LdapRepository
+        private lateinit var ldapServiceUserBind: LdapServiceUserBind
+        private lateinit var userLookupService: UserLookupService
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            organisationService = mockk<OrganisationService>()
+            accessGroupsService = mockk<AccessGroupsService>()
+            ldapRepository = mockk<LdapRepository>()
+            ldapServiceUserBind = mockk<LdapServiceUserBind>()
+            userLookupService = UserLookupService(
+                "CN=%s",
+                ldapServiceUserBind,
+                ldapRepository,
+                organisationService,
+                accessGroupsService,
+                ::MemberOfToDeltaRolesMapper
+            )
+        }
+    }
+}


### PR DESCRIPTION
Add a new function to UserLookupService that reads the user from AD and then interprets its roles, access groups etc.

This simplifies a few code paths that previously had to read all organisations and access groups and then call the roles mapper. It hasn't helped as much as I'd hoped, but it should also be easier to migrate to a database where we wouldn't need the list of all organisations and access groups to load a user's roles.