### PR TITLE
DT-697 Add total number of available records to user audit fetch

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/UserAuditTrailRepo.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/UserAuditTrailRepo.kt
@@ -59,6 +59,19 @@ class UserAuditTrailRepo {
     }
 
     @Blocking
+    fun getAuditItemCount(conn: Connection, userCn: String): Int {
+        val stmt = conn.prepareStatement(
+            "SELECT COUNT(*) " +
+                "FROM user_audit " +
+                "WHERE user_cn = ?"
+        )
+        stmt.setString(1, userCn)
+        val resultSet = stmt.executeQuery()
+        resultSet.next()
+        return resultSet.getInt(1)
+    }
+
+    @Blocking
     fun insertAuditRow(
         conn: Connection,
         action: AuditAction,

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditTrailRepoTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditTrailRepoTest.kt
@@ -41,6 +41,13 @@ class UserAuditTrailRepoTest {
         }
     }
 
+    @Test
+    fun testRecordCount() {
+        testDbPool.useConnectionBlocking("test_login_audit") {
+            assertEquals(2, repo.getAuditItemCount(it, "some.user!audit-test.com"))
+        }
+    }
+
     companion object {
         lateinit var repo: UserAuditTrailRepo
 


### PR DESCRIPTION
**Description** Return "totalRecords" with the fetch user audit JSON response, and accept a pageSize query parameter.

**Local testing** Tested locally as part of Delta change

**Release** Auth service only
