### PR TITLE
DT-697 Add endpoint to get audit CSV for all users

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditService.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.json.Json
 import uk.gov.communities.delta.auth.config.AzureADSSOClient
 import uk.gov.communities.delta.auth.repositories.DbPool
 import uk.gov.communities.delta.auth.repositories.UserAuditTrailRepo
+import java.time.Instant
 
 class UserAuditService(private val userAuditTrailRepo: UserAuditTrailRepo, private val dbPool: DbPool) {
     suspend fun getAuditForUser(userCn: String) = withContext(Dispatchers.IO) {
@@ -31,6 +32,12 @@ class UserAuditService(private val userAuditTrailRepo: UserAuditTrailRepo, priva
                     userAuditTrailRepo.getAuditItemCount(it, userCn),
                 )
             }
+        }
+    }
+
+    suspend fun getAuditForAllUsers(from: Instant, to: Instant) = withContext(Dispatchers.IO) {
+        dbPool.useConnectionBlocking("all_users_audit_read") {
+            userAuditTrailRepo.getAuditForAllUsers(it, from, to)
         }
     }
 

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditTrailRepoTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditTrailRepoTest.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.junit.BeforeClass
 import org.junit.Test
 import uk.gov.communities.delta.auth.repositories.UserAuditTrailRepo
+import java.time.Instant
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
@@ -45,6 +46,16 @@ class UserAuditTrailRepoTest {
     fun testRecordCount() {
         testDbPool.useConnectionBlocking("test_login_audit") {
             assertEquals(2, repo.getAuditItemCount(it, "some.user!audit-test.com"))
+        }
+    }
+
+    @Test
+    fun testAllUserAudit() {
+        testDbPool.useConnectionBlocking("test_login_audit") { conn ->
+            val all = repo.getAuditForAllUsers(conn, Instant.now().minusSeconds(60), Instant.now().plusSeconds(10))
+            assertEquals(2, all.filter { it.userCn == "some.user!audit-test.com" }.size)
+            val allAfterNow = repo.getAuditForAllUsers(conn, Instant.now().plusSeconds(60), Instant.now().plusSeconds(100))
+            assertEquals(0, allAfterNow.size)
         }
     }
 


### PR DESCRIPTION
**Description** For the "Download audit report" button on the Admin -> Users page in Delta. This can get pretty large on production, but should be fine for a reasonable time range. The query isn't indexed, but the table is still small enough that a full scan is ~seconds.

We could combine this with the other CSV endpoint and make all the parameters optional, but it felt slightly simpler to make it separate.

**Local testing** Tested as part of Delta work.

**Release** Auth service only.
