### PR TITLE
Add CloudWatch alarm on large number of error logs

### DIFF
--- a/terraform/modules/auth_service/monitoring.tf
+++ b/terraform/modules/auth_service/monitoring.tf
@@ -151,3 +151,22 @@ Review the ${module.fargate.log_group_name} log group.
   alarm_actions     = [var.alarms_sns_topic_arn]
   ok_actions        = [var.alarms_sns_topic_arn]
 }
+
+resource "aws_cloudwatch_metric_alarm" "error_log_count_high" {
+  alarm_name          = "auth-${var.environment}-error-log-count-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = local.metric_error_log_filter
+  namespace           = local.auth_metrics_namespace
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 10
+  treat_missing_data  = "notBreaching"
+
+  alarm_description = <<EOF
+There are an unsually high number of errors being logged by the auth service.
+Review the ${module.fargate.log_group_name} log group, you may want to apply the filter "level = 'ERROR'".
+  EOF
+  alarm_actions     = [var.alarms_sns_topic_arn]
+  ok_actions        = [var.alarms_sns_topic_arn]
+}


### PR DESCRIPTION
**Description** Add an alarm based on the "ERROR" level logs metric filter. This might be too noisy at the current threshold, but let's see, hopefully it will help us keep the logs nice and clean too.

**Local testing** Applied to test, looks OK though I haven't tried to set it off.

**Release** Terraform part of normal release process.
