### PR TITLE
DT-629 Enable user update notification emails on production

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -32,8 +32,8 @@ locals {
   environment                    = "production"
   cloudwatch_log_expiration_days = 731
   dclg_access_group_notification_settings = {
-    enabled                     = false
-    additional_recipient_emails = []
+    enabled                     = true
+    additional_recipient_emails = ["Group-DLUHCDeltaNotifications@softwire.com", "DELTAadmin@levellingup.gov.uk", "DELTAStatSupport@levellingup.gov.uk"]
   }
 }
 

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -33,7 +33,7 @@ locals {
   cloudwatch_log_expiration_days = 731
   dclg_access_group_notification_settings = {
     enabled                     = true
-    additional_recipient_emails = ["Group-DLUHCDeltaNotifications@softwire.com", "DELTAadmin@levellingup.gov.uk", "DELTAStatSupport@levellingup.gov.uk"]
+    additional_recipient_emails = ["Group-DLUHCDeltaNotifications@softwire.com", "delta-notifications@levellingup.gov.uk", "DELTAadmin@levellingup.gov.uk", "DELTAStatSupport@levellingup.gov.uk"]
   }
 }
 


### PR DESCRIPTION
**Description** Enable the new user update notifications on production. Should be roughly co-ordinated with removing the old `mhclg-user-added-to-stats-user-group` part of the ldap-audit which I'll raise a ticket for, though I think it's fine if both are enabled for a bit.
