### PR TITLE
DT-983 new endpoint for MFA reset plus tests

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -314,6 +314,11 @@ class Injection(
         userAuditService,
     )
 
+    fun adminResetMfaTokenController() = AdminResetMfaTokenController(
+        userLookupService,
+        userService,
+    )
+
     fun editAccessGroupsController() = EditAccessGroupsController(
         userLookupService,
         groupService,

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
@@ -204,6 +204,7 @@ fun Route.internalRoutes(injection: Injection) {
     val adminGetUserController = injection.adminGetUserController()
     val adminEditEmailController = injection.adminEditEmailController()
     val adminEnableDisableUserController = injection.adminEnableDisableUserController()
+    val adminResetMfaTokenController = injection.adminResetMfaTokenController()
     val editRolesController = injection.editRolesController()
     val editOrganisationsController = injection.editOrganisationsController()
     val editAccessGroupsController = injection.editAccessGroupsController()
@@ -223,6 +224,7 @@ fun Route.internalRoutes(injection: Injection) {
             adminGetUserController,
             adminEditEmailController,
             adminEnableDisableUserController,
+            adminResetMfaTokenController,
             editRolesController,
             editOrganisationsController,
             editAccessGroupsController,
@@ -257,6 +259,7 @@ fun Route.bearerTokenRoutes(
     adminGetUserController: AdminGetUserController,
     adminEditUserEmailController: AdminEditUserEmailController,
     adminEnableDisableUserController: AdminEnableDisableUserController,
+    adminResetMfaTokenController: AdminResetMfaTokenController,
     editRolesController: EditRolesController,
     editOrganisationsController: EditOrganisationsController,
     editAccessGroupsController: EditAccessGroupsController,
@@ -293,6 +296,9 @@ fun Route.bearerTokenRoutes(
             }
             post("/admin/disable-user") {
                 adminEnableDisableUserController.disableUser(call)
+            }
+            route("/admin/reset-mfa-token") {
+                adminResetMfaTokenController.route(this)
             }
             route("/roles") {
                 editRolesController.route(this)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminResetMfaTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminResetMfaTokenController.kt
@@ -1,0 +1,46 @@
+package uk.gov.communities.delta.auth.controllers.internal
+
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import kotlinx.serialization.Serializable
+import org.slf4j.LoggerFactory
+import uk.gov.communities.delta.auth.services.DeltaSystemRole
+import uk.gov.communities.delta.auth.services.UserLookupService
+import uk.gov.communities.delta.auth.services.UserService
+
+class AdminResetMfaTokenController (
+    private val userLookupService: UserLookupService,
+    private val userService: UserService,
+) : AdminUserController(userLookupService) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    fun route(route: Route) {
+        route.post { resetUserMfaToken(call) }
+    }
+
+    private suspend fun resetUserMfaToken(call: ApplicationCall) {
+        val session = getSessionIfUserHasPermittedRole(
+            arrayOf(DeltaSystemRole.ADMIN), call
+        )
+
+        val requestData = call.receive<DeltaResetMfaTokenRequest>()
+
+        val userToEdit = userLookupService.lookupUserByCn(requestData.userToEditCn)
+        logger.atInfo().log("Resetting MFA token for user {}", userToEdit.cn)
+
+        if (userToEdit.deltaTOTPSecret.isNullOrEmpty()) {
+            return call.respond(mapOf("message" to "User MFA token already reset."))
+        }
+
+        userService.resetMfaToken(userToEdit, session, call)
+        return call.respond(mapOf("message" to "MFA token has been updated."))
+    }
+
+    @Serializable
+    data class DeltaResetMfaTokenRequest(
+        val userToEditCn: String,
+    )
+}

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserService.kt
@@ -307,10 +307,10 @@ class UserService(
             val modificationArray = arrayOf(modificationItem)
             ldapServiceUserBind.useServiceUserBind {
                 it.modifyAttributes(userToReset.dn, modificationArray)
-                logger.atInfo().addKeyValue("unixHomeDirectory", "").log("MFA token deleted")
+                logger.atInfo().addKeyValue("userToResetCn", userToReset.cn).log("MFA token deleted")
             }
         } catch (e: Exception) {
-            logger.atError().addKeyValue("unixHomeDirectory", "").log("Error deleted MFA token", e)
+            logger.atError().addKeyValue("userToResetCn", userToReset.cn).log("Error deleting MFA token", e)
             throw e
         }
         val auditMap = mapOf("unixHomeDirectory" to "")

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminResetMfaTokenControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminResetMfaTokenControllerTest.kt
@@ -31,7 +31,7 @@ import java.time.Instant
 import kotlin.test.assertEquals
 
 class AdminResetMfaTokenControllerTest {
-    
+
     @Test
     fun adminCanResetUserMfaToken() = testSuspend {
         testClient.post("/admin/reset-mfa-token") {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminResetMfaTokenControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminResetMfaTokenControllerTest.kt
@@ -1,0 +1,170 @@
+package uk.gov.communities.delta.controllers
+
+import io.ktor.client.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.http.headers
+import io.ktor.serialization.kotlinx.json.*
+import io.ktor.server.auth.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import io.ktor.test.dispatcher.*
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import org.junit.*
+import uk.gov.communities.delta.auth.config.DeltaConfig
+import uk.gov.communities.delta.auth.controllers.internal.AdminResetMfaTokenController
+import uk.gov.communities.delta.auth.plugins.ApiError
+import uk.gov.communities.delta.auth.plugins.configureSerialization
+import uk.gov.communities.delta.auth.security.CLIENT_HEADER_AUTH_NAME
+import uk.gov.communities.delta.auth.security.OAUTH_ACCESS_BEARER_TOKEN_AUTH_NAME
+import uk.gov.communities.delta.auth.security.clientHeaderAuth
+import uk.gov.communities.delta.auth.services.OAuthSession
+import uk.gov.communities.delta.auth.services.OAuthSessionService
+import uk.gov.communities.delta.auth.services.UserLookupService
+import uk.gov.communities.delta.auth.services.UserService
+import uk.gov.communities.delta.auth.withBearerTokenAuth
+import uk.gov.communities.delta.helper.testLdapUser
+import uk.gov.communities.delta.helper.testServiceClient
+import java.time.Instant
+import kotlin.test.assertEquals
+
+class AdminResetMfaTokenControllerTest {
+    @Test
+    fun adminCanResetUserMfaToken() = testSuspend {
+        testClient.post("/admin/reset-mfa-token") {
+            headers {
+                append("Authorization", "Bearer ${adminSession.authToken}")
+                append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+            }
+            contentType(ContentType.Application.Json)
+            setBody("{\"userToEditCn\": \"test!user.com\"}")
+        }.apply {
+            assertEquals(HttpStatusCode.OK, status)
+            coVerify(exactly = 1) {
+                userService.resetMfaToken(userToUpdate, adminSession, any())
+            }
+            confirmVerified(userService)
+        }
+    }
+    @Test
+    fun nonAdminCannotResetUserMfaToken() = testSuspend {
+        Assert.assertThrows(ApiError::class.java) {
+            runBlocking {
+                testClient.post("/admin/reset-mfa-token") {
+                    headers {
+                        append("Authorization", "Bearer ${nonFullAdminSession.authToken}")
+                        append("Delta-Client", "${client.clientId}:${client.clientSecret}")
+                    }
+                    contentType(ContentType.Application.Json)
+                    setBody("{\"userToEditCn\": \"test!user.com\"}")
+                }
+            }
+        }.apply {
+            assertEquals("forbidden", errorCode)
+            confirmVerified(userService)
+        }
+    }
+
+    @Before
+    fun resetMocks() {
+        clearAllMocks()
+        coEvery {
+            oauthSessionService.retrieveFomAuthToken(
+                adminSession.authToken,
+                client
+            )
+        } answers { adminSession }
+        coEvery {
+            oauthSessionService.retrieveFomAuthToken(
+                nonFullAdminSession.authToken,
+                client
+            )
+        } answers { nonFullAdminSession }
+        coEvery { userLookupService.lookupUserByCn(adminUser.cn) } returns adminUser
+        coEvery { userLookupService.lookupUserByCn(nonFullAdminUser.cn) } returns nonFullAdminUser
+        coEvery { userLookupService.lookupUserByCn(userToUpdate.cn) } returns userToUpdate
+        coEvery { userService.resetMfaToken(userToUpdate, any(), any()) } just runs
+    }
+
+    companion object {
+        private lateinit var testApp: TestApplication
+        private lateinit var testClient: HttpClient
+        private lateinit var controller: AdminResetMfaTokenController
+
+        private val oauthSessionService = mockk<OAuthSessionService>()
+
+        private val userLookupService = mockk<UserLookupService>()
+        private val userService = mockk<UserService>()
+
+        private val client = testServiceClient()
+
+        private val adminUser = testLdapUser(cn = "admin", memberOfCNs = listOf(DeltaConfig.DATAMART_DELTA_ADMIN))
+        private val nonFullAdminUser = testLdapUser(cn = "nonFullAdmin", memberOfCNs = listOf(
+            DeltaConfig.DATAMART_DELTA_READ_ONLY_ADMIN,
+            DeltaConfig.DATAMART_DELTA_USER,
+            DeltaConfig.DATAMART_DELTA_INTERNAL_USER,
+            DeltaConfig.DATAMART_DELTA_REPORT_USERS
+        ))
+
+        private val userToUpdate = testLdapUser(
+            cn = "test!user.com",
+            email = "test@user.com",
+            memberOfCNs = listOf(
+                DeltaConfig.DATAMART_DELTA_USER,
+            ),
+        )
+
+        private val adminSession = OAuthSession(1, adminUser.cn, client, "adminToken", Instant.now(), "trace", false)
+        private val nonFullAdminSession = OAuthSession(1, nonFullAdminUser.cn, client, "readOnlyAdminToken", Instant.now(), "trace", false)
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            controller = AdminResetMfaTokenController(
+                userLookupService,
+                userService,
+            )
+
+            testApp = TestApplication {
+                application {
+                    configureSerialization()
+                    authentication {
+                        bearer(OAUTH_ACCESS_BEARER_TOKEN_AUTH_NAME) {
+                            realm = "auth-service"
+                            authenticate { oauthSessionService.retrieveFomAuthToken(it.token,
+                                client
+                            ) }
+                        }
+                        clientHeaderAuth(CLIENT_HEADER_AUTH_NAME) {
+                            headerName = "Delta-Client"
+                            clients = listOf(testServiceClient())
+                        }
+                    }
+                    routing {
+                        withBearerTokenAuth {
+                            route("/admin/reset-mfa-token") {
+                                controller.route(this)
+                            }
+                        }
+                    }
+                }
+            }
+
+            testClient = testApp.createClient {
+                install(ContentNegotiation) {
+                    json()
+                }
+                followRedirects = false
+            }
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDown() {
+            testApp.stop()
+        }
+
+    }
+}

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminResetMfaTokenControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminResetMfaTokenControllerTest.kt
@@ -31,6 +31,7 @@ import java.time.Instant
 import kotlin.test.assertEquals
 
 class AdminResetMfaTokenControllerTest {
+    
     @Test
     fun adminCanResetUserMfaToken() = testSuspend {
         testClient.post("/admin/reset-mfa-token") {
@@ -48,6 +49,7 @@ class AdminResetMfaTokenControllerTest {
             confirmVerified(userService)
         }
     }
+
     @Test
     fun nonAdminCannotResetUserMfaToken() = testSuspend {
         Assert.assertThrows(ApiError::class.java) {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminResetMfaTokenControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminResetMfaTokenControllerTest.kt
@@ -116,6 +116,7 @@ class AdminResetMfaTokenControllerTest {
             memberOfCNs = listOf(
                 DeltaConfig.DATAMART_DELTA_USER,
             ),
+            deltaTOTPSecret = "TopOfThePops"
         )
 
         private val adminSession = OAuthSession(1, adminUser.cn, client, "adminToken", Instant.now(), "trace", false)


### PR DESCRIPTION
**Description** Auth service side of putting MFA reset in the auth service.

**Local testing** Local testing for controller, and service method worked in E2E testing.

**Release** No extra release steps or documentation changes that I am aware of.
