### PR TITLE
Dt 896 notification status changes in auth service

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -309,6 +309,11 @@ class Injection(
         userAuditService,
     )
 
+    fun adminEditUserNotificationStatusController() = AdminEditUserNotificationStatusController(
+        userLookupService,
+        userService,
+    )
+
     fun editAccessGroupsController() = EditAccessGroupsController(
         userLookupService,
         groupService,

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
@@ -297,7 +297,7 @@ fun Route.bearerTokenRoutes(
             post("/admin/disable-user") {
                 adminEnableDisableUserController.disableUser(call)
             }
-            route("/update-user-notifications") {
+            route("/admin/update-notification-status") {
                 adminEditUserNotificationStatusController.route(this)
             }
             route("/roles") {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
@@ -204,6 +204,7 @@ fun Route.internalRoutes(injection: Injection) {
     val adminGetUserController = injection.adminGetUserController()
     val adminEditEmailController = injection.adminEditEmailController()
     val adminEnableDisableUserController = injection.adminEnableDisableUserController()
+    val adminEditUserNotificationStatusController = injection.adminEditUserNotificationStatusController()
     val editRolesController = injection.editRolesController()
     val editOrganisationsController = injection.editOrganisationsController()
     val editAccessGroupsController = injection.editAccessGroupsController()
@@ -223,6 +224,7 @@ fun Route.internalRoutes(injection: Injection) {
             adminGetUserController,
             adminEditEmailController,
             adminEnableDisableUserController,
+            adminEditUserNotificationStatusController,
             editRolesController,
             editOrganisationsController,
             editAccessGroupsController,
@@ -257,6 +259,7 @@ fun Route.bearerTokenRoutes(
     adminGetUserController: AdminGetUserController,
     adminEditUserEmailController: AdminEditUserEmailController,
     adminEnableDisableUserController: AdminEnableDisableUserController,
+    adminEditUserNotificationStatusController: AdminEditUserNotificationStatusController,
     editRolesController: EditRolesController,
     editOrganisationsController: EditOrganisationsController,
     editAccessGroupsController: EditAccessGroupsController,
@@ -293,6 +296,9 @@ fun Route.bearerTokenRoutes(
             }
             post("/admin/disable-user") {
                 adminEnableDisableUserController.disableUser(call)
+            }
+            route("/update-user-notifications") {
+                adminEditUserNotificationStatusController.route(this)
             }
             route("/roles") {
                 editRolesController.route(this)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminEditUserNotificationStatusController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminEditUserNotificationStatusController.kt
@@ -1,0 +1,44 @@
+package uk.gov.communities.delta.auth.controllers.internal
+
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.slf4j.LoggerFactory
+import uk.gov.communities.delta.auth.services.DeltaSystemRole
+import uk.gov.communities.delta.auth.services.UserLookupService
+import uk.gov.communities.delta.auth.services.UserService
+
+class AdminEditUserNotificationStatusController(
+    private val userLookupService: UserLookupService,
+    private val userService: UserService,
+) : AdminUserController(userLookupService) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    fun route(route: Route) {
+        route.post { updateUserNotifications(call) }
+    }
+
+    private suspend fun updateUserNotifications(call: ApplicationCall) {
+        val session = getSessionIfUserHasPermittedRole(
+            arrayOf(DeltaSystemRole.ADMIN, DeltaSystemRole.READ_ONLY_ADMIN), call
+        )
+
+        val requestData = call.receive<DeltaChangeNotificationStatusRequest>()
+
+        val userToEdit = userLookupService.lookupUserByCn(requestData.userToEditCn)
+        logger.atInfo().log("Updating notification status for user {} to {}", userToEdit.cn, requestData.enableNotifications)
+
+        userService.updateNotificationStatus(userToEdit, requestData.enableNotifications, session, call)
+        return call.respond(mapOf("message" to "Notification status has been updated."))
+    }
+
+    @Serializable
+    data class DeltaChangeNotificationStatusRequest(
+        val userToEditCn: String,
+        val enableNotifications: Boolean,
+    )
+}

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserService.kt
@@ -84,6 +84,28 @@ class UserService(
         auditUserUpdate(ldapUser.cn, triggeringAdminSession, call, auditMap)
     }
 
+    suspend fun updateNotificationStatus(
+        ldapUser: LdapUser,
+        notificationsActive: Boolean,
+        triggeringAdminSession: OAuthSession?,
+        call: ApplicationCall,
+    ) {
+        val newStatus = if (notificationsActive) "active" else "inactive"
+        try {
+            val statusModification = ModificationItem(DirContext.REPLACE_ATTRIBUTE, BasicAttribute("st", newStatus))
+            val modificationArray = arrayOf(statusModification)
+            ldapServiceUserBind.useServiceUserBind {
+                it.modifyAttributes(ldapUser.dn, modificationArray)
+                logger.atInfo().addKeyValue("NewSt", newStatus).log("Notification status updated")
+            }
+        } catch (e: Exception) {
+            logger.atError().addKeyValue("UserSt", newStatus).log("Error changing notification status", e)
+            throw e
+        }
+        val auditMap = mapOf("st" to newStatus)
+        auditUserUpdate(ldapUser.cn, triggeringAdminSession, call, auditMap)
+    }
+
     private suspend fun auditUserCreation(
         userCN: String,
         ssoClient: AzureADSSOClient?,

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEditUserNotificationStatusControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEditUserNotificationStatusControllerTest.kt
@@ -1,0 +1,190 @@
+package uk.gov.communities.delta.controllers
+
+import io.ktor.client.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import io.ktor.server.auth.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import io.ktor.test.dispatcher.*
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import org.junit.*
+import uk.gov.communities.delta.auth.config.DeltaConfig
+import uk.gov.communities.delta.auth.controllers.internal.AdminEditUserNotificationStatusController
+import uk.gov.communities.delta.auth.plugins.ApiError
+import uk.gov.communities.delta.auth.plugins.configureSerialization
+import uk.gov.communities.delta.auth.security.*
+import uk.gov.communities.delta.auth.services.*
+import uk.gov.communities.delta.auth.withBearerTokenAuth
+import uk.gov.communities.delta.helper.testLdapUser
+import uk.gov.communities.delta.helper.testServiceClient
+import java.time.Instant
+import kotlin.test.assertEquals
+
+class AdminEditUserNotificationStatusControllerTest {
+
+    @Test
+    fun fullAdminCanUpdateUserNotificationStatus() = testSuspend {
+        testClient.post("/admin/update-notification-status") {
+            headers {
+                append("Authorization", "Bearer ${fullAdminSession.authToken}")
+                append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+            }
+            contentType(ContentType.Application.Json)
+            setBody("{\"userToEditCn\": \"test!user.com\", " +
+                "\"enableNotifications\": true}")
+        }.apply {
+            assertEquals(HttpStatusCode.OK, status)
+            coVerify(exactly = 1) {
+                userService.updateNotificationStatus(userToUpdate, true, fullAdminSession, any())
+            }
+            confirmVerified(userService)
+        }
+    }
+
+    @Test
+    fun readOnlyAdminCanUpdateUserNotificationStatus() = testSuspend {
+        testClient.post("/admin/update-notification-status") {
+            headers {
+                append("Authorization", "Bearer ${readOnlyAdminSession.authToken}")
+                append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+            }
+            contentType(ContentType.Application.Json)
+            setBody("{\"userToEditCn\": \"test!user.com\", " +
+                "\"enableNotifications\": false}")
+        }.apply {
+            assertEquals(HttpStatusCode.OK, status)
+            coVerify(exactly = 1) {
+                userService.updateNotificationStatus(userToUpdate, false, readOnlyAdminSession, any())
+            }
+            confirmVerified(userService)
+        }
+    }
+
+    @Test
+    fun nonAdminCannotUpdateEmail() = testSuspend {
+        Assert.assertThrows(ApiError::class.java) {
+            runBlocking {
+                testClient.post("/admin/update-notification-status") {
+                    headers {
+                        append("Authorization", "Bearer ${nonAdminSession.authToken}")
+                        append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+                    }
+                    contentType(ContentType.Application.Json)
+                    setBody("{\"userToEditCn\": \"test!user.com\", " +
+                        "\"enableNotifications\": false}")
+                }
+            }
+        }.apply {
+            assertEquals("forbidden", errorCode)
+            confirmVerified(userService)
+        }
+    }
+
+    @Before
+    fun resetMocks() {
+        clearAllMocks()
+        coEvery {
+            oauthSessionService.retrieveFomAuthToken(
+                fullAdminSession.authToken,
+                client
+            )
+        } answers { fullAdminSession }
+        coEvery {
+            oauthSessionService.retrieveFomAuthToken(
+                readOnlyAdminSession.authToken,
+                client
+            )
+        } answers { readOnlyAdminSession }
+        coEvery {
+            oauthSessionService.retrieveFomAuthToken(
+                nonAdminSession.authToken,
+                client
+            )
+        } answers { nonAdminSession }
+        coEvery { userLookupService.lookupUserByCn(fullAdminUser.cn) } returns fullAdminUser
+        coEvery { userLookupService.lookupUserByCn(readOnlyAdminUser.cn) } returns readOnlyAdminUser
+        coEvery { userLookupService.lookupUserByCn(nonAdminUser.cn) } returns nonAdminUser
+        coEvery { userLookupService.lookupUserByCn(userToUpdate.cn) } returns userToUpdate
+        coEvery { userService.updateNotificationStatus(userToUpdate, any(), any(), any()) } just runs
+    }
+
+    companion object {
+        private lateinit var testApp: TestApplication
+        private lateinit var testClient: HttpClient
+        private lateinit var controller: AdminEditUserNotificationStatusController
+
+        private val oauthSessionService = mockk<OAuthSessionService>()
+
+        private val userLookupService = mockk<UserLookupService>()
+        private val userService = mockk<UserService>()
+
+        private val client = testServiceClient()
+
+        private val fullAdminUser = testLdapUser(cn = "admin", memberOfCNs = listOf(DeltaConfig.DATAMART_DELTA_ADMIN))
+        private val readOnlyAdminUser = testLdapUser(cn = "readonlyadmin", memberOfCNs = listOf(DeltaConfig.DATAMART_DELTA_READ_ONLY_ADMIN))
+        private val nonAdminUser = testLdapUser(cn = "nonadmin", memberOfCNs = listOf(DeltaConfig.DATAMART_DELTA_USER))
+
+        private val userToUpdate = testLdapUser(
+            cn = "test!user.com",
+            email = "test@user.com",
+            memberOfCNs = listOf(
+                DeltaConfig.DATAMART_DELTA_USER,
+            ),
+        )
+
+        private val fullAdminSession = OAuthSession(1, fullAdminUser.cn, client, "fullAdminToken", Instant.now(), "trace", false)
+        private val readOnlyAdminSession = OAuthSession(1, readOnlyAdminUser.cn, client, "readOnlyAdminToken", Instant.now(), "trace", false)
+        private val nonAdminSession = OAuthSession(1, nonAdminUser.cn, client, "nonAdminToken", Instant.now(), "trace", false)
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            controller = AdminEditUserNotificationStatusController(
+                userLookupService,
+                userService,
+            )
+
+            testApp = TestApplication {
+                application {
+                    configureSerialization()
+                    authentication {
+                        bearer(OAUTH_ACCESS_BEARER_TOKEN_AUTH_NAME) {
+                            realm = "auth-service"
+                            authenticate { oauthSessionService.retrieveFomAuthToken(it.token,
+                                client
+                            ) }
+                        }
+                        clientHeaderAuth(CLIENT_HEADER_AUTH_NAME) {
+                            headerName = "Delta-Client"
+                            clients = listOf(testServiceClient())
+                        }
+                    }
+                    routing {
+                        withBearerTokenAuth {
+                            route("/admin/update-user-notifications") {
+                                controller.route(this)
+                            }
+                        }
+                    }
+                }
+            }
+
+            testClient = testApp.createClient {
+                install(ContentNegotiation) {
+                    json()
+                }
+                followRedirects = false
+            }
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDown() {
+            testApp.stop()
+        }
+    }
+}


### PR DESCRIPTION
**Description** Auth service endpoint to update notification status in AD.

**Local testing** Local automated tests. It also works when used as the endpoint for the Delta user details page.

**Release** I assume no release changes.
