### PR TITLE
DT-696 DCLG update emails correctly ignore changes to other organisation access group membership

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/AccessGroupDCLGMembershipUpdateEmailService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/AccessGroupDCLGMembershipUpdateEmailService.kt
@@ -76,13 +76,14 @@ class AccessGroupDCLGMembershipUpdateEmailService(
             return
         }
 
-        val previousDCLGGroups = previousAccessGroups.filter { it.organisationIds.contains("dclg") }.toSet()
-        val newDCLGGroups = newAccessGroups.filter { it.organisationIds.contains("dclg") }.toSet()
+        val previousDCLGGroupNames = previousAccessGroups.filter { it.organisationIds.contains("dclg") }
+            .map { it.name }.toSet()
+        val newDCLGGroups = newAccessGroups.filter { it.organisationIds.contains("dclg") }
 
-        val newGroups = newDCLGGroups - previousDCLGGroups
-        if (newGroups.isEmpty()) return
+        val addedGroups = newDCLGGroups.filter { !previousDCLGGroupNames.contains(it.name) }
+        if (addedGroups.isEmpty()) return
 
-        launchSendEmailJob(user, actingUser, newGroups.map { AccessGroup(it.name, it.displayName) })
+        launchSendEmailJob(user, actingUser, addedGroups.map { AccessGroup(it.name, it.displayName) })
     }
 
     private fun launchSendEmailJob(user: UpdatedUser, actingUser: LdapUser, addedGroups: Collection<AccessGroup>) {


### PR DESCRIPTION
Previously the comparison included the list of organisation ids, so adding a new organisation to an access group that already had dclg for a user would trigger an email.