### PR TITLE
Dt 836 move API authentication to the auth service

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -77,7 +77,6 @@ class Injection(
     val dbPool = DbPool(databaseConfig)
 
     private val samlTokenService = SAMLTokenService()
-    private val deltaApiTokenService = DeltaApiTokenService(dbPool, TimeSource.System)
     private val ldapRepository = LdapRepository(ldapConfig, LdapRepository.ObjectGUIDMode.NEW_JAVA_UUID_STRING)
     private val ldapServiceUserBind = LdapServiceUserBind(ldapConfig, ldapRepository)
 
@@ -101,6 +100,8 @@ class Injection(
         ::MemberOfToDeltaRolesMapper
     )
     private val userService = UserService(ldapServiceUserBind, userLookupService, userAuditService, ldapConfig)
+
+    private val deltaApiTokenService = DeltaApiTokenService(dbPool, TimeSource.System, userLookupService, userAuditService)
 
     private val emailService = EmailService(
         emailConfig,

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -240,7 +240,6 @@ class Injection(
         ::MemberOfToDeltaRolesMapper
     )
 
-    // TODO 836 find out why this is done this way and if I should do this here
     fun externalDeltaApiTokenController(): ExternalDeltaApiTokenController {
         val adLoginService = ADLdapLoginService(
             ADLdapLoginService.Configuration(ldapConfig.deltaUserDnFormat),

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -101,7 +101,7 @@ class Injection(
     )
     private val userService = UserService(ldapServiceUserBind, userLookupService, userAuditService, ldapConfig)
 
-    private val deltaApiTokenService = DeltaApiTokenService(dbPool, TimeSource.System, userLookupService, userAuditService)
+    private val deltaApiTokenService = DeltaApiTokenService(dbPool, TimeSource.System, userAuditService)
 
     private val emailService = EmailService(
         emailConfig,

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -74,11 +74,12 @@ class Injection(
         Runtime.getRuntime().addShutdownHook(Thread { close() })
     }
 
+    val dbPool = DbPool(databaseConfig)
+
     private val samlTokenService = SAMLTokenService()
+    private val deltaApiTokenService = DeltaApiTokenService(dbPool)
     private val ldapRepository = LdapRepository(ldapConfig, LdapRepository.ObjectGUIDMode.NEW_JAVA_UUID_STRING)
     private val ldapServiceUserBind = LdapServiceUserBind(ldapConfig, ldapRepository)
-
-    val dbPool = DbPool(databaseConfig)
 
     val userAuditTrailRepo = UserAuditTrailRepo()
     val userAuditService = UserAuditService(userAuditTrailRepo, dbPool)
@@ -238,6 +239,10 @@ class Injection(
         organisationService,
         ::MemberOfToDeltaRolesMapper
     )
+
+    fun externalDeltaApiTokenController() = ExternalDeltaApiTokenController(deltaApiTokenService)
+
+    fun internalDeltaApiTokenController() = InternalDeltaApiTokenController(deltaApiTokenService)
 
     fun refreshUserInfoController() = RefreshUserInfoController(
         userLookupService,

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -157,8 +157,9 @@ class Injection(
     fun tasksMap(): Map<String, AuthServiceTask> {
         val deleteOldAuthCodesTask = DeleteOldAuthCodes(dbPool)
         val deleteOldDeltaSessionsTask = DeleteOldDeltaSessions(dbPool)
+        val deleteOldApiTokensTask = DeleteOldApiTokens(dbPool)
         val updateUserGuidMapTask = UpdateUserGUIDMap(ldapConfig, dbPool)
-        val tasks = listOf(deleteOldAuthCodesTask, deleteOldDeltaSessionsTask, updateUserGuidMapTask)
+        val tasks = listOf(deleteOldAuthCodesTask, deleteOldDeltaSessionsTask, deleteOldApiTokensTask, updateUserGuidMapTask)
         return tasks.associateBy { it.name }
     }
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
@@ -250,11 +250,13 @@ fun Route.deltaApiRoutes(
     externalDeltaApiTokenController: ExternalDeltaApiTokenController,
     internalDeltaApiTokenController: InternalDeltaApiTokenController,
 ) {
-    post("/delta-api/token") {
-        externalDeltaApiTokenController.createApiToken(call)
+    route("/delta-api/oauth/token") {
+        externalDeltaApiTokenController.route(this)
     }
-    post("/internal/delta-api/validate") {
-        internalDeltaApiTokenController.validateApiRequest(call)
+    authenticate(CLIENT_HEADER_AUTH_NAME, strategy = AuthenticationStrategy.Required) {
+        route("/internal/delta-api/validate") {
+            internalDeltaApiTokenController.route(this)
+        }
     }
 }
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
@@ -43,6 +43,10 @@ fun Application.configureRouting(injection: Injection) {
             injection.externalDeltaResetPasswordController(),
             injection.externalDeltaForgotPasswordController(),
         )
+        deltaApiRoutes(
+            injection.externalDeltaApiTokenController(),
+            injection.internalDeltaApiTokenController(),
+        )
     }
 }
 
@@ -196,8 +200,6 @@ fun oauthClientCallbackRoute(ssoClientInternalId: String) = "/delta/oauth/${ssoC
 fun Route.internalRoutes(injection: Injection) {
     val generateSAMLTokenController = injection.generateSAMLTokenController()
     val oauthTokenController = injection.internalOAuthTokenController()
-    val externalDeltaApiTokenController = injection.externalDeltaApiTokenController()
-    val internalDeltaApiTokenController = injection.internalDeltaApiTokenController()
     val refreshUserInfoController = injection.refreshUserInfoController()
     val fetchUserAuditController = injection.fetchUserAuditController()
     val adminEmailController = injection.adminEmailController()
@@ -217,11 +219,6 @@ fun Route.internalRoutes(injection: Injection) {
         serviceUserRoutes(generateSAMLTokenController)
 
         oauthTokenRoute(oauthTokenController)
-
-        deltaApiRoutes(
-            externalDeltaApiTokenController,
-            internalDeltaApiTokenController,
-        )
 
         bearerTokenRoutes(
             refreshUserInfoController,

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Routing.kt
@@ -196,6 +196,8 @@ fun oauthClientCallbackRoute(ssoClientInternalId: String) = "/delta/oauth/${ssoC
 fun Route.internalRoutes(injection: Injection) {
     val generateSAMLTokenController = injection.generateSAMLTokenController()
     val oauthTokenController = injection.internalOAuthTokenController()
+    val externalDeltaApiTokenController = injection.externalDeltaApiTokenController()
+    val internalDeltaApiTokenController = injection.internalDeltaApiTokenController()
     val refreshUserInfoController = injection.refreshUserInfoController()
     val fetchUserAuditController = injection.fetchUserAuditController()
     val adminEmailController = injection.adminEmailController()
@@ -214,6 +216,11 @@ fun Route.internalRoutes(injection: Injection) {
         serviceUserRoutes(generateSAMLTokenController)
 
         oauthTokenRoute(oauthTokenController)
+
+        deltaApiRoutes(
+            externalDeltaApiTokenController,
+            internalDeltaApiTokenController,
+        )
 
         bearerTokenRoutes(
             refreshUserInfoController,
@@ -236,6 +243,18 @@ fun Route.internalRoutes(injection: Injection) {
 fun Route.oauthTokenRoute(oauthTokenController: OAuthTokenController) {
     route("/token") {
         oauthTokenController.route(this)
+    }
+}
+
+fun Route.deltaApiRoutes(
+    externalDeltaApiTokenController: ExternalDeltaApiTokenController,
+    internalDeltaApiTokenController: InternalDeltaApiTokenController,
+) {
+    post("/delta-api/token") {
+        externalDeltaApiTokenController.createApiToken(call)
+    }
+    post("/internal/delta-api/validate") {
+        internalDeltaApiTokenController.validateApiRequest(call)
     }
 }
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/ClientConfig.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/ClientConfig.kt
@@ -63,7 +63,7 @@ class ClientConfig(val clients: List<Client>) {
                     "http://localhost:8080",
                 )
             }
-            val deltaApi = Client("api", deltaApiSecret, samlCredentials)
+            val deltaApi = Client("delta-api", deltaApiSecret, samlCredentials)
             return ClientConfig(listOfNotNull(marklogic, deltaWebsite, devDeltaWebsite, devDeltaWebsiteToTestEnvironment, deltaApi))
         }
     }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/ClientConfig.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/ClientConfig.kt
@@ -34,6 +34,7 @@ class ClientConfig(val clients: List<Client>) {
             // so that we can develop delta against test without running the auth service locally
             val devDeltaWebsiteSecret =
                 Env.getOptionalOrDevFallback("CLIENT_SECRET_DELTA_WEBSITE_DEV", "dev-delta-website-client-secret")
+            val deltaApiSecret = Env.getRequiredOrDevFallback("CLIENT_SECRET_DELTA_API", "dev-api-client-secret")
             val samlCredentials = SAMLConfig.credentialsFromEnvironment()
 
             val marklogic =
@@ -62,7 +63,8 @@ class ClientConfig(val clients: List<Client>) {
                     "http://localhost:8080",
                 )
             }
-            return ClientConfig(listOfNotNull(marklogic, deltaWebsite, devDeltaWebsite, devDeltaWebsiteToTestEnvironment))
+            val deltaApi = Client("api", deltaApiSecret, samlCredentials)
+            return ClientConfig(listOfNotNull(marklogic, deltaWebsite, devDeltaWebsite, devDeltaWebsiteToTestEnvironment, deltaApi))
         }
     }
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/ExternalDeltaApiTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/ExternalDeltaApiTokenController.kt
@@ -1,14 +1,18 @@
 package uk.gov.communities.delta.auth.controllers.external
 
+import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import kotlinx.serialization.Serializable
 import org.slf4j.LoggerFactory
+import uk.gov.communities.delta.auth.plugins.ApiError
+import uk.gov.communities.delta.auth.security.IADLdapLoginService
 import uk.gov.communities.delta.auth.services.DeltaApiTokenService
 
 class ExternalDeltaApiTokenController(
-    private val tokenService: DeltaApiTokenService
+    private val tokenService: DeltaApiTokenService,
+    private val ldapService: IADLdapLoginService,
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -16,7 +20,19 @@ class ExternalDeltaApiTokenController(
     suspend fun createApiToken(call: ApplicationCall) {
         val requestPayload = call.receive<ApiTokenRequest>()
 
-        val apiToken = tokenService.generateApiSamlToken()
+        // TODO 836 do we need to do something fancier like in the logincontroller?
+        val loginResult = ldapService.ldapLogin(requestPayload.username, requestPayload.password)
+
+        if (loginResult !is IADLdapLoginService.LdapLoginSuccess ||
+            !tokenService.validateApiClientIdAndSecret(requestPayload.client_id, requestPayload.client_secret)) {
+            throw ApiError(
+                HttpStatusCode.Forbidden,
+                "invalid credentials",
+                "user or client credentials not recognised",
+            )
+        }
+
+        val apiToken = tokenService.createAndStoreApiToken(requestPayload.username, requestPayload.client_id)
         return call.respond(mapOf("api_token" to apiToken))
     }
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/ExternalDeltaApiTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/ExternalDeltaApiTokenController.kt
@@ -65,7 +65,7 @@ class ExternalDeltaApiTokenController(
             )
         }
 
-        val apiToken = tokenService.createAndStoreApiToken(userCn, clientId, loginResult.user.javaUUIDObjectGuid, call)
+        val apiToken = tokenService.createAndStoreApiToken(userCn, clientId, loginResult.user.getGUID(), call)
         return call.respond(mapOf(
             "access_token" to apiToken,
             "expires_in" to (DeltaApiTokenService.API_TOKEN_EXPIRY_HOURS * 3600).toString(),

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/ExternalDeltaApiTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/ExternalDeltaApiTokenController.kt
@@ -1,0 +1,30 @@
+package uk.gov.communities.delta.auth.controllers.external
+
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import kotlinx.serialization.Serializable
+import org.slf4j.LoggerFactory
+import uk.gov.communities.delta.auth.services.DeltaApiTokenService
+
+class ExternalDeltaApiTokenController(
+    private val tokenService: DeltaApiTokenService
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    suspend fun createApiToken(call: ApplicationCall) {
+        val requestPayload = call.receive<ApiTokenRequest>()
+
+        val apiToken = tokenService.generateApiSamlToken()
+        return call.respond(mapOf("api_token" to apiToken))
+    }
+
+    @Serializable
+    data class ApiTokenRequest(
+        val username: String,
+        val password: String,
+        val client_id: String,
+        val client_secret: String,
+    )
+}

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/ExternalDeltaApiTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/ExternalDeltaApiTokenController.kt
@@ -4,6 +4,8 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.plugins.ApiError
@@ -14,33 +16,52 @@ class ExternalDeltaApiTokenController(
     private val tokenService: DeltaApiTokenService,
     private val ldapService: IADLdapLoginService,
 ) {
-
     private val logger = LoggerFactory.getLogger(javaClass)
+
+    fun route(route: Route) {
+        route.post {
+            createApiToken(call)
+        }
+    }
 
     suspend fun createApiToken(call: ApplicationCall) {
         val requestPayload = call.receive<ApiTokenRequest>()
 
-        // TODO 836 do we need to do something fancier like in the logincontroller?
+        if (requestPayload.grant_type != "password") {
+            throw ApiError(
+                HttpStatusCode.Forbidden,
+                "invalid_grant_type",
+                "grant_type must be password",
+            )
+        }
+
+        // TODO 836 check this takes a CN rather than an email (if it takes an email, rename things to match)
+        // TODO 836 also check whether keycloak takes an email
         val loginResult = ldapService.ldapLogin(requestPayload.username, requestPayload.password)
 
         if (loginResult !is IADLdapLoginService.LdapLoginSuccess ||
             !tokenService.validateApiClientIdAndSecret(requestPayload.client_id, requestPayload.client_secret)) {
             throw ApiError(
                 HttpStatusCode.Forbidden,
-                "invalid credentials",
+                "invalid_credentials",
                 "user or client credentials not recognised",
             )
         }
 
         val apiToken = tokenService.createAndStoreApiToken(requestPayload.username, requestPayload.client_id)
-        return call.respond(mapOf("api_token" to apiToken))
+        return call.respond(mapOf(
+            "access_token" to apiToken,
+            "expires_in" to (DeltaApiTokenService.API_TOKEN_EXPIRY_HOURS * 3600).toString(),
+            "token_type" to "Bearer"
+        ))
     }
 
     @Serializable
     data class ApiTokenRequest(
-        val username: String,
-        val password: String,
-        val client_id: String,
-        val client_secret: String,
+        @SerialName("grant_type") val grant_type: String,
+        @SerialName("username") val username: String,
+        @SerialName("password") val password: String,
+        @SerialName("client_id") val client_id: String,
+        @SerialName("client_secret") val client_secret: String,
     )
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/ExternalDeltaApiTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/ExternalDeltaApiTokenController.kt
@@ -27,6 +27,11 @@ class ExternalDeltaApiTokenController(
     suspend fun createApiToken(call: ApplicationCall) {
         val requestPayload = call.receive<ApiTokenRequest>()
 
+        logger.atInfo()
+            .addKeyValue("userCn", requestPayload.username)
+            .addKeyValue("clientId", requestPayload.client_id)
+            .log("Received API token request")
+
         if (requestPayload.grant_type != "password") {
             throw ApiError(
                 HttpStatusCode.Forbidden,
@@ -35,8 +40,6 @@ class ExternalDeltaApiTokenController(
             )
         }
 
-        // TODO 836 check this takes a CN rather than an email (if it takes an email, rename things to match)
-        // TODO 836 also check whether keycloak takes an email
         val loginResult = ldapService.ldapLogin(requestPayload.username, requestPayload.password)
 
         if (loginResult !is IADLdapLoginService.LdapLoginSuccess ||

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/ExternalDeltaApiTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/ExternalDeltaApiTokenController.kt
@@ -72,13 +72,4 @@ class ExternalDeltaApiTokenController(
             "token_type" to "Bearer"
         ))
     }
-
-    @Serializable
-    data class ApiTokenRequest(
-        @SerialName("grant_type") val grant_type: String,
-        @SerialName("username") val username: String,
-        @SerialName("password") val password: String,
-        @SerialName("client_id") val client_id: String,
-        @SerialName("client_secret") val client_secret: String,
-    )
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/InternalDeltaApiTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/InternalDeltaApiTokenController.kt
@@ -1,26 +1,55 @@
 package uk.gov.communities.delta.auth.controllers.internal
 
 import io.ktor.server.application.*
+import io.ktor.server.auth.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import kotlinx.serialization.Serializable
 import org.slf4j.LoggerFactory
+import uk.gov.communities.delta.auth.saml.SAMLTokenService
+import uk.gov.communities.delta.auth.security.CLIENT_HEADER_AUTH_NAME
+import uk.gov.communities.delta.auth.security.ClientPrincipal
+import uk.gov.communities.delta.auth.security.DELTA_AD_LDAP_SERVICE_USERS_AUTH_NAME
+import uk.gov.communities.delta.auth.security.DeltaLdapPrincipal
 import uk.gov.communities.delta.auth.services.DeltaApiTokenService
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 
 class InternalDeltaApiTokenController(
-    private val tokenService: DeltaApiTokenService
+    private val tokenService: DeltaApiTokenService,
+    private val samlTokenService: SAMLTokenService,
 ) {
-
     private val logger = LoggerFactory.getLogger(javaClass)
+    fun route(route: Route) {
+        route.post {
+            validateApiRequestAndReturnSamlToken(call)
+        }
+    }
 
-    suspend fun validateApiRequest(call: ApplicationCall) {
-        // TODO 836 any validation or whatever here?
-
+    // TODO 836 is this what I want this method to be called?
+    private suspend fun validateApiRequestAndReturnSamlToken(call: ApplicationCall) {
         val apiToken = call.receive<ApiValidationRequest>().token
 
         if (tokenService.validateApiToken(apiToken)) {
-            val samlToken = tokenService.generateApiSamlToken()
-            return call.respond(mapOf("saml_token" to samlToken))
+            // TODO 836 lots of repeated code with generatesamltokencontroller - move into service? maybe not tbh
+            val user = call.principal<DeltaLdapPrincipal>(DELTA_AD_LDAP_SERVICE_USERS_AUTH_NAME)!!
+            val client = call.principal<ClientPrincipal>(CLIENT_HEADER_AUTH_NAME)!!
+
+            val validFrom = Instant.now().minus(10, ChronoUnit.MILLIS)
+            val validTo = validFrom.plus(GenerateSAMLTokenController.SAML_TOKEN_EXPIRY_HOURS, ChronoUnit.HOURS)
+                .truncatedTo(ChronoUnit.SECONDS)
+
+            val token = samlTokenService.generate(client.client.samlCredential, user.ldapUser, validFrom, validTo)
+
+            call.respond(
+                GenerateSAMLTokenController.GenerateSAMLTokenResponse(
+                    username = user.ldapUser.cn,
+                    token = token,
+                    expiry = DateTimeFormatter.ISO_INSTANT.format(validTo),
+                )
+            )
         }
     }
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/InternalDeltaApiTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/InternalDeltaApiTokenController.kt
@@ -1,0 +1,31 @@
+package uk.gov.communities.delta.auth.controllers.internal
+
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import kotlinx.serialization.Serializable
+import org.slf4j.LoggerFactory
+import uk.gov.communities.delta.auth.services.DeltaApiTokenService
+
+class InternalDeltaApiTokenController(
+    private val tokenService: DeltaApiTokenService
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    suspend fun validateApiRequest(call: ApplicationCall) {
+        // TODO 836 any validation or whatever here?
+
+        val apiToken = call.receive<ApiValidationRequest>().token
+
+        if (tokenService.validateApiToken(apiToken)) {
+            val samlToken = tokenService.generateApiSamlToken()
+            return call.respond(mapOf("saml_token" to samlToken))
+        }
+    }
+
+    @Serializable
+    data class ApiValidationRequest(
+        val token: String,
+    )
+}

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/InternalDeltaApiTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/InternalDeltaApiTokenController.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.delta.auth.controllers.internal
 
+import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.request.*
@@ -7,12 +8,14 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.Serializable
 import org.slf4j.LoggerFactory
+import uk.gov.communities.delta.auth.plugins.ApiError
 import uk.gov.communities.delta.auth.saml.SAMLTokenService
 import uk.gov.communities.delta.auth.security.CLIENT_HEADER_AUTH_NAME
 import uk.gov.communities.delta.auth.security.ClientPrincipal
 import uk.gov.communities.delta.auth.security.DELTA_AD_LDAP_SERVICE_USERS_AUTH_NAME
 import uk.gov.communities.delta.auth.security.DeltaLdapPrincipal
 import uk.gov.communities.delta.auth.services.DeltaApiTokenService
+import uk.gov.communities.delta.auth.services.UserLookupService
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
@@ -20,35 +23,44 @@ import java.time.temporal.ChronoUnit
 class InternalDeltaApiTokenController(
     private val tokenService: DeltaApiTokenService,
     private val samlTokenService: SAMLTokenService,
+    private val userLookupService: UserLookupService
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
+
     fun route(route: Route) {
         route.post {
             validateApiRequestAndReturnSamlToken(call)
         }
     }
 
-    // TODO 836 is this what I want this method to be called?
     private suspend fun validateApiRequestAndReturnSamlToken(call: ApplicationCall) {
         val apiToken = call.receive<ApiValidationRequest>().token
 
-        if (tokenService.validateApiToken(apiToken)) {
-            // TODO 836 lots of repeated code with generatesamltokencontroller - move into service? maybe not tbh
-            val user = call.principal<DeltaLdapPrincipal>(DELTA_AD_LDAP_SERVICE_USERS_AUTH_NAME)!!
+        val userWithTokenCn = tokenService.validateApiToken(apiToken)
+        if (!userWithTokenCn.isNullOrEmpty()) {
             val client = call.principal<ClientPrincipal>(CLIENT_HEADER_AUTH_NAME)!!
+
+            val user = userLookupService.lookupUserByCn(userWithTokenCn)
 
             val validFrom = Instant.now().minus(10, ChronoUnit.MILLIS)
             val validTo = validFrom.plus(GenerateSAMLTokenController.SAML_TOKEN_EXPIRY_HOURS, ChronoUnit.HOURS)
                 .truncatedTo(ChronoUnit.SECONDS)
 
-            val token = samlTokenService.generate(client.client.samlCredential, user.ldapUser, validFrom, validTo)
+            val token = samlTokenService.generate(client.client.samlCredential, user, validFrom, validTo)
 
             call.respond(
                 GenerateSAMLTokenController.GenerateSAMLTokenResponse(
-                    username = user.ldapUser.cn,
+                    username = user.cn,
                     token = token,
                     expiry = DateTimeFormatter.ISO_INSTANT.format(validTo),
                 )
+            )
+        }
+        else {
+            throw ApiError(
+                HttpStatusCode.Forbidden,
+                "invalid_api_token",
+                "the api token is not valid or has expired",
             )
         }
     }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/InternalDeltaApiTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/InternalDeltaApiTokenController.kt
@@ -51,7 +51,7 @@ class InternalDeltaApiTokenController(
 
             val token = samlTokenService.generate(
                 systemClient.client.samlCredential,
-                userLookupService.lookupUserByCn(userCn),
+                userLookupService.lookupUserByCN(userCn),
                 validFrom,
                 validTo
             )
@@ -62,7 +62,7 @@ class InternalDeltaApiTokenController(
                     token = token,
                     expiry = DateTimeFormatter.ISO_INSTANT.format(validTo),
                     clientId = clientId,
-                    userGuid = userGuid,
+                    userGuid = userGuid.toString(),
                 )
             )
         } else {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/InternalDeltaApiTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/InternalDeltaApiTokenController.kt
@@ -36,8 +36,14 @@ class InternalDeltaApiTokenController(
     private suspend fun validateApiRequestAndReturnSamlToken(call: ApplicationCall) {
         val apiToken = call.receive<ApiValidationRequest>().token
 
+        logger.atInfo()
+            .log("Received API token to SAML token exchange request")
+
         val userWithTokenCn = tokenService.validateApiToken(apiToken)
         if (!userWithTokenCn.isNullOrEmpty()) {
+            logger.atInfo()
+                .addKeyValue("userCn", userWithTokenCn)
+                .log("Generating SAML token for user")
             val client = call.principal<ClientPrincipal>(CLIENT_HEADER_AUTH_NAME)!!
 
             val user = userLookupService.lookupUserByCn(userWithTokenCn)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/UserAuditTrailRepo.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/UserAuditTrailRepo.kt
@@ -25,6 +25,7 @@ class UserAuditTrailRepo {
         USER_ENABLE_BY_ADMIN("user_enable_by_admin"),
         USER_DISABLE_BY_ADMIN("user_disable_by_admin"),
         IMPERSONATE_USER("impersonate_user"),
+        API_TOKEN_CREATE("create_api_token"),
         ;
 
         companion object {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/DeltaApiTokenService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/DeltaApiTokenService.kt
@@ -1,17 +1,93 @@
 package uk.gov.communities.delta.auth.services
 
+import org.jetbrains.annotations.Blocking
+import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.repositories.DbPool
+import uk.gov.communities.delta.auth.repositories.map
+import uk.gov.communities.delta.auth.saml.SAMLTokenService
+import uk.gov.communities.delta.auth.utils.TimeSource
+import uk.gov.communities.delta.auth.utils.hashBase64String
+import java.sql.Timestamp
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 
-class DeltaApiTokenService(private val dbPool: DbPool) {
-    fun createAndStoreApiToken(): String {
+// TODO 836 add logging
+class DeltaApiTokenService(
+    private val dbPool: DbPool,
+    private val samlTokenService: SAMLTokenService,
+    private val timeSource: TimeSource
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    suspend fun validateApiClientIdAndSecret(id: String, secret: String): Boolean {
+        return dbPool.useConnectionNonBlocking("Validate client id and secret") {
+            val stmt = it.prepareStatement(
+                "SELECT client_secret FROM api_clients " +
+                    "WHERE client_id = ?"
+            )
+            stmt.setString(1, id)
+            val result = stmt.executeQuery()
+            if (!result.next()) {
+                false
+            } else {
+                result.getString("client_secret") == secret
+            }
+        }
+    }
+
+    fun createAndStoreApiToken(username: String, clientId: String): String {
+        // validate username and password and client stuff in controller
+        val apiToken = generateApiToken()
+        // store token
+        insertApiToken(apiToken, timeSource.now(), username, clientId)
+        // return token
+        return apiToken
+    }
+
+    suspend fun validateApiToken(apiToken: String): Boolean {
+        return dbPool.useConnectionNonBlocking("Validate client id and secret") {
+            val stmt = it.prepareStatement(
+                "SELECT created_at, created_by_user, created_by_client FROM api_tokens " +
+                    "WHERE token_hash = ?"
+            )
+            stmt.setBytes(1, hashBase64String(apiToken))
+            val result = stmt.executeQuery()
+            if (!result.next()) {
+                false
+            } else {
+                val now = timeSource.now()
+                result.getTime("created_at").toInstant().plus(API_TOKEN_EXPIRY_HOURS, ChronoUnit.HOURS) > now
+            }
+        }
+    }
+
+    fun getApiSamlToken(): String {
         throw NotImplementedError()
     }
 
-    fun validateApiToken(apiToken: String): Boolean {
-        throw NotImplementedError()
+    private fun generateApiToken(): String {
+        // TODO 836 do we need a special approach here?
+        val characters = ('A'..'Z') + ('a'..'z') + ('0'..'9')
+        return (1..32).map { characters.random() }.joinToString("")
     }
 
-    fun generateApiSamlToken(): String {
-        throw NotImplementedError()
+    @Blocking
+    private fun insertApiToken(token: String, now: Instant, username: String, clientId: String) {
+        return dbPool.useConnectionBlocking("Insert api_token") {
+            val stmt = it.prepareStatement(
+                "INSERT INTO delta_session (token_hash, created_at, created_by_user, created_by_client) " +
+                    "VALUES (?, ?, ?, ?)"
+            )
+            stmt.setBytes(1, hashBase64String(token))
+            stmt.setTimestamp(2, Timestamp.from(now))
+            stmt.setString(3, username)
+            stmt.setString(4, clientId)
+            stmt.executeQuery() // TODO 836 do we need any checking for errors? does this do that?
+            it.commit()
+        }
+    }
+
+    companion object {
+        const val API_TOKEN_EXPIRY_HOURS = 1L
     }
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/DeltaApiTokenService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/DeltaApiTokenService.kt
@@ -1,0 +1,17 @@
+package uk.gov.communities.delta.auth.services
+
+import uk.gov.communities.delta.auth.repositories.DbPool
+
+class DeltaApiTokenService(private val dbPool: DbPool) {
+    fun createAndStoreApiToken(): String {
+        throw NotImplementedError()
+    }
+
+    fun validateApiToken(apiToken: String): Boolean {
+        throw NotImplementedError()
+    }
+
+    fun generateApiSamlToken(): String {
+        throw NotImplementedError()
+    }
+}

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/DeltaApiTokenService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/DeltaApiTokenService.kt
@@ -17,7 +17,6 @@ import java.time.temporal.ChronoUnit
 class DeltaApiTokenService(
     private val dbPool: DbPool,
     private val timeSource: TimeSource,
-    private val userLookupService: UserLookupService,
     private val userAuditService: UserAuditService,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/DeltaApiTokenService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/DeltaApiTokenService.kt
@@ -3,18 +3,22 @@ package uk.gov.communities.delta.auth.services
 import org.jetbrains.annotations.Blocking
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.repositories.DbPool
+import uk.gov.communities.delta.auth.repositories.LdapUser
 import uk.gov.communities.delta.auth.repositories.map
 import uk.gov.communities.delta.auth.saml.SAMLTokenService
 import uk.gov.communities.delta.auth.utils.TimeSource
 import uk.gov.communities.delta.auth.utils.hashBase64String
+import uk.gov.communities.delta.auth.utils.randomBase64
+import java.nio.ByteBuffer
+import java.security.SecureRandom
 import java.sql.Timestamp
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import java.util.*
 
 // TODO 836 add logging
 class DeltaApiTokenService(
     private val dbPool: DbPool,
-    private val samlTokenService: SAMLTokenService,
     private val timeSource: TimeSource
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -37,52 +41,43 @@ class DeltaApiTokenService(
 
     fun createAndStoreApiToken(username: String, clientId: String): String {
         // validate username and password and client stuff in controller
-        val apiToken = generateApiToken()
+        val apiToken = randomBase64(32)
         // store token
         insertApiToken(apiToken, timeSource.now(), username, clientId)
         // return token
         return apiToken
     }
 
-    suspend fun validateApiToken(apiToken: String): Boolean {
+    suspend fun validateApiToken(apiToken: String): String? {
         return dbPool.useConnectionNonBlocking("Validate client id and secret") {
             val stmt = it.prepareStatement(
-                "SELECT created_at, created_by_user, created_by_client FROM api_tokens " +
-                    "WHERE token_hash = ?"
+                "SELECT created_at, created_by_user_cn, created_by_client_id FROM api_tokens " +
+                    "WHERE token_hash = ? AND created_at > ?"
             )
             stmt.setBytes(1, hashBase64String(apiToken))
+            val earliestValidCreationTime = timeSource.now().plus(-API_TOKEN_EXPIRY_HOURS, ChronoUnit.HOURS)
+            stmt.setTimestamp(2, Timestamp.from(earliestValidCreationTime))
             val result = stmt.executeQuery()
             if (!result.next()) {
-                false
+                null
             } else {
-                val now = timeSource.now()
-                result.getTime("created_at").toInstant().plus(API_TOKEN_EXPIRY_HOURS, ChronoUnit.HOURS) > now
+                result.getString("created_by_user_cn")
             }
         }
-    }
-
-    fun getApiSamlToken(): String {
-        throw NotImplementedError()
-    }
-
-    private fun generateApiToken(): String {
-        // TODO 836 do we need a special approach here?
-        val characters = ('A'..'Z') + ('a'..'z') + ('0'..'9')
-        return (1..32).map { characters.random() }.joinToString("")
     }
 
     @Blocking
     private fun insertApiToken(token: String, now: Instant, username: String, clientId: String) {
         return dbPool.useConnectionBlocking("Insert api_token") {
             val stmt = it.prepareStatement(
-                "INSERT INTO delta_session (token_hash, created_at, created_by_user, created_by_client) " +
+                "INSERT INTO api_tokens (token_hash, created_at, created_by_user_cn, created_by_client_id) " +
                     "VALUES (?, ?, ?, ?)"
             )
             stmt.setBytes(1, hashBase64String(token))
             stmt.setTimestamp(2, Timestamp.from(now))
             stmt.setString(3, username)
             stmt.setString(4, clientId)
-            stmt.executeQuery() // TODO 836 do we need any checking for errors? does this do that?
+            stmt.executeUpdate()
             it.commit()
         }
     }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/DeltaApiTokenService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/DeltaApiTokenService.kt
@@ -16,7 +16,6 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.*
 
-// TODO 836 add logging
 class DeltaApiTokenService(
     private val dbPool: DbPool,
     private val timeSource: TimeSource
@@ -40,11 +39,9 @@ class DeltaApiTokenService(
     }
 
     fun createAndStoreApiToken(username: String, clientId: String): String {
-        // validate username and password and client stuff in controller
+        logger.atInfo().addKeyValue("clientId", clientId).log("Creating new API token for client")
         val apiToken = randomBase64(32)
-        // store token
         insertApiToken(apiToken, timeSource.now(), username, clientId)
-        // return token
         return apiToken
     }
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/DeltaApiTokenService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/DeltaApiTokenService.kt
@@ -1,24 +1,24 @@
 package uk.gov.communities.delta.auth.services
 
+import io.ktor.server.application.*
+import kotlinx.serialization.json.Json
 import org.jetbrains.annotations.Blocking
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.repositories.DbPool
-import uk.gov.communities.delta.auth.repositories.LdapUser
-import uk.gov.communities.delta.auth.repositories.map
-import uk.gov.communities.delta.auth.saml.SAMLTokenService
 import uk.gov.communities.delta.auth.utils.TimeSource
 import uk.gov.communities.delta.auth.utils.hashBase64String
 import uk.gov.communities.delta.auth.utils.randomBase64
-import java.nio.ByteBuffer
-import java.security.SecureRandom
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 import java.sql.Timestamp
 import java.time.Instant
 import java.time.temporal.ChronoUnit
-import java.util.*
 
 class DeltaApiTokenService(
     private val dbPool: DbPool,
-    private val timeSource: TimeSource
+    private val timeSource: TimeSource,
+    private val userLookupService: UserLookupService,
+    private val userAuditService: UserAuditService,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -33,15 +33,20 @@ class DeltaApiTokenService(
             if (!result.next()) {
                 false
             } else {
-                result.getString("client_secret") == secret
+                val secretBytes = secret.toByteArray(StandardCharsets.UTF_8)
+                val referenceBytes = result.getString("client_secret").toByteArray(StandardCharsets.UTF_8)
+                MessageDigest.isEqual(secretBytes, referenceBytes)
             }
         }
     }
 
-    fun createAndStoreApiToken(username: String, clientId: String): String {
+    suspend fun createAndStoreApiToken(username: String, clientId: String, call: ApplicationCall): String {
         logger.atInfo().addKeyValue("clientId", clientId).log("Creating new API token for client")
         val apiToken = randomBase64(32)
-        insertApiToken(apiToken, timeSource.now(), username, clientId)
+
+        val userGuid = userLookupService.lookupUserByCn(username).javaUUIDObjectGuid
+
+        insertApiToken(apiToken, timeSource.now(), username, userGuid, clientId, call)
         return apiToken
     }
 
@@ -64,17 +69,21 @@ class DeltaApiTokenService(
     }
 
     @Blocking
-    private fun insertApiToken(token: String, now: Instant, username: String, clientId: String) {
+    private suspend fun insertApiToken(token: String, now: Instant, username: String, userGuid: String?, clientId: String, call: ApplicationCall) {
+        userAuditService.apiTokenCreationAudit(username, call)
+
         return dbPool.useConnectionBlocking("Insert api_token") {
             val stmt = it.prepareStatement(
-                "INSERT INTO api_tokens (token_hash, created_at, created_by_user_cn, created_by_client_id) " +
-                    "VALUES (?, ?, ?, ?)"
+                "INSERT INTO api_tokens (token_hash, created_at, created_by_user_cn, created_by_user_guid, created_by_client_id) " +
+                    "VALUES (?, ?, ?, ?, ?)"
             )
             stmt.setBytes(1, hashBase64String(token))
             stmt.setTimestamp(2, Timestamp.from(now))
             stmt.setString(3, username)
-            stmt.setString(4, clientId)
+            stmt.setString(4, userGuid)
+            stmt.setString(5, clientId)
             stmt.executeUpdate()
+
             it.commit()
         }
     }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditService.kt
@@ -64,6 +64,7 @@ class UserAuditService(private val userAuditTrailRepo: UserAuditTrailRepo, priva
     val userUpdateAudit = insertAnonDetailedAuditRowFun(UserAuditTrailRepo.AuditAction.USER_UPDATE)
     val userEnableAudit = insertSimpleAuditRowFun(UserAuditTrailRepo.AuditAction.USER_ENABLE_BY_ADMIN)
     val userDisableAudit = insertSimpleAuditRowFun(UserAuditTrailRepo.AuditAction.USER_DISABLE_BY_ADMIN)
+    val apiTokenCreationAudit = insertAnonSimpleAuditRowFun(UserAuditTrailRepo.AuditAction.API_TOKEN_CREATE)
 
     // A user doing something to their own account with no extra data
     private fun insertAnonSimpleAuditRowFun(auditAction: UserAuditTrailRepo.AuditAction): suspend (String, ApplicationCall) -> Unit {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/tasks/DeleteOldApiTokens.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/tasks/DeleteOldApiTokens.kt
@@ -1,0 +1,25 @@
+package uk.gov.communities.delta.auth.tasks
+
+import org.slf4j.LoggerFactory
+import uk.gov.communities.delta.auth.repositories.DbPool
+import java.sql.Timestamp
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class DeleteOldApiTokens(private val db: DbPool) : AuthServiceTask("DeleteOldApiTokens")  {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    // Tasks are run separately anyway
+    @Suppress("BlockingMethodInNonBlockingContext")
+    override suspend fun execute() {
+        db.useConnectionBlocking("DeleteOldApiTokens") {
+            val stmt = it.prepareStatement(
+                "DELETE FROM api_tokens WHERE created_at < ?"
+            )
+            stmt.setTimestamp(1, Timestamp.from(Instant.now().minus(1, ChronoUnit.DAYS)))
+            val result = stmt.executeUpdate()
+            it.commit()
+            logger.info("Deleted {} old api tokens", result)
+        }
+    }
+}

--- a/auth-service/src/main/resources/db/migration/V12__api_tokens.sql
+++ b/auth-service/src/main/resources/db/migration/V12__api_tokens.sql
@@ -10,7 +10,7 @@ CREATE TABLE api_tokens
     token_hash           bytea     NOT NULL UNIQUE,
     created_at           timestamp NOT NULL,
     created_by_user_cn   text      NOT NULL,
-    created_by_user_guid text,
+    created_by_user_guid text      NOT NULL,
     created_by_client_id text      NOT NULL,
     CONSTRAINT fk_client_id FOREIGN KEY(created_by_client_id) REFERENCES api_clients(client_id)
 );

--- a/auth-service/src/main/resources/db/migration/V9__api_tokens.sql
+++ b/auth-service/src/main/resources/db/migration/V9__api_tokens.sql
@@ -14,5 +14,3 @@ CREATE TABLE api_tokens
     created_by_client_id text      NOT NULL,
     CONSTRAINT fk_client_id FOREIGN KEY(created_by_client_id) REFERENCES api_clients(client_id)
 );
-
-CREATE UNIQUE INDEX token_hash_idx ON api_tokens (token_hash)

--- a/auth-service/src/main/resources/db/migration/V9__api_tokens.sql
+++ b/auth-service/src/main/resources/db/migration/V9__api_tokens.sql
@@ -2,16 +2,14 @@ CREATE TABLE api_clients
 (
     client_id     text NOT NULL,
     client_secret text NOT NULL,
-    UNIQUE (client_id, client_secret)
-)
+    PRIMARY KEY(client_id)
+);
 
 CREATE TABLE api_tokens
 (
-    token_hash        bytea     NOT NULL,
-    created_at        timestamp NOT NULL,
-    created_by_user   text      NOT NULL,-- username
-    created_by_client text      NOT NULL-- client id
+    token_hash           bytea     NOT NULL,
+    created_at           timestamp NOT NULL,
+    created_by_user_cn   text      NOT NULL,
+    created_by_client_id text      NOT NULL,
+    CONSTRAINT fk_client_id FOREIGN KEY(created_by_client_id) REFERENCES api_clients(client_id)
 );
-
-/* do we want an index and a way to look up the tokens faster? I don't know how many tokens and what kind of
-turnaround speed we're expecting */

--- a/auth-service/src/main/resources/db/migration/V9__api_tokens.sql
+++ b/auth-service/src/main/resources/db/migration/V9__api_tokens.sql
@@ -1,9 +1,16 @@
+CREATE TABLE api_clients
+(
+    client_id     text NOT NULL,
+    client_secret text NOT NULL,
+    UNIQUE (client_id, client_secret)
+)
+
 CREATE TABLE api_tokens
 (
-    token      bytea     NOT NULL,-- varchar? since it's a string
-    created_at timestamp NOT NULL,
-    created_by_user varchar(255) NOT NULL,-- username
-    created_by_client varchar(255) NOT NULL-- client id
+    token_hash        bytea     NOT NULL,
+    created_at        timestamp NOT NULL,
+    created_by_user   text      NOT NULL,-- username
+    created_by_client text      NOT NULL-- client id
 );
 
 /* do we want an index and a way to look up the tokens faster? I don't know how many tokens and what kind of

--- a/auth-service/src/main/resources/db/migration/V9__api_tokens.sql
+++ b/auth-service/src/main/resources/db/migration/V9__api_tokens.sql
@@ -1,0 +1,10 @@
+CREATE TABLE api_tokens
+(
+    token      bytea     NOT NULL,-- varchar? since it's a string
+    created_at timestamp NOT NULL,
+    created_by_user varchar(255) NOT NULL,-- username
+    created_by_client varchar(255) NOT NULL-- client id
+);
+
+/* do we want an index and a way to look up the tokens faster? I don't know how many tokens and what kind of
+turnaround speed we're expecting */

--- a/auth-service/src/main/resources/db/migration/V9__api_tokens.sql
+++ b/auth-service/src/main/resources/db/migration/V9__api_tokens.sql
@@ -7,9 +7,12 @@ CREATE TABLE api_clients
 
 CREATE TABLE api_tokens
 (
-    token_hash           bytea     NOT NULL,
+    token_hash           bytea     NOT NULL UNIQUE,
     created_at           timestamp NOT NULL,
     created_by_user_cn   text      NOT NULL,
+    created_by_user_guid text,
     created_by_client_id text      NOT NULL,
     CONSTRAINT fk_client_id FOREIGN KEY(created_by_client_id) REFERENCES api_clients(client_id)
 );
+
+CREATE UNIQUE INDEX token_hash_idx ON api_tokens (token_hash)

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/ExternalDeltaApiTokenControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/ExternalDeltaApiTokenControllerTest.kt
@@ -39,7 +39,7 @@ class ExternalDeltaApiTokenControllerTest {
                 tokenService.validateApiClientIdAndSecret(validClientId, validClientSecret)
             }
             coVerify(exactly = 1) {
-                tokenService.createAndStoreApiToken(testUser.cn, validClientId, any())
+                tokenService.createAndStoreApiToken(testUser.cn, validClientId, testUser.javaUUIDObjectGuid, any())
             }
             confirmVerified(tokenService)
         }
@@ -62,7 +62,7 @@ class ExternalDeltaApiTokenControllerTest {
             }
         }.apply {
             assertEquals("invalid_grant_type", errorCode)
-            coVerify(exactly = 0) { tokenService.createAndStoreApiToken(any(), any(), any()) }
+            coVerify(exactly = 0) { tokenService.createAndStoreApiToken(any(), any(), any(), any()) }
         }
     }
 
@@ -83,7 +83,7 @@ class ExternalDeltaApiTokenControllerTest {
             }
         }.apply {
             assertEquals("invalid_grant", errorCode)
-            coVerify(exactly = 0) { tokenService.createAndStoreApiToken(any(), any(), any()) }
+            coVerify(exactly = 0) { tokenService.createAndStoreApiToken(any(), any(), any(), any()) }
         }
     }
 
@@ -104,7 +104,7 @@ class ExternalDeltaApiTokenControllerTest {
             }
         }.apply {
             assertEquals("invalid_client", errorCode)
-            coVerify(exactly = 0) { tokenService.createAndStoreApiToken(any(), any(), any()) }
+            coVerify(exactly = 0) { tokenService.createAndStoreApiToken(any(), any(), any(), any()) }
         }
     }
 
@@ -116,7 +116,7 @@ class ExternalDeltaApiTokenControllerTest {
             testUser)
         coEvery { tokenService.validateApiClientIdAndSecret(any(), any()) } returns false
         coEvery { tokenService.validateApiClientIdAndSecret(validClientId, validClientSecret) } returns true
-        coEvery { tokenService.createAndStoreApiToken(any(), any(), any()) } returns "newApiToken"
+        coEvery { tokenService.createAndStoreApiToken(any(), any(), any(), any()) } returns "newApiToken"
     }
 
     companion object {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/ExternalDeltaApiTokenControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/ExternalDeltaApiTokenControllerTest.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.delta.controllers
 import io.ktor.client.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
+import io.ktor.client.request.forms.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
@@ -24,16 +25,16 @@ import kotlin.test.assertEquals
 class ExternalDeltaApiTokenControllerTest {
     @Test
     fun testCreateApiToken() = testSuspend {
-        testClient.post("/delta-api/oauth/token") {
-            contentType(ContentType.Application.Json)
-            setBody("""
-                {"grant_type": "${validGrantType}",
-                "username": "${testUser.cn}",
-                "password": "${validUserPassword}",
-                "client_id": "${validClientId}",
-                "client_secret": "${validClientSecret}"}
-            """.trimIndent())
-        }.apply {
+        testClient.submitForm(
+            url = "/delta-api/oauth/token",
+            formParameters = parameters {
+                append("grant_type", validGrantType)
+                append("username", testUser.cn)
+                append("password", validUserPassword)
+                append("client_id", validClientId)
+                append("client_secret", validClientSecret)
+            }
+        ).apply {
             assertEquals(HttpStatusCode.OK, status)
             coVerify(exactly = 1) {
                 tokenService.validateApiClientIdAndSecret(validClientId, validClientSecret)
@@ -49,16 +50,16 @@ class ExternalDeltaApiTokenControllerTest {
     fun grantTypeMustBePassword() = testSuspend {
         Assert.assertThrows(ApiError::class.java) {
             runBlocking {
-                testClient.post("/delta-api/oauth/token") {
-                    contentType(ContentType.Application.Json)
-                    setBody("""
-                        {"grant_type": "device_code",
-                        "username": "${testUser.cn}",
-                        "password": "${validUserPassword}",
-                        "client_id": "${validClientId}",
-                        "client_secret": "${validClientSecret}"}
-                    """.trimIndent())
-                }
+                testClient.submitForm(
+                    url = "/delta-api/oauth/token",
+                    formParameters = parameters {
+                        append("grant_type", "device_code")
+                        append("username", testUser.cn)
+                        append("password", validUserPassword)
+                        append("client_id", validClientId)
+                        append("client_secret", validClientSecret)
+                    }
+                )
             }
         }.apply {
             assertEquals("invalid_grant_type", errorCode)
@@ -70,16 +71,16 @@ class ExternalDeltaApiTokenControllerTest {
     fun userCredentialsMustBeValid() = testSuspend {
         Assert.assertThrows(ApiError::class.java) {
             runBlocking {
-                testClient.post("/delta-api/oauth/token") {
-                    contentType(ContentType.Application.Json)
-                    setBody("""
-                        {"grant_type": "${validGrantType}",
-                        "username": "${testUser.cn}",
-                        "password": "wrong_password",
-                        "client_id": "${validClientId}",
-                        "client_secret": "${validClientSecret}"}
-                    """.trimIndent())
-                }
+                testClient.submitForm(
+                    url = "/delta-api/oauth/token",
+                    formParameters = parameters {
+                        append("grant_type", validGrantType)
+                        append("username", testUser.cn)
+                        append("password", "wrong_password")
+                        append("client_id", validClientId)
+                        append("client_secret", validClientSecret)
+                    }
+                )
             }
         }.apply {
             assertEquals("invalid_grant", errorCode)
@@ -91,16 +92,16 @@ class ExternalDeltaApiTokenControllerTest {
     fun clientCredentialsMustBeValid() = testSuspend {
         Assert.assertThrows(ApiError::class.java) {
             runBlocking {
-                testClient.post("/delta-api/oauth/token") {
-                    contentType(ContentType.Application.Json)
-                    setBody("""
-                        {"grant_type": "${validGrantType}",
-                        "username": "${testUser.cn}",
-                        "password": "${validUserPassword}",
-                        "client_id": "${validClientId}",
-                        "client_secret": "wrong_secret"}
-                    """.trimIndent())
-                }
+                testClient.submitForm(
+                    url = "/delta-api/oauth/token",
+                    formParameters = parameters {
+                        append("grant_type", validGrantType)
+                        append("username", testUser.cn)
+                        append("password", validUserPassword)
+                        append("client_id", validClientId)
+                        append("client_secret", "wrong_secret")
+                    }
+                )
             }
         }.apply {
             assertEquals("invalid_client", errorCode)

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/ExternalDeltaApiTokenControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/ExternalDeltaApiTokenControllerTest.kt
@@ -40,7 +40,7 @@ class ExternalDeltaApiTokenControllerTest {
                 tokenService.validateApiClientIdAndSecret(validClientId, validClientSecret)
             }
             coVerify(exactly = 1) {
-                tokenService.createAndStoreApiToken(testUser.cn, validClientId, testUser.javaUUIDObjectGuid, any())
+                tokenService.createAndStoreApiToken(testUser.cn, validClientId, testUser.getGUID(), any())
             }
             confirmVerified(tokenService)
         }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/ExternalDeltaApiTokenControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/ExternalDeltaApiTokenControllerTest.kt
@@ -1,0 +1,4 @@
+package uk.gov.communities.delta.controllers
+
+class ExternalDeltaApiTokenControllerTest {
+}

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/ExternalDeltaApiTokenControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/ExternalDeltaApiTokenControllerTest.kt
@@ -39,7 +39,7 @@ class ExternalDeltaApiTokenControllerTest {
                 tokenService.validateApiClientIdAndSecret(validClientId, validClientSecret)
             }
             coVerify(exactly = 1) {
-                tokenService.createAndStoreApiToken(testUser.cn, validClientId)
+                tokenService.createAndStoreApiToken(testUser.cn, validClientId, any())
             }
             confirmVerified(tokenService)
         }
@@ -62,7 +62,7 @@ class ExternalDeltaApiTokenControllerTest {
             }
         }.apply {
             assertEquals("invalid_grant_type", errorCode)
-            coVerify(exactly = 0) { tokenService.createAndStoreApiToken(any(), any()) }
+            coVerify(exactly = 0) { tokenService.createAndStoreApiToken(any(), any(), any()) }
         }
     }
 
@@ -82,8 +82,8 @@ class ExternalDeltaApiTokenControllerTest {
                 }
             }
         }.apply {
-            assertEquals("invalid_credentials", errorCode)
-            coVerify(exactly = 0) { tokenService.createAndStoreApiToken(any(), any()) }
+            assertEquals("invalid_grant", errorCode)
+            coVerify(exactly = 0) { tokenService.createAndStoreApiToken(any(), any(), any()) }
         }
     }
 
@@ -103,8 +103,8 @@ class ExternalDeltaApiTokenControllerTest {
                 }
             }
         }.apply {
-            assertEquals("invalid_credentials", errorCode)
-            coVerify(exactly = 0) { tokenService.createAndStoreApiToken(any(), any()) }
+            assertEquals("invalid_client", errorCode)
+            coVerify(exactly = 0) { tokenService.createAndStoreApiToken(any(), any(), any()) }
         }
     }
 
@@ -116,7 +116,7 @@ class ExternalDeltaApiTokenControllerTest {
             testUser)
         coEvery { tokenService.validateApiClientIdAndSecret(any(), any()) } returns false
         coEvery { tokenService.validateApiClientIdAndSecret(validClientId, validClientSecret) } returns true
-        coEvery { tokenService.createAndStoreApiToken(any(), any()) } returns "newApiToken"
+        coEvery { tokenService.createAndStoreApiToken(any(), any(), any()) } returns "newApiToken"
     }
 
     companion object {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/ExternalDeltaApiTokenControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/ExternalDeltaApiTokenControllerTest.kt
@@ -1,4 +1,167 @@
 package uk.gov.communities.delta.controllers
 
+import io.ktor.client.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import io.ktor.server.application.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import io.ktor.test.dispatcher.*
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import org.junit.*
+import uk.gov.communities.delta.auth.controllers.external.ExternalDeltaApiTokenController
+import uk.gov.communities.delta.auth.plugins.ApiError
+import uk.gov.communities.delta.auth.plugins.configureSerialization
+import uk.gov.communities.delta.auth.security.IADLdapLoginService
+import uk.gov.communities.delta.auth.services.DeltaApiTokenService
+import uk.gov.communities.delta.helper.testLdapUser
+import uk.gov.communities.delta.helper.testServiceClient
+import kotlin.test.assertEquals
+
 class ExternalDeltaApiTokenControllerTest {
+    @Test
+    fun testCreateApiToken() = testSuspend {
+        testClient.post("/delta-api/oauth/token") {
+            contentType(ContentType.Application.Json)
+            setBody("""
+                {"grant_type": "${validGrantType}",
+                "username": "${testUser.cn}",
+                "password": "${validUserPassword}",
+                "client_id": "${validClientId}",
+                "client_secret": "${validClientSecret}"}
+            """.trimIndent())
+        }.apply {
+            assertEquals(HttpStatusCode.OK, status)
+            coVerify(exactly = 1) {
+                tokenService.validateApiClientIdAndSecret(validClientId, validClientSecret)
+            }
+            coVerify(exactly = 1) {
+                tokenService.createAndStoreApiToken(testUser.cn, validClientId)
+            }
+            confirmVerified(tokenService)
+        }
+    }
+
+    @Test
+    fun grantTypeMustBePassword() = testSuspend {
+        Assert.assertThrows(ApiError::class.java) {
+            runBlocking {
+                testClient.post("/delta-api/oauth/token") {
+                    contentType(ContentType.Application.Json)
+                    setBody("""
+                        {"grant_type": "device_code",
+                        "username": "${testUser.cn}",
+                        "password": "${validUserPassword}",
+                        "client_id": "${validClientId}",
+                        "client_secret": "${validClientSecret}"}
+                    """.trimIndent())
+                }
+            }
+        }.apply {
+            assertEquals("invalid_grant_type", errorCode)
+            coVerify(exactly = 0) { tokenService.createAndStoreApiToken(any(), any()) }
+        }
+    }
+
+    @Test
+    fun userCredentialsMustBeValid() = testSuspend {
+        Assert.assertThrows(ApiError::class.java) {
+            runBlocking {
+                testClient.post("/delta-api/oauth/token") {
+                    contentType(ContentType.Application.Json)
+                    setBody("""
+                        {"grant_type": "${validGrantType}",
+                        "username": "${testUser.cn}",
+                        "password": "wrong_password",
+                        "client_id": "${validClientId}",
+                        "client_secret": "${validClientSecret}"}
+                    """.trimIndent())
+                }
+            }
+        }.apply {
+            assertEquals("invalid_credentials", errorCode)
+            coVerify(exactly = 0) { tokenService.createAndStoreApiToken(any(), any()) }
+        }
+    }
+
+    @Test
+    fun clientCredentialsMustBeValid() = testSuspend {
+        Assert.assertThrows(ApiError::class.java) {
+            runBlocking {
+                testClient.post("/delta-api/oauth/token") {
+                    contentType(ContentType.Application.Json)
+                    setBody("""
+                        {"grant_type": "${validGrantType}",
+                        "username": "${testUser.cn}",
+                        "password": "${validUserPassword}",
+                        "client_id": "${validClientId}",
+                        "client_secret": "wrong_secret"}
+                    """.trimIndent())
+                }
+            }
+        }.apply {
+            assertEquals("invalid_credentials", errorCode)
+            coVerify(exactly = 0) { tokenService.createAndStoreApiToken(any(), any()) }
+        }
+    }
+
+    @Before
+    fun resetMocks() {
+        clearAllMocks()
+        coEvery { ldapService.ldapLogin(any(), any()) } returns IADLdapLoginService.UnknownAuthenticationFailure
+        coEvery { ldapService.ldapLogin(testUser.cn, validUserPassword) } returns IADLdapLoginService.LdapLoginSuccess(
+            testUser)
+        coEvery { tokenService.validateApiClientIdAndSecret(any(), any()) } returns false
+        coEvery { tokenService.validateApiClientIdAndSecret(validClientId, validClientSecret) } returns true
+        coEvery { tokenService.createAndStoreApiToken(any(), any()) } returns "newApiToken"
+    }
+
+    companion object {
+        private lateinit var testApp: TestApplication
+        private lateinit var testClient: HttpClient
+        private lateinit var controller: ExternalDeltaApiTokenController
+
+        private val tokenService = mockk<DeltaApiTokenService>()
+        private val ldapService = mockk<IADLdapLoginService>()
+
+        private val testUser = testLdapUser()
+
+        private val validGrantType = "password"
+        private val validUserPassword = "test_password"
+        private val validClientId = "id"
+        private val validClientSecret = "correct_password"
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            controller = ExternalDeltaApiTokenController(tokenService, ldapService)
+
+            testApp = TestApplication {
+                application {
+                    configureSerialization()
+                    routing {
+                        route("/delta-api/oauth/token") {
+                            controller.route(this)
+                        }
+                    }
+                }
+            }
+
+            testClient = testApp.createClient {
+                install(ContentNegotiation) {
+                    json()
+                }
+                followRedirects = false
+            }
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDown() {
+            testApp.stop()
+        }
+    }
 }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/InternalDeltaApiTokenControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/InternalDeltaApiTokenControllerTest.kt
@@ -1,0 +1,4 @@
+package uk.gov.communities.delta.controllers
+
+class InternalDeltaApiTokenControllerTest {
+}

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/InternalDeltaApiTokenControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/InternalDeltaApiTokenControllerTest.kt
@@ -1,4 +1,121 @@
 package uk.gov.communities.delta.controllers
 
+import io.ktor.client.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import io.ktor.server.auth.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import io.ktor.test.dispatcher.*
+import io.mockk.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import org.junit.AfterClass
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import uk.gov.communities.delta.auth.config.Client
+import uk.gov.communities.delta.auth.config.SAMLConfig
+import uk.gov.communities.delta.auth.controllers.internal.InternalDeltaApiTokenController
+import uk.gov.communities.delta.auth.plugins.configureSerialization
+import uk.gov.communities.delta.auth.saml.SAMLTokenService
+import uk.gov.communities.delta.auth.security.CLIENT_HEADER_AUTH_NAME
+import uk.gov.communities.delta.auth.security.clientHeaderAuth
+import uk.gov.communities.delta.auth.services.DeltaApiTokenService
+import uk.gov.communities.delta.auth.services.UserLookupService
+import uk.gov.communities.delta.helper.testLdapUser
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
 class InternalDeltaApiTokenControllerTest {
+    @Test
+    fun testValidateApiToken() = testSuspend {
+        testClient.post("/internal/delta-api/validate") {
+            headers {
+                append(HttpHeaders.Accept, "application/json")
+                append("Delta-Client", "${serviceClient.clientId}:${serviceClient.clientSecret}")
+            }
+            contentType(ContentType.Application.Json)
+            setBody("{\"token\": \"${apiToken}\"}")
+        }.apply {
+            assertEquals(HttpStatusCode.OK, status)
+            val json = Json.parseToJsonElement(bodyAsText())
+            assertNotNull(json.jsonObject["token"])
+            assertEquals(samlToken, json.jsonObject["token"]!!.toString().removePrefix("\"").removeSuffix("\""))
+            coVerify(exactly = 1) {
+                tokenService.validateApiToken(apiToken)
+            }
+            coVerify(exactly = 1) {
+                samlTokenService.generate(serviceClient.samlCredential, testUser, any(), any())
+            }
+            confirmVerified(tokenService)
+        }
+    }
+
+    @Before
+    fun resetMocks() {
+        clearAllMocks()
+        coEvery { tokenService.validateApiToken(any()) } returns null
+        coEvery { tokenService.validateApiToken(apiToken)} returns testUser.cn
+        coEvery { userLookupService.lookupUserByCn(testUser.cn) } returns testUser
+        coEvery { samlTokenService.generate(serviceClient.samlCredential, testUser, any(), any())} returns samlToken
+    }
+
+    companion object {
+        private lateinit var testApp: TestApplication
+        private lateinit var testClient: HttpClient
+        private lateinit var controller: InternalDeltaApiTokenController
+
+        private val tokenService = mockk<DeltaApiTokenService>()
+        private val samlTokenService = mockk<SAMLTokenService>()
+        private val userLookupService = mockk<UserLookupService>()
+
+        private val apiToken = "valid_api_token"
+        private val samlToken = "saml_token"
+
+        private val testUser = testLdapUser()
+
+        private val serviceClient = Client("test-client", "test-secret", SAMLConfig.insecureHardcodedCredentials())
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            controller = InternalDeltaApiTokenController(tokenService, samlTokenService, userLookupService)
+
+            testApp = TestApplication {
+                application {
+                    configureSerialization()
+                    authentication {
+                        clientHeaderAuth(CLIENT_HEADER_AUTH_NAME) {
+                            headerName = "Delta-Client"
+                            clients = listOf(serviceClient)
+                        }
+                    }
+                    routing {
+                        authenticate(CLIENT_HEADER_AUTH_NAME, strategy = AuthenticationStrategy.Required) {
+                            route("/internal/delta-api/validate") {
+                                controller.route(this)
+                            }
+                        }
+                    }
+                }
+            }
+
+            testClient = testApp.createClient {
+                install(ContentNegotiation) {
+                    json()
+                }
+                followRedirects = false
+            }
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDown() {
+            testApp.stop()
+        }
+    }
 }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/InternalDeltaApiTokenControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/InternalDeltaApiTokenControllerTest.kt
@@ -27,6 +27,7 @@ import uk.gov.communities.delta.auth.security.clientHeaderAuth
 import uk.gov.communities.delta.auth.services.DeltaApiTokenService
 import uk.gov.communities.delta.auth.services.UserLookupService
 import uk.gov.communities.delta.helper.testLdapUser
+import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
@@ -81,8 +82,8 @@ class InternalDeltaApiTokenControllerTest {
     fun resetMocks() {
         clearAllMocks()
         coEvery { tokenService.validateApiToken(any()) } returns null
-        coEvery { tokenService.validateApiToken(apiToken)} returns Triple(testUser.cn, testUserClientId, testUser.javaUUIDObjectGuid)
-        coEvery { userLookupService.lookupUserByCn(testUser.cn) } returns testUser
+        coEvery { tokenService.validateApiToken(apiToken)} returns Triple(testUser.cn, testUserClientId, testUser.getGUID())
+        coEvery { userLookupService.lookupUserByCN(testUser.cn) } returns testUser
         coEvery { samlTokenService.generate(serviceClient.samlCredential, testUser, any(), any())} returns samlToken
     }
 
@@ -98,7 +99,7 @@ class InternalDeltaApiTokenControllerTest {
         private val apiToken = "valid_api_token"
         private val samlToken = "saml_token"
 
-        private val testUser = testLdapUser(javaUUIDObjectGuid = "testGuid")
+        private val testUser = testLdapUser()
         private val testUserClientId = "client_id"
 
         private val serviceClient = Client("test-client", "test-secret", SAMLConfig.insecureHardcodedCredentials())

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/service/DeltaApiTokenServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/service/DeltaApiTokenServiceTest.kt
@@ -1,4 +1,49 @@
 package uk.gov.communities.delta.service
 
+import io.ktor.test.dispatcher.*
+import org.junit.BeforeClass
+import org.junit.Test
+import uk.gov.communities.delta.auth.services.DeltaApiTokenService
+import uk.gov.communities.delta.auth.utils.TimeSource
+import uk.gov.communities.delta.dbintegration.testDbPool
+import uk.gov.communities.delta.helper.testServiceClient
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
 class DeltaApiTokenServiceTest {
+    @Test
+    fun canValidateApiClientIdAndSecret() = testSuspend {
+        val result = service.validateApiClientIdAndSecret("valid_id", "valid_secret")
+        assertTrue(result)
+    }
+
+    @Test
+    fun rejectsInvalidClientIdAndSecret() = testSuspend {
+        val result = service.validateApiClientIdAndSecret("ff", "gg")
+        assertFalse(result)
+    }
+
+    @Test
+    fun canCreateAndStoreAndValidateApiToken() = testSuspend {
+        val userName = "user_name"
+        val token = service.createAndStoreApiToken(userName, "valid_id")
+        val result = service.validateApiToken(token)
+        assertEquals(userName, result)
+    }
+
+    companion object {
+        lateinit var service: DeltaApiTokenService
+        val client = testServiceClient()
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            service = DeltaApiTokenService(testDbPool, TimeSource.System)
+            testDbPool.useConnectionBlocking("test_data_creation") {
+                it.createStatement().execute("INSERT INTO api_clients (client_id, client_secret) VALUES ('valid_id', 'valid_secret')")
+                it.commit()
+            }
+        }
+    }
 }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/service/DeltaApiTokenServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/service/DeltaApiTokenServiceTest.kt
@@ -52,15 +52,12 @@ class DeltaApiTokenServiceTest {
     @Before
     fun resetMocks() {
         clearAllMocks()
-        coEvery { userLookupService.lookupUserByCn(testUser.cn) } returns testUser
         coEvery { userAuditService.apiTokenCreationAudit(testUser.cn, any()) } just runs
     }
 
     companion object {
         lateinit var service: DeltaApiTokenService
         val client = testServiceClient()
-
-        private val userLookupService = mockk<UserLookupService>()
         private val userAuditService = mockk<UserAuditService>()
 
         private val testUser = testLdapUser()
@@ -68,7 +65,7 @@ class DeltaApiTokenServiceTest {
         @BeforeClass
         @JvmStatic
         fun setup() {
-            service = DeltaApiTokenService(testDbPool, TimeSource.System, userLookupService, userAuditService)
+            service = DeltaApiTokenService(testDbPool, TimeSource.System, userAuditService)
             testDbPool.useConnectionBlocking("test_data_creation") {
                 it.createStatement().execute("INSERT INTO api_clients (client_id, client_secret) VALUES ('valid_id', 'valid_secret')")
                 it.commit()

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/service/DeltaApiTokenServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/service/DeltaApiTokenServiceTest.kt
@@ -33,10 +33,13 @@ class DeltaApiTokenServiceTest {
     @Test
     fun canCreateAndStoreAndValidateApiToken() = testSuspend {
         val userName = testUser.cn
+        val userGuid = testUser.javaUUIDObjectGuid
+        val userClientId = "valid_id"
         val fakeCall = mockk<ApplicationCall>()
-        val token = service.createAndStoreApiToken(userName, "valid_id", fakeCall)
+        val token = service.createAndStoreApiToken(userName, userClientId, userGuid, fakeCall)
         val result = service.validateApiToken(token)
-        assertEquals(userName, result)
+        assertEquals(Triple(userName, userClientId, userGuid), result)
+        coVerify { userAuditService.apiTokenCreationAudit(userName, any()) }
     }
 
     @Test

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/service/DeltaApiTokenServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/service/DeltaApiTokenServiceTest.kt
@@ -1,0 +1,4 @@
+package uk.gov.communities.delta.service
+
+class DeltaApiTokenServiceTest {
+}

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/service/DeltaApiTokenServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/service/DeltaApiTokenServiceTest.kt
@@ -34,13 +34,13 @@ class DeltaApiTokenServiceTest {
     @Test
     fun canCreateAndStoreAndValidateApiToken() = testSuspend {
         val userName = testUser.cn
-        val userGuid = testUser.javaUUIDObjectGuid
+        val userGuid = testUser.getGUID()
         val userClientId = "valid_id"
         val fakeCall = mockk<ApplicationCall>()
         val token = service.createAndStoreApiToken(userName, userClientId, userGuid, fakeCall)
         val result = service.validateApiToken(token)
         assertEquals(Triple(userName, userClientId, userGuid), result)
-        coVerify { userAuditService.apiTokenCreationAudit(userName, any()) }
+        coVerify { userAuditService.apiTokenCreationAudit(userGuid, any()) }
     }
 
     @Test
@@ -53,7 +53,7 @@ class DeltaApiTokenServiceTest {
     @Before
     fun resetMocks() {
         clearAllMocks()
-        coEvery { userAuditService.apiTokenCreationAudit(testUser.cn, any()) } just runs
+        coEvery { userAuditService.apiTokenCreationAudit(testUser.getGUID(), any()) } just runs
     }
 
     companion object {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/service/DeltaApiTokenServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/service/DeltaApiTokenServiceTest.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.delta.service
 import io.ktor.server.application.*
 import io.ktor.test.dispatcher.*
 import io.mockk.*
+import org.junit.AfterClass
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -68,6 +69,16 @@ class DeltaApiTokenServiceTest {
             service = DeltaApiTokenService(testDbPool, TimeSource.System, userAuditService)
             testDbPool.useConnectionBlocking("test_data_creation") {
                 it.createStatement().execute("INSERT INTO api_clients (client_id, client_secret) VALUES ('valid_id', 'valid_secret')")
+                it.commit()
+            }
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun teardown() {
+            testDbPool.useConnectionBlocking("test_data_removal") {
+                it.createStatement().execute("DELETE FROM api_tokens")
+                it.createStatement().execute("DELETE FROM api_clients")
                 it.commit()
             }
         }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/service/DeltaApiTokenServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/service/DeltaApiTokenServiceTest.kt
@@ -1,11 +1,17 @@
 package uk.gov.communities.delta.service
 
+import io.ktor.server.application.*
 import io.ktor.test.dispatcher.*
+import io.mockk.*
+import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
 import uk.gov.communities.delta.auth.services.DeltaApiTokenService
+import uk.gov.communities.delta.auth.services.UserAuditService
+import uk.gov.communities.delta.auth.services.UserLookupService
 import uk.gov.communities.delta.auth.utils.TimeSource
 import uk.gov.communities.delta.dbintegration.testDbPool
+import uk.gov.communities.delta.helper.testLdapUser
 import uk.gov.communities.delta.helper.testServiceClient
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -26,20 +32,40 @@ class DeltaApiTokenServiceTest {
 
     @Test
     fun canCreateAndStoreAndValidateApiToken() = testSuspend {
-        val userName = "user_name"
-        val token = service.createAndStoreApiToken(userName, "valid_id")
+        val userName = testUser.cn
+        val fakeCall = mockk<ApplicationCall>()
+        val token = service.createAndStoreApiToken(userName, "valid_id", fakeCall)
         val result = service.validateApiToken(token)
         assertEquals(userName, result)
+    }
+
+    @Test
+    fun rejectsInvalidApiToken() = testSuspend {
+        val token = "fake_token"
+        val result = service.validateApiToken(token)
+        assertEquals(null, result)
+    }
+
+    @Before
+    fun resetMocks() {
+        clearAllMocks()
+        coEvery { userLookupService.lookupUserByCn(testUser.cn) } returns testUser
+        coEvery { userAuditService.apiTokenCreationAudit(testUser.cn, any()) } just runs
     }
 
     companion object {
         lateinit var service: DeltaApiTokenService
         val client = testServiceClient()
 
+        private val userLookupService = mockk<UserLookupService>()
+        private val userAuditService = mockk<UserAuditService>()
+
+        private val testUser = testLdapUser()
+
         @BeforeClass
         @JvmStatic
         fun setup() {
-            service = DeltaApiTokenService(testDbPool, TimeSource.System)
+            service = DeltaApiTokenService(testDbPool, TimeSource.System, userLookupService, userAuditService)
             testDbPool.useConnectionBlocking("test_data_creation") {
                 it.createStatement().execute("INSERT INTO api_clients (client_id, client_secret) VALUES ('valid_id', 'valid_secret')")
                 it.commit()

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/tasks/DeleteOldApiTokensTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/tasks/DeleteOldApiTokensTest.kt
@@ -14,19 +14,21 @@ import uk.gov.communities.delta.auth.utils.TimeSource
 import uk.gov.communities.delta.dbintegration.testDbPool
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import java.util.*
 import kotlin.test.assertEquals
 
 class DeleteOldApiTokensTest {
     @Test
     fun deleteOldApiTokensTest() = testSuspend {
         clearAllMocks()
-        val userGuid = null
+        val newUserGuid = UUID.randomUUID()
+        val oldUserGuid = UUID.randomUUID()
         val userClientId = "valid_id"
         val fakeCall = mockk<ApplicationCall>()
         coEvery { userAuditService.apiTokenCreationAudit(any(), any()) } just runs
-        deltaApiTokenService.createAndStoreApiToken("newTokenUser", userClientId, userGuid, fakeCall)
+        deltaApiTokenService.createAndStoreApiToken("newTokenUser", userClientId, newUserGuid, fakeCall)
         time = { Instant.now().minus(2, ChronoUnit.DAYS) }
-        deltaApiTokenService.createAndStoreApiToken("oldTokenUser", userClientId, userGuid, fakeCall)
+        deltaApiTokenService.createAndStoreApiToken("oldTokenUser", userClientId, oldUserGuid, fakeCall)
         time = { Instant.now() }
 
         testDbPool.useConnectionBlocking("test") {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/tasks/DeleteOldApiTokensTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/tasks/DeleteOldApiTokensTest.kt
@@ -3,13 +3,13 @@ package uk.gov.communities.delta.tasks
 import io.ktor.server.application.*
 import io.ktor.test.dispatcher.*
 import io.mockk.*
+import org.junit.AfterClass
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
 import uk.gov.communities.delta.auth.services.DeltaApiTokenService
 import uk.gov.communities.delta.auth.services.UserAuditService
 import uk.gov.communities.delta.auth.tasks.DeleteOldApiTokens
-import uk.gov.communities.delta.auth.tasks.DeleteOldAuthCodes
 import uk.gov.communities.delta.auth.utils.TimeSource
 import uk.gov.communities.delta.dbintegration.testDbPool
 import java.time.Instant
@@ -87,6 +87,16 @@ class DeleteOldApiTokensTest {
         fun setup() {
             testDbPool.useConnectionBlocking("test_data_creation") {
                 it.createStatement().execute("INSERT INTO api_clients (client_id, client_secret) VALUES ('valid_id', 'valid_secret')")
+                it.commit()
+            }
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun teardown() {
+            testDbPool.useConnectionBlocking("test_data_removal") {
+                it.createStatement().execute("DELETE FROM api_tokens")
+                it.createStatement().execute("DELETE FROM api_clients")
                 it.commit()
             }
         }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/tasks/DeleteOldApiTokensTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/tasks/DeleteOldApiTokensTest.kt
@@ -1,0 +1,94 @@
+package uk.gov.communities.delta.tasks
+
+import io.ktor.server.application.*
+import io.ktor.test.dispatcher.*
+import io.mockk.*
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import uk.gov.communities.delta.auth.services.DeltaApiTokenService
+import uk.gov.communities.delta.auth.services.UserAuditService
+import uk.gov.communities.delta.auth.tasks.DeleteOldApiTokens
+import uk.gov.communities.delta.auth.tasks.DeleteOldAuthCodes
+import uk.gov.communities.delta.auth.utils.TimeSource
+import uk.gov.communities.delta.dbintegration.testDbPool
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import kotlin.test.assertEquals
+
+class DeleteOldApiTokensTest {
+    @Test
+    fun deleteOldApiTokensTest() = testSuspend {
+        clearAllMocks()
+        val userGuid = null
+        val userClientId = "valid_id"
+        val fakeCall = mockk<ApplicationCall>()
+        coEvery { userAuditService.apiTokenCreationAudit(any(), any()) } just runs
+        deltaApiTokenService.createAndStoreApiToken("newTokenUser", userClientId, userGuid, fakeCall)
+        time = { Instant.now().minus(2, ChronoUnit.DAYS) }
+        deltaApiTokenService.createAndStoreApiToken("oldTokenUser", userClientId, userGuid, fakeCall)
+        time = { Instant.now() }
+
+        testDbPool.useConnectionBlocking("test") {
+            assertEquals(
+                1,
+                countApiTokens("oldTokenUser")
+            )
+            assertEquals(
+                1,
+                countApiTokens("newTokenUser")
+            )
+        }
+
+        DeleteOldApiTokens(testDbPool).execute()
+
+        testDbPool.useConnectionBlocking("test") {
+            assertEquals(
+                0,
+                countApiTokens("oldTokenUser")
+            )
+            assertEquals(
+                1,
+                countApiTokens("newTokenUser")
+            )
+        }
+    }
+
+    private fun countApiTokens(userCn: String): Int {
+        return testDbPool.useConnectionBlocking("test") {
+            val stmt = it
+                .prepareStatement("SELECT COUNT(*) FROM api_tokens WHERE created_by_user_cn = ?")
+            stmt.setString(1, userCn)
+            val resultSet = stmt.executeQuery()
+            resultSet.next()
+            resultSet.getInt(1)
+        }
+    }
+
+    @Before
+    fun resetMocks() {
+        clearAllMocks()
+        coEvery { userAuditService.apiTokenCreationAudit(any(), any()) } just runs
+    }
+
+    companion object {
+        private var time = { Instant.now() }
+
+        private val timeSource = object : TimeSource {
+            override fun now(): Instant {
+                return time()
+            }
+        }
+        private val userAuditService = mockk<UserAuditService>()
+        private val deltaApiTokenService = DeltaApiTokenService(testDbPool, timeSource, userAuditService)
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            testDbPool.useConnectionBlocking("test_data_creation") {
+                it.createStatement().execute("INSERT INTO api_clients (client_id, client_secret) VALUES ('valid_id', 'valid_secret')")
+                it.commit()
+            }
+        }
+    }
+}

--- a/terraform/modules/auth_service/main.tf
+++ b/terraform/modules/auth_service/main.tf
@@ -167,6 +167,10 @@ module "fargate" {
       name      = "AZ_SSO_CLIENTS_JSON"
       valueFrom = data.aws_secretsmanager_secret.sso_config.arn
     },
+    {
+      name      = "CLIENT_SECRET_DELTA_API"
+      valueFrom = aws_secretsmanager_secret.client_secret_delta_api.arn
+    },
     var.delta_website_local_dev_client_secret_arn == null ? null : {
       name      = "CLIENT_SECRET_DELTA_WEBSITE_DEV"
       valueFrom = var.delta_website_local_dev_client_secret_arn

--- a/terraform/modules/auth_service/schedule.tf
+++ b/terraform/modules/auth_service/schedule.tf
@@ -8,6 +8,10 @@ locals {
       cron     = "10 0 * * ? *" // Ten past midnight
       timezone = "Europe/London"
     }
+    DeleteOldApiTokens = {
+      cron     = "20 0 * * ? *" // Twenty past midnight
+      timezone = "Europe/London"
+    }
   }
 }
 

--- a/terraform/modules/auth_service/secrets.tf
+++ b/terraform/modules/auth_service/secrets.tf
@@ -11,10 +11,30 @@ data "aws_secretsmanager_secret" "saml_certificate" {
 # See api/README.md and terraform/test/main.tf in the Delta repository for setup instructions
 data "aws_secretsmanager_secret" "delta_saml_private_key" {
   name = "delta-saml-private-key-${var.environment}"
+
+  //noinspection HCLUnknownBlockType
+  lifecycle {
+    //noinspection HCLUnknownBlockType
+    postcondition {
+      //noinspection HILUnresolvedReference
+      condition     = self.kms_key_id == aws_kms_key.auth_service.arn
+      error_message = "Secret must use the auth service KMS key"
+    }
+  }
 }
 
 data "aws_secretsmanager_secret" "delta_saml_certificate" {
   name = "delta-saml-certificate-${var.environment}"
+
+  //noinspection HCLUnknownBlockType
+  lifecycle {
+    //noinspection HCLUnknownBlockType
+    postcondition {
+      //noinspection HILUnresolvedReference
+      condition     = self.kms_key_id == aws_kms_key.auth_service.arn
+      error_message = "Secret must use the auth service KMS key"
+    }
+  }
 }
 
 resource "aws_kms_key" "auth_service" {

--- a/terraform/modules/auth_service/secrets.tf
+++ b/terraform/modules/auth_service/secrets.tf
@@ -13,7 +13,7 @@ data "aws_secretsmanager_secret" "delta_saml_private_key" {
   name = "delta-saml-private-key-${var.environment}"
 }
 
-data "aws_secretsmanager_secret" "delta_saml_private_key" {
+data "aws_secretsmanager_secret" "delta_saml_certificate" {
   name = "delta-saml-certificate-${var.environment}"
 }
 

--- a/terraform/modules/auth_service/secrets.tf
+++ b/terraform/modules/auth_service/secrets.tf
@@ -7,6 +7,16 @@ data "aws_secretsmanager_secret" "saml_certificate" {
   name = "api-saml-certificate-${var.environment}"
 }
 
+# TODO 836 ticket specific release action: manually create these secrets, copying the current values from the API secrets, so they can be referenced here
+# See api/README.md and terraform/test/main.tf in the Delta repository for setup instructions
+data "aws_secretsmanager_secret" "delta_saml_private_key" {
+  name = "delta-saml-private-key-${var.environment}"
+}
+
+data "aws_secretsmanager_secret" "delta_saml_private_key" {
+  name = "delta-saml-certificate-${var.environment}"
+}
+
 resource "aws_kms_key" "auth_service" {
   description         = "auth-service-${var.environment}"
   enable_key_rotation = true

--- a/terraform/modules/auth_service/secrets.tf
+++ b/terraform/modules/auth_service/secrets.tf
@@ -132,3 +132,21 @@ data "aws_secretsmanager_secret" "delta_ses_credentials" {
 
   name = var.mail_settings.smtp_secret_name
 }
+
+resource "random_password" "client_secret_delta_api" {
+  length  = 32
+  special = false
+}
+
+# No CMK, secret is shared between multiple services
+# tfsec:ignore:aws-ssm-secret-use-customer-key
+resource "aws_secretsmanager_secret" "client_secret_delta_api" {
+  name                    = "tf-${var.environment}-delta-api-client-secret"
+  description             = "Shared secret for Delta API Gateway -> auth service for internal API calls"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "client_secret_delta_api" {
+  secret_id     = aws_secretsmanager_secret.client_secret_delta_api.id
+  secret_string = random_password.client_secret_delta_api.result
+}


### PR DESCRIPTION
**Description** Endpoints in the auth service and service methods to support them.

**Local testing** Automated tests for all new methods and endpoints, and manually tested locally with the gateway.

**Release** The auth service side I don't think entails any changes.
