### PR TITLE
DT-976-2: Remove uses of userCN (using userGUID instead)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_ci }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_key_ci }}
       AWS_REGION: "eu-west-1"
-      VERSION: "10.0"
+      VERSION: "11.0"
       REPOSITORY: "delta-auth-service"
       ECR_PATH: "468442790030.dkr.ecr.eu-west-1.amazonaws.com"
     outputs:

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaLoginController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaLoginController.kt
@@ -192,7 +192,6 @@ class DeltaLoginController(
                 }
 
                 val authCode = authorizationCodeService.generateAndStore(
-                    userCn = loginResult.user.cn,
                     loginResult.user.getGUID(),
                     client = client,
                     traceId = call.callId!!,
@@ -200,7 +199,7 @@ class DeltaLoginController(
                 )
 
                 logger.atInfo().withAuthCode(authCode).log("Successful login")
-                userAuditService.userFormLoginAudit(loginResult.user.cn, loginResult.user.getGUID(), call)
+                userAuditService.userFormLoginAudit(loginResult.user.getGUID(), call)
                 successfulLoginCounter.increment(1.0)
                 call.respondRedirect(client.deltaWebsiteUrl + "/login/oauth2/redirect?code=${authCode.code}&state=${queryParams.state.encodeURLParameter()}")
             }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSSOLoginController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSSOLoginController.kt
@@ -37,6 +37,7 @@ class DeltaSSOLoginController(
     private val ssoConfig: AzureADSSOConfig,
     private val ssoLoginStateService: SSOLoginSessionStateService,
     private val ldapLookupService: UserLookupService,
+    private val userGUIDMapService: UserGUIDMapService,
     private val authorizationCodeService: AuthorizationCodeService,
     private val microsoftGraphService: MicrosoftGraphService,
     private val registrationService: RegistrationService,
@@ -78,8 +79,8 @@ class DeltaSSOLoginController(
 
         logger.info("OAuth callback successfully authenticated user with email {}, checking in on-prem AD", email)
 
-        var user = ldapLookupService.userIfExists(email)
-        if (user == null) {
+        var userGUID = userGUIDMapService.userGUIDIfExists(email)
+        if (userGUID == null) {
             if (!ssoClient.required) {
                 logger.info("User {} not found in AD, and SSO is not required, so redirecting to register page", email)
                 return call.respondRedirect("/delta/register?fromSSOEmail=${email.encodeURLParameter()}")
@@ -99,9 +100,10 @@ class DeltaSSOLoginController(
                 logger.error("Error creating SSO User, result was {}", registrationResult.toString())
                 throw Exception("Error creating SSO User")
             }
-            user = ldapLookupService.userIfExists(email)!!
+            userGUID = userGUIDMapService.userGUIDIfExists(email)!!
         }
 
+        val user = ldapLookupService.lookupUserByGUID(userGUID)
         checkUserEnabled(user)
         checkUserHasEmail(user)
         lookupAndCheckAzureGroups(user, principal, ssoClient)
@@ -109,12 +111,12 @@ class DeltaSSOLoginController(
 
         val client = clientConfig.oauthClients.first { it.clientId == session.clientId }
         val authCode = authorizationCodeService.generateAndStore(
-            userCn = user.cn, userGUID = user.getGUID(), client = client, traceId = call.callId!!, isSso = true
+            userGUID = user.getGUID(), client = client, traceId = call.callId!!, isSso = true
         )
 
         logger.atInfo().withAuthCode(authCode).log("Successful OAuth login")
         ssoLoginCounter.increment()
-        userAuditService.userSSOLoginAudit(authCode.userCn, authCode.userGUID, ssoClient, jwt.userObjectId, call)
+        userAuditService.userSSOLoginAudit(authCode.userGUID, ssoClient, jwt.userObjectId, call)
         call.sessions.clear<LoginSessionCookie>()
         call.respondRedirect(client.deltaWebsiteUrl + "/login/oauth2/redirect?code=${authCode.code}&state=${session.deltaState.encodeURLParameter()}")
     }
@@ -159,7 +161,7 @@ class DeltaSSOLoginController(
         if (!user.accountEnabled) {
             throw OAuthLoginException(
                 "user_disabled",
-                "User ${user.cn} is disabled in Active Directory, login blocked",
+                "User ${user.getGUID()} is disabled in Active Directory, login blocked",
                 "Your Delta user account is disabled. If you haven't used your account before please check for an activation email otherwise please contact the service desk"
             )
         }
@@ -169,7 +171,7 @@ class DeltaSSOLoginController(
         if (user.email.isNullOrEmpty()) {
             throw OAuthLoginException(
                 "user_no_mail_attribute",
-                "User ${user.cn} has no email set in Active Directory, login blocked",
+                "User ${user.getGUID()} has no email set in Active Directory, login blocked",
                 "Your Delta user account is not fully set up (missing mail attribute). Please contact the Service Desk."
             )
         }
@@ -212,7 +214,7 @@ class DeltaSSOLoginController(
         if (ssoClient.requiredGroupId != null && !azGroups.contains(ssoClient.requiredGroupId)) {
             throw OAuthLoginException(
                 "not_in_required_azure_group",
-                "User ${user.cn} not in required Azure group ${ssoClient.requiredGroupId}",
+                "User ${user.getGUID()} not in required Azure group ${ssoClient.requiredGroupId}",
                 "This account (${user.cn.replace('!', '@')}) is not configured for Single Sign On for Delta (not in required Azure AD users group ${ssoClient.requiredGroupId}). Please contact the Service Desk"
             )
         }
@@ -221,7 +223,7 @@ class DeltaSSOLoginController(
         if (adminGroups.isNotEmpty() && ssoClient.requiredAdminGroupId != null && !azGroups.contains(ssoClient.requiredAdminGroupId)) {
             throw OAuthLoginException(
                 "not_in_required_admin_group",
-                "User ${user.cn} is admin in Delta (member of ${adminGroups.joinToString(", ")}), but not member of required admin group ${ssoClient.requiredAdminGroupId}",
+                "User ${user.getGUID()} is admin in Delta (member of ${adminGroups.joinToString(", ")}), but not member of required admin group ${ssoClient.requiredAdminGroupId}",
                 "You are an admin user in Delta, but have not been added to the Delta Admin SSO Users group in ${ssoClient.internalId.uppercase()} (${ssoClient.requiredAdminGroupId}). Please contact the Service Desk"
             )
         }
@@ -231,12 +233,12 @@ class DeltaSSOLoginController(
         if (!user.memberOfCNs.contains(DeltaConfig.DATAMART_DELTA_USER)) {
             logger.error(
                 "User {} is not a member of required Delta group {}",
-                keyValue("username", user.cn),
+                keyValue("userGUID", user.getGUID()),
                 DeltaConfig.DATAMART_DELTA_USER
             )
             throw OAuthLoginException(
                 "not_delta_user",
-                "User ${user.cn} is not member of required Delta group ${DeltaConfig.DATAMART_DELTA_USER}",
+                "User ${user.getGUID()} is not member of required Delta group ${DeltaConfig.DATAMART_DELTA_USER}",
                 "Your Delta user is misconfigured (not in ${DeltaConfig.DATAMART_DELTA_USER}). Please contact the Service Desk",
             )
         }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaUserRegistrationController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaUserRegistrationController.kt
@@ -19,7 +19,6 @@ class DeltaUserRegistrationController(
     private val ssoConfig: AzureADSSOConfig,
     private val organisationService: OrganisationService,
     private val registrationService: RegistrationService,
-    private val userAuditService: UserAuditService,
 ) {
     private val logger = LoggerFactory.getLogger(this.javaClass)
     private val emailAddressChecker = EmailAddressChecker()

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminEditUserEmailController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminEditUserEmailController.kt
@@ -10,12 +10,14 @@ import kotlinx.serialization.Serializable
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.plugins.ApiError
 import uk.gov.communities.delta.auth.services.DeltaSystemRole
+import uk.gov.communities.delta.auth.services.UserGUIDMapService
 import uk.gov.communities.delta.auth.services.UserLookupService
 import uk.gov.communities.delta.auth.services.UserService
 import uk.gov.communities.delta.auth.utils.EmailAddressChecker
 
 class AdminEditUserEmailController(
     private val userLookupService: UserLookupService,
+    private val userGUIDMapService: UserGUIDMapService,
     private val userService: UserService,
 ) : AdminUserController(userLookupService) {
 
@@ -33,8 +35,9 @@ class AdminEditUserEmailController(
         val requestData = call.receive<DeltaEmailChangeRequest>()
         val requestedEmail = requestData.newEmail
 
-        // TODO DT-1022 - use GUID once it is being received
-        val userToEdit = userLookupService.lookupUserByCn(requestData.userToEditCn)
+        // TODO DT-1022 - get GUID from request directly
+        val userToEditGUID = userGUIDMapService.getGUID(requestData.userToEditCn)
+        val userToEdit = userLookupService.lookupUserByGUID(userToEditGUID)
 
         validateEmail(requestedEmail)
         logger.atInfo().addKeyValue("oldUserEmail", userToEdit.email)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminEditUserNotificationStatusController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminEditUserNotificationStatusController.kt
@@ -4,15 +4,16 @@ import io.ktor.server.application.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.services.DeltaSystemRole
+import uk.gov.communities.delta.auth.services.UserGUIDMapService
 import uk.gov.communities.delta.auth.services.UserLookupService
 import uk.gov.communities.delta.auth.services.UserService
 
 class AdminEditUserNotificationStatusController(
     private val userLookupService: UserLookupService,
+    private val userGUIDMapService: UserGUIDMapService,
     private val userService: UserService,
 ) : AdminUserController(userLookupService) {
 
@@ -29,8 +30,13 @@ class AdminEditUserNotificationStatusController(
 
         val requestData = call.receive<DeltaChangeNotificationStatusRequest>()
 
-        val userToEdit = userLookupService.lookupUserByCn(requestData.userToEditCn)
-        logger.atInfo().log("Updating notification status for user {} to {}", userToEdit.cn, requestData.enableNotifications)
+        val userToEditGUID = userGUIDMapService.getGUID(requestData.userToEditCn)
+        val userToEdit = userLookupService.lookupUserByGUID(userToEditGUID)
+        logger.atInfo().log(
+            "Updating notification status for user {} to {}",
+            userToEdit.getGUID(),
+            requestData.enableNotifications
+        )
 
         userService.updateNotificationStatus(userToEdit, requestData.enableNotifications, session, call)
         return call.respond(mapOf("message" to "Notification status has been updated."))

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminGetUserController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminGetUserController.kt
@@ -5,14 +5,16 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import org.slf4j.LoggerFactory
-import uk.gov.communities.delta.auth.plugins.ApiError
+import uk.gov.communities.delta.auth.plugins.NoUserException
 import uk.gov.communities.delta.auth.services.DeltaSystemRole
 import uk.gov.communities.delta.auth.services.LdapUserWithRoles
+import uk.gov.communities.delta.auth.services.UserGUIDMapService
 import uk.gov.communities.delta.auth.services.UserLookupService
-import uk.gov.communities.delta.auth.utils.getUserFromCallParameters
+import uk.gov.communities.delta.auth.utils.getUserGUIDFromCallParameters
 
 class AdminGetUserController(
     private val userLookupService: UserLookupService,
+    private val userGUIDMapService: UserGUIDMapService,
 ) : AdminUserController(userLookupService) {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -28,14 +30,14 @@ class AdminGetUserController(
 
         val userWithRoles: LdapUserWithRoles
         try {
-            val user = getUserFromCallParameters( // TODO DT-1022 - make this get userGUID instead
+            val userGUID = getUserGUIDFromCallParameters(
                 call.request.queryParameters,
-                userLookupService,
+                userGUIDMapService,
                 "An error occurred when getting user details",
                 "get_user"
             )
-            userWithRoles = userLookupService.loadUserRoles(user) // TODO DT-1022 - change back to lookupUserByGUIDAndLoadRoles
-        } catch (e: ApiError) {
+            userWithRoles = userLookupService.lookupUserByGUIDAndLoadRoles(userGUID)
+        } catch (e: NoUserException) {
             logger.warn(e.errorDescription)
             return call.respond(HttpStatusCode.NotFound, "User not found")
         }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminResetMfaTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminResetMfaTokenController.kt
@@ -7,11 +7,13 @@ import io.ktor.server.routing.*
 import kotlinx.serialization.Serializable
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.services.DeltaSystemRole
+import uk.gov.communities.delta.auth.services.UserGUIDMapService
 import uk.gov.communities.delta.auth.services.UserLookupService
 import uk.gov.communities.delta.auth.services.UserService
 
 class AdminResetMfaTokenController (
     private val userLookupService: UserLookupService,
+    private val userGUIDMapService: UserGUIDMapService,
     private val userService: UserService,
 ) : AdminUserController(userLookupService) {
 
@@ -28,8 +30,9 @@ class AdminResetMfaTokenController (
 
         val requestData = call.receive<DeltaResetMfaTokenRequest>()
 
-        val userToEdit = userLookupService.lookupUserByCn(requestData.userToEditCn)
-        logger.atInfo().log("Resetting MFA token for user {}", userToEdit.cn)
+        val userToEditGUID = userGUIDMapService.getGUID(requestData.userToEditCn) // TODO DT-1022 - get GUID directly
+        val userToEdit = userLookupService.lookupUserByGUID(userToEditGUID)
+        logger.atInfo().log("Resetting MFA token for user {}", userToEdit.getGUID())
 
         if (userToEdit.deltaTOTPSecret.isNullOrEmpty()) {
             return call.respond(mapOf("message" to "User MFA token already reset."))

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/EditLdapGroupsController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/EditLdapGroupsController.kt
@@ -15,7 +15,8 @@ import uk.gov.communities.delta.auth.utils.getUserFromCallParameters
 
 class EditLdapGroupsController(
     private val groupService: GroupService,
-    private val userLookupService: UserLookupService
+    private val userLookupService: UserLookupService,
+    private val userGUIDMapService: UserGUIDMapService,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -27,13 +28,14 @@ class EditLdapGroupsController(
         val user = getUserFromCallParameters(
             call.parameters,
             userLookupService,
+            userGUIDMapService,
             "An error occurred adding groups to the user",
             "add_ldap_group"
         )
         
         if (!user.memberOfCNs.contains(groupCn)) {
             logger.info("Adding user {} to group CN={}", user.getGUID(), groupCn)
-            groupService.addUserToGroup(user, groupCn, call, null, userLookupService)
+            groupService.addUserToGroup(user, groupCn, call, null)
         }
         call.response.status(HttpStatusCode.NoContent)
     }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/EditOrganisationsController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/EditOrganisationsController.kt
@@ -32,7 +32,7 @@ class EditOrganisationsController(
     private suspend fun updateUserOrganisations(call: ApplicationCall) {
         val session = call.principal<OAuthSession>()!!
         val (callingUser, callingUserRoles) = userLookupService.lookupCurrentUserAndLoadRoles(session)
-        logger.atInfo().log("Updating organisations for user {}", session.userCn)
+        logger.atInfo().log("Updating organisations for user {}", session.userGUID)
 
         val requestedOrganisations = call.receive<DeltaUserOrganisations>().selectedDomainOrganisationCodes
         val userDomainOrgCodes = organisationService.findAllByEmail(callingUser.email).map { it.code }.toSet()
@@ -51,7 +51,7 @@ class EditOrganisationsController(
         for (org in orgsToAdd) {
             for (role in callingUserRoles.systemRoles) {
                 val roleGroupString = role.role.adCn(org)
-                groupService.addUserToGroup(callingUser, roleGroupString, call, null, userLookupService,)
+                groupService.addUserToGroup(callingUser, roleGroupString, call, null)
             }
         }
 
@@ -63,7 +63,6 @@ class EditOrganisationsController(
                         group,
                         call,
                         null,
-                        userLookupService,
                     )
                 }
             }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/EditRolesController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/EditRolesController.kt
@@ -32,7 +32,7 @@ class EditRolesController(
         val request = call.receive<DeltaUserRolesRequest>()
 
         val (callingUser, callingUserRoles) = userLookupService.lookupCurrentUserAndLoadRoles(session)
-        logger.atInfo().log("Request to update own roles for user ${session.userCn}")
+        logger.atInfo().log("Request to update own roles for user ${session.userGUID}")
 
         checkRequestedRolesArePermitted(request, callingUser)
 
@@ -50,19 +50,11 @@ class EditRolesController(
         val groupCNsToRemoveFilteredForMembership =
             groupCNsToRemove.filter { callingUser.memberOfCNs.contains(it) }
 
-        logger.atInfo().log("Granting user ${session.userCn} groups $groupCNsToAddFilteredForNonMembership")
-        groupCNsToAddFilteredForNonMembership
-            .forEach {
-                groupService.addUserToGroup(callingUser, it, call, null, userLookupService,)
-            }
+        logger.atInfo().log("Granting user ${session.userGUID} groups $groupCNsToAddFilteredForNonMembership")
+        groupCNsToAddFilteredForNonMembership.forEach { groupService.addUserToGroup(callingUser, it, call, null) }
 
-        logger.atInfo().log("Revoking user ${session.userCn} groups $groupCNsToRemoveFilteredForMembership")
-        groupCNsToRemoveFilteredForMembership
-            .forEach {
-                groupService.removeUserFromGroup(
-                    callingUser, it, call, null, userLookupService,
-                )
-            }
+        logger.atInfo().log("Revoking user ${session.userGUID} groups $groupCNsToRemoveFilteredForMembership")
+        groupCNsToRemoveFilteredForMembership.forEach { groupService.removeUserFromGroup(callingUser, it, call, null) }
 
         return call.respond(mapOf("message" to "Roles have been updated. Any changes to your roles or access groups will take effect the next time you log in."))
     }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/EditUserDetailsController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/EditUserDetailsController.kt
@@ -30,7 +30,7 @@ class EditUserDetailsController(
     private suspend fun updateUserDetails(call: ApplicationCall) {
         val session = call.principal<OAuthSession>()!!
         val callingUser = userLookupService.lookupCurrentUser(session)
-        logger.atInfo().log("Updating details for user {}", session.userCn)
+        logger.atInfo().log("Updating details for user {}", session.userGUID)
 
         val updatedDeltaUserDetails = call.receive<DeltaUserMyDetails>()
 
@@ -45,7 +45,7 @@ class EditUserDetailsController(
 
         val modifications = getModifications(callingUser, updatedDeltaUserDetails)
 
-        userService.updateUser(callingUser, modifications, null, userLookupService, call)
+        userService.updateUser(callingUser, modifications, null, call)
 
         return call.respond(mapOf("message" to "Details have been updated."))
     }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/GenerateSAMLTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/GenerateSAMLTokenController.kt
@@ -33,7 +33,7 @@ class GenerateSAMLTokenController(private val samlTokenService: SAMLTokenService
 
         call.respond(
             GenerateSAMLTokenResponse(
-                username = user.ldapUser.cn, // TODO DT-1022 - make the SAML token response use GUID not CN?
+                username = user.ldapUser.cn,
                 token = token,
                 expiry = DateTimeFormatter.ISO_INSTANT.format(validTo),
             )

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/GenerateSAMLTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/GenerateSAMLTokenController.kt
@@ -33,7 +33,7 @@ class GenerateSAMLTokenController(private val samlTokenService: SAMLTokenService
 
         call.respond(
             GenerateSAMLTokenResponse(
-                username = user.ldapUser.cn,
+                username = user.ldapUser.cn, // TODO DT-1022 - make the SAML token response use GUID not CN?
                 token = token,
                 expiry = DateTimeFormatter.ISO_INSTANT.format(validTo),
             )

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/OAuthTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/OAuthTokenController.kt
@@ -68,7 +68,7 @@ class OAuthTokenController(
             val samlToken = samlTokenService.samlTokenForSession(userSession.session, userSession.user)
 
             val roles = memberOfToDeltaRolesMapperFactory(
-                userSession.user.cn, allOrganisations.await(), allAccessGroups.await()
+                userSession.user.getGUID(), allOrganisations.await(), allAccessGroups.await()
             ).map(userSession.user.memberOfCNs)
 
             logger.atInfo().withSession(userSession.session).log("Successful token request")

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/Monitoring.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/Monitoring.kt
@@ -89,7 +89,7 @@ val addBearerSessionInfoToMDC = createRouteScopedPlugin("AddBearerSessionInfoToM
         val session = call.principal<OAuthSession>() ?: return@on proceed()
         val mdcContextMap = MDC.getCopyOfContextMap() ?: mutableMapOf()
         mdcContextMap["username"] = session.userCn
-        // TODO DT-976-2 - once all sessions have a GUID log GUID instead of username
+        mdcContextMap["userGUID"] = session.userGUID.toString()
         mdcContextMap["oauthSession"] = session.id.toString()
         mdcContextMap["trace"] = session.traceId
         withContext(MDCContext(mdcContextMap)) {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/StatusPages.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/StatusPages.kt
@@ -135,6 +135,8 @@ open class ApiError(
     val userVisibleMessage: String? = null,
 ) : Exception("$errorCode ($statusCode) $errorDescription")
 
+open class NoUserException(errorMessage: String) : ApiError(HttpStatusCode.BadRequest, "no_user", errorMessage)
+
 open class UserVisibleServerError(
     val errorCode: String,
     exceptionMessage: String,

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/LdapRepository.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/LdapRepository.kt
@@ -1,13 +1,12 @@
 package uk.gov.communities.delta.auth.repositories
 
-import io.ktor.http.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import org.jetbrains.annotations.Blocking
 import org.slf4j.LoggerFactory
 import uk.gov.communities.delta.auth.config.DeltaConfig
 import uk.gov.communities.delta.auth.config.LDAPConfig
-import uk.gov.communities.delta.auth.plugins.ApiError
+import uk.gov.communities.delta.auth.plugins.NoUserException
 import uk.gov.communities.delta.auth.utils.toActiveDirectoryGUIDSearchString
 import uk.gov.communities.delta.auth.utils.toGUIDString
 import java.lang.Integer.parseInt
@@ -23,6 +22,7 @@ import javax.naming.ldap.Control
 import javax.naming.ldap.InitialLdapContext
 import javax.naming.ldap.PagedResultsControl
 import javax.naming.ldap.PagedResultsResponseControl
+import kotlin.collections.set
 import kotlin.time.Duration.Companion.seconds
 
 class LdapRepository(
@@ -32,8 +32,6 @@ class LdapRepository(
     enum class ObjectGUIDMode {
         OLD_MANGLED, NEW_JAVA_UUID_STRING;
     }
-
-    class NoUserException(errorMessage: String) : ApiError(HttpStatusCode.BadRequest, "no_user", errorMessage)
 
     private val logger = LoggerFactory.getLogger(javaClass)
     private val groupDnToCnRegex = Regex(ldapConfig.groupDnFormat.replace("%s", "([\\w-]+)"))

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/UserGUIDMapRepo.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/UserGUIDMapRepo.kt
@@ -1,0 +1,62 @@
+package uk.gov.communities.delta.auth.repositories
+
+import org.jetbrains.annotations.Blocking
+import uk.gov.communities.delta.auth.plugins.NoUserException
+import java.sql.Connection
+import java.util.*
+
+class UserGUIDMapRepo {
+
+    @Blocking
+    fun getCNForUser(conn: Connection, userGUID: UUID): String {
+        val stmt = conn.prepareStatement("SELECT user_cn FROM user_guid_map WHERE user_guid = ?")
+        stmt.setObject(1, userGUID)
+        val result = stmt.executeQuery()
+        if (!result.next()) throw NoUserException("No user found with GUID $userGUID")
+        else return result.getString("user_cn")
+    }
+
+    @Blocking
+    fun getGUIDForUser(conn: Connection, userCN: String): UUID {
+        val stmt = conn.prepareStatement("SELECT user_guid FROM user_guid_map WHERE user_cn = ?")
+        stmt.setObject(1, userCN)
+        val result = stmt.executeQuery()
+        if (!result.next()) throw NoUserException("No user found with userCN $userCN")
+        else return result.getObject("user_guid", UUID::class.java)
+    }
+
+    @Blocking
+    fun updateUser(conn: Connection, user: LdapUser, newUserCN: String) {
+        val stmt = conn.prepareStatement("UPDATE user_guid_map SET user_cn = ? WHERE user_guid = ?")
+        stmt.setString(1, newUserCN)
+        stmt.setObject(2, user.getGUID())
+        val result = stmt.executeUpdate()
+        if (result == 0)
+        // NB: this should not be seen in production or staging but may occur on test or dev due to shared AD
+            addMissingUser(conn, user, newUserCN)
+        else if (result != 1) throw Exception("Expected to change only 1 row but was $result")
+    }
+
+    @Blocking
+    fun addMissingUser(conn: Connection, user: LdapUser, newUserCN: String? = null) {
+        // NB: this should not need to be used in production or staging but may occur on test or dev due to shared AD
+        addRow(conn, newUserCN ?: user.cn, user.getGUID())
+    }
+
+    @Blocking
+    fun newUser(conn: Connection, user: LdapUser) {
+        addRow(conn, user.cn, user.getGUID())
+    }
+
+    @Blocking
+    private fun addRow(conn: Connection, userCN: String, userGUID: UUID) {
+        val stmt = conn.prepareStatement(
+            "INSERT INTO user_guid_map (user_guid, user_cn) VALUES (?, ?) " +
+                "ON CONFLICT (user_guid) DO UPDATE SET user_cn = ?"
+        )
+        stmt.setObject(1, userGUID)
+        stmt.setString(2, userCN)
+        stmt.setString(3, userCN)
+        stmt.executeUpdate()
+    }
+}

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/ADLdapLoginService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/ADLdapLoginService.kt
@@ -76,7 +76,7 @@ class ADLdapLoginService(
         return try {
             context = ldapRepository.bind(userDn, password)
             val user = ldapRepository.mapUserFromContext(context, userDn)
-            if (!user.accountEnabled) throw Exception("Logged in user '${user.cn}' is disabled, this should never happen")
+            if (!user.accountEnabled) throw Exception("Logged in user '${user.getGUID()}' is disabled, this should never happen")
             IADLdapLoginService.LdapLoginSuccess(user)
         } catch (e: NamingException) {
             logger.debug("LDAP login failed for user $userDn", e)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/Security.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/security/Security.kt
@@ -65,7 +65,7 @@ fun Application.configureSecurity(injection: Injection) {
                     logger.warn("OAuth Bearer token authentication, rejecting due to missing client authentication")
                     return@authenticate null
                 }
-                oauthSessionService.retrieveFomAuthToken(it.token, clientPrincipal.client as DeltaLoginEnabledClient)
+                oauthSessionService.retrieveFromAuthToken(it.token, clientPrincipal.client as DeltaLoginEnabledClient)
             }
         }
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/AuthorizationCodeService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/AuthorizationCodeService.kt
@@ -18,7 +18,6 @@ import java.util.*
 // It's a short-lived code that can be exchanged using the token endpoint for user details and a longer lived access token
 data class AuthCode(
     val code: String,
-    val userCn: String,
     val userGUID: UUID,
     val client: Client,
     val createdAt: Instant,
@@ -38,7 +37,6 @@ class AuthorizationCodeService(private val dbPool: DbPool, private val timeSourc
     }
 
     suspend fun generateAndStore(
-        userCn: String,
         userGUID: UUID,
         client: Client,
         traceId: String,
@@ -46,7 +44,7 @@ class AuthorizationCodeService(private val dbPool: DbPool, private val timeSourc
     ): AuthCode {
         val code = randomBase64(AUTH_CODE_LENGTH_BYTES)
         val now = timeSource.now()
-        val authCode = AuthCode(code, userCn, userGUID, client, now, traceId, isSso)
+        val authCode = AuthCode(code, userGUID, client, now, traceId, isSso)
         withContext(Dispatchers.IO) { insert(authCode) }
 
         logger.atInfo().withAuthCode(authCode).log("Generated auth code at {}", now)
@@ -66,16 +64,15 @@ class AuthorizationCodeService(private val dbPool: DbPool, private val timeSourc
     private fun insert(authCode: AuthCode) {
         dbPool.useConnectionBlocking("Insert Auth Code") {
             val stmt = it.prepareStatement(
-                "INSERT INTO authorization_code (username, client_id, code_hash, created_at, trace_id, is_sso, user_guid) " +
-                    "VALUES (?, ?, ?, ?, ?, ?, ?)"
+                "INSERT INTO authorization_code (client_id, code_hash, created_at, trace_id, is_sso, user_guid) " +
+                    "VALUES (?, ?, ?, ?, ?, ?)"
             )
-            stmt.setString(1, authCode.userCn)
-            stmt.setString(2, authCode.client.clientId)
-            stmt.setBytes(3, hashBase64String(authCode.code))
-            stmt.setTimestamp(4, Timestamp.from(authCode.createdAt))
-            stmt.setString(5, authCode.traceId)
-            stmt.setBoolean(6, authCode.isSso)
-            stmt.setObject(7, authCode.userGUID)
+            stmt.setString(1, authCode.client.clientId)
+            stmt.setBytes(2, hashBase64String(authCode.code))
+            stmt.setTimestamp(3, Timestamp.from(authCode.createdAt))
+            stmt.setString(4, authCode.traceId)
+            stmt.setBoolean(5, authCode.isSso)
+            stmt.setObject(6, authCode.userGUID)
             stmt.executeUpdate()
             it.commit()
         }
@@ -92,7 +89,7 @@ class AuthorizationCodeService(private val dbPool: DbPool, private val timeSourc
         return dbPool.useConnectionBlocking("Consume auth code") {
             val stmt = it.prepareStatement(
                 "DELETE FROM authorization_code " +
-                    "WHERE code_hash = ? AND client_id = ? RETURNING username, created_at, trace_id, is_sso, user_guid"
+                    "WHERE code_hash = ? AND client_id = ? RETURNING created_at, trace_id, is_sso, user_guid"
             )
             stmt.setBytes(1, codeHash)
             stmt.setString(2, client.clientId)
@@ -103,7 +100,6 @@ class AuthorizationCodeService(private val dbPool: DbPool, private val timeSourc
             }
             val authCode = AuthCode(
                 code = code,
-                userCn = resultSet.getString("username"),
                 userGUID = resultSet.getObject("user_guid", UUID::class.java),
                 client = client,
                 createdAt = resultSet.getTimestamp("created_at").toInstant(),
@@ -117,4 +113,4 @@ class AuthorizationCodeService(private val dbPool: DbPool, private val timeSourc
 }
 
 fun LoggingEventBuilder.withAuthCode(authCode: AuthCode): LoggingEventBuilder =
-    addKeyValue("username", authCode.userCn).addKeyValue("trace", authCode.traceId)
+    addKeyValue("userGUID", authCode.userGUID).addKeyValue("trace", authCode.traceId)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/EmailService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/EmailService.kt
@@ -43,7 +43,7 @@ class EmailService(
 
     suspend fun sendAlreadyAUserEmail(
         firstName: String,
-        userCN: String,
+        userGUID: UUID,
         contacts: EmailContacts,
     ) {
         sendTemplateEmail(
@@ -55,61 +55,36 @@ class EmailService(
                 "userFirstName" to firstName,
             )
         )
-        logger.atInfo().addKeyValue("userCN", userCN).log("Sent already-a-user email")
+        logger.atInfo().addKeyValue("receivingUserGUID", userGUID).log("Sent already-a-user email")
     }
 
     suspend fun sendSetPasswordEmail(
         user: LdapUser,
         token: String,
         triggeringAdminSession: OAuthSession?,
-        userLookupService: UserLookupService, // TODO DT-976-2 - remove once GUID is definitely in session
         call: ApplicationCall
-    ) {
-        sendSetPasswordEmail(
-            user.firstName,
-            token,
-            user.cn,
-            user.getGUID(),
-            triggeringAdminSession,
-            userLookupService,
-            EmailContacts(user.email!!, user.fullName, emailConfig),
-            call
-        )
-    }
-
-    suspend fun sendSetPasswordEmail(
-        firstName: String,
-        token: String,
-        userCN: String,
-        userGUID: UUID,
-        triggeringAdminSession: OAuthSession?,
-        userLookupService: UserLookupService, // TODO DT-976-2 - remove once GUID is definitely in session
-        contacts: EmailContacts,
-        call: ApplicationCall,
     ) {
         sendTemplateEmail(
             "new-user",
-            contacts,
+            EmailContacts(user.email!!, user.fullName, emailConfig),
             "DLUHC Delta - New User Account",
             mapOf(
                 "deltaUrl" to deltaConfig.deltaWebsiteUrl,
-                "userFirstName" to firstName,
+                "userFirstName" to user.firstName,
                 "setPasswordUrl" to getSetPasswordURL(
                     token,
-                    userCN,
+                    user.getGUID(),
                     authServiceConfig.serviceUrl
                 )
             )
         )
         if (triggeringAdminSession != null) userAuditService.adminSetPasswordEmailAudit(
-            userCN,
-            userGUID,
-            triggeringAdminSession.userCn,
-            triggeringAdminSession.getUserGUID(userLookupService),
+            user.getGUID(),
+            triggeringAdminSession.userGUID,
             call
         )
-        else userAuditService.setPasswordEmailAudit(userCN, userGUID, call)
-        logger.atInfo().addKeyValue("userCN", userCN).log("Sent new-user email")
+        else userAuditService.setPasswordEmailAudit(user.getGUID(), call)
+        logger.atInfo().addKeyValue("receivingUserGUID", user.getGUID()).log("Sent new-user email")
     }
 
     suspend fun sendNoUserEmail(emailAddress: String) {
@@ -128,132 +103,69 @@ class EmailService(
     }
 
     suspend fun sendNotYetEnabledEmail(user: LdapUser, token: String, call: ApplicationCall) {
-        sendNotYetEnabledEmail(
-            user.firstName,
-            token,
-            user.cn,
-            user.getGUID(),
-            EmailContacts(user.email!!, user.fullName, emailConfig),
-            call,
-        )
-    }
-
-    private suspend fun sendNotYetEnabledEmail(
-        firstName: String,
-        token: String,
-        userCN: String,
-        userGUID: UUID,
-        contacts: EmailContacts,
-        call: ApplicationCall,
-    ) {
         sendTemplateEmail(
             "not-yet-enabled-user",
-            contacts,
+            EmailContacts(user.email!!, user.fullName, emailConfig),
             "DLUHC Delta - Set Your Password",
             mapOf(
                 "deltaUrl" to deltaConfig.deltaWebsiteUrl,
-                "userFirstName" to firstName,
+                "userFirstName" to user.firstName,
                 "setPasswordUrl" to getSetPasswordURL(
                     token,
-                    userCN,
+                    user.getGUID(),
                     authServiceConfig.serviceUrl
                 )
             )
         )
-        userAuditService.setPasswordEmailAudit(userCN, userGUID, call)
-        logger.atInfo().addKeyValue("userCN", userCN).log("Sent not-yet-enabled-user email")
+        userAuditService.setPasswordEmailAudit(user.getGUID(), call)
+        logger.atInfo().addKeyValue("receivingUserGUID", user.getGUID()).log("Sent not-yet-enabled-user email")
     }
 
     suspend fun sendPasswordNeverSetEmail(user: LdapUser, token: String, call: ApplicationCall) {
-        sendPasswordNeverSetEmail(
-            user.firstName,
-            token,
-            user.cn,
-            user.getGUID(),
-            EmailContacts(user.email!!, user.fullName, emailConfig),
-            call,
-        )
-    }
-
-    private suspend fun sendPasswordNeverSetEmail(
-        firstName: String,
-        token: String,
-        userCN: String,
-        userGUID: UUID,
-        contacts: EmailContacts,
-        call: ApplicationCall,
-    ) {
         sendTemplateEmail(
             "password-never-set",
-            contacts,
+            EmailContacts(user.email!!, user.fullName, emailConfig),
             "DLUHC Delta - Set Password",
             mapOf(
                 "deltaUrl" to deltaConfig.deltaWebsiteUrl,
                 "setPasswordUrl" to getSetPasswordURL(
                     token,
-                    userCN,
+                    user.getGUID(),
                     authServiceConfig.serviceUrl
                 ),
-                "userFirstName" to firstName,
+                "userFirstName" to user.firstName,
             )
         )
-        userAuditService.setPasswordEmailAudit(userCN, userGUID, call)
-        logger.atInfo().addKeyValue("userCN", userCN).log("Sent password-never-set email")
+        userAuditService.setPasswordEmailAudit(user.getGUID(), call)
+        logger.atInfo().addKeyValue("receivingUserGUID", user.getGUID()).log("Sent password-never-set email")
     }
 
     suspend fun sendResetPasswordEmail(
         user: LdapUser,
         token: String,
         triggeringAdminSession: OAuthSession?,
-        userLookupService: UserLookupService, // TODO DT-976-2 - remove once GUID is definitely in session
         call: ApplicationCall
-    ) {
-        sendResetPasswordEmail(
-            user.firstName,
-            token,
-            user.cn,
-            user.getGUID(),
-            triggeringAdminSession,
-            userLookupService,
-            EmailContacts(user.email!!, user.fullName, emailConfig),
-            call,
-        )
-    }
-
-    private suspend fun sendResetPasswordEmail(
-        firstName: String,
-        token: String,
-        userCN: String,
-        userGUID: UUID,
-        triggeringAdminSession: OAuthSession?,
-        userLookupService: UserLookupService, // TODO DT-976-2 - remove once GUID is definitely in session
-        contacts: EmailContacts,
-        call: ApplicationCall,
     ) {
         sendTemplateEmail(
             "reset-password",
-            contacts,
+            EmailContacts(user.email!!, user.fullName, emailConfig),
             "DLUHC Delta - Reset Your Password",
             mapOf(
                 "deltaUrl" to deltaConfig.deltaWebsiteUrl,
-                "userFirstName" to firstName,
+                "userFirstName" to user.firstName,
                 "resetPasswordUrl" to getResetPasswordURL(
                     token,
-                    userCN,
+                    user.getGUID(),
                     authServiceConfig.serviceUrl
                 )
             )
         )
         if (triggeringAdminSession != null) userAuditService.adminResetPasswordEmailAudit(
-            userCN,
-            userGUID,
-            triggeringAdminSession.userCn,
-            triggeringAdminSession.getUserGUID(userLookupService),
-            call
+            user.getGUID(), triggeringAdminSession.userGUID, call
         )
-        else userAuditService.resetPasswordEmailAudit(userCN, userGUID, call)
+        else userAuditService.resetPasswordEmailAudit(user.getGUID(), call)
 
-        logger.atInfo().addKeyValue("userCN", userCN).log("Sent reset-password email")
+        logger.atInfo().addKeyValue("receivingUserGUID", user.getGUID()).log("Sent reset-password email")
     }
 
     suspend fun sendEmailForUserAddedToDCLGInAccessGroup(

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/LdapServiceUserBind.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/LdapServiceUserBind.kt
@@ -2,15 +2,9 @@ package uk.gov.communities.delta.auth.services
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.jetbrains.annotations.Blocking
 import uk.gov.communities.delta.auth.config.LDAPConfig
 import uk.gov.communities.delta.auth.repositories.LdapRepository
-import javax.naming.directory.Attributes
-import javax.naming.directory.SearchControls
-import javax.naming.ldap.Control
 import javax.naming.ldap.InitialLdapContext
-import javax.naming.ldap.PagedResultsControl
-import javax.naming.ldap.PagedResultsResponseControl
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OAuthSessionService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OAuthSessionService.kt
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory
 import org.slf4j.spi.LoggingEventBuilder
 import uk.gov.communities.delta.auth.config.DeltaLoginEnabledClient
 import uk.gov.communities.delta.auth.repositories.DbPool
+import uk.gov.communities.delta.auth.repositories.UserGUIDMapRepo
 import uk.gov.communities.delta.auth.utils.TimeSource
 import uk.gov.communities.delta.auth.utils.hashBase64String
 import uk.gov.communities.delta.auth.utils.randomBase64
@@ -18,30 +19,29 @@ import kotlin.time.Duration.Companion.hours
 
 data class OAuthSession(
     val id: Int, // Our internal database id, no relation to the value of the SESSIONID cookie in Delta, or sessionId from Delta's logs
-    val userCn: String,
-    val userGUID: UUID?, // TODO DT-976-2 - make this not nullable
+    val userCn: String?,
+    val userGUID: UUID,
     val client: DeltaLoginEnabledClient,
     val authToken: String,
     val createdAt: Instant,
     val traceId: String,
     val isSso: Boolean,
-    val impersonatedUserCn: String? = null,
     val impersonatedUserGUID: UUID? = null,
 ) : Principal {
     fun expired(timeSource: TimeSource) =
         createdAt.plusSeconds(OAuthSessionService.TOKEN_VALID_DURATION_SECONDS) < timeSource.now()
-
-    suspend fun getUserGUID(userLookupService: UserLookupService): UUID {
-        return this.userGUID ?: userLookupService.lookupUserByCn(this.userCn).getGUID() // TODO DT-976-2 - no longer needed
-    }
 }
 
 interface IOAuthSessionService {
     suspend fun create(authCode: AuthCode, client: DeltaLoginEnabledClient): OAuthSession
-    suspend fun retrieveFomAuthToken(authToken: String, client: DeltaLoginEnabledClient): OAuthSession?
+    suspend fun retrieveFromAuthToken(authToken: String, client: DeltaLoginEnabledClient): OAuthSession?
 }
 
-class OAuthSessionService(private val dbPool: DbPool, private val timeSource: TimeSource) : IOAuthSessionService {
+class OAuthSessionService(
+    private val dbPool: DbPool,
+    private val timeSource: TimeSource,
+    private val userGUIDMapRepo: UserGUIDMapRepo
+) : IOAuthSessionService {
     private val logger = LoggerFactory.getLogger(javaClass)
 
     companion object {
@@ -59,10 +59,10 @@ class OAuthSessionService(private val dbPool: DbPool, private val timeSource: Ti
     }
 
 
-    override suspend fun retrieveFomAuthToken(authToken: String, client: DeltaLoginEnabledClient): OAuthSession? {
+    override suspend fun retrieveFromAuthToken(authToken: String, client: DeltaLoginEnabledClient): OAuthSession? {
         val session = withContext(Dispatchers.IO) { select(authToken, client) } ?: return null
         if (session.expired(timeSource)) {
-            logger.atInfo().withSession(session).log("Session expired. Crated at {}", session.createdAt)
+            logger.atInfo().withSession(session).log("Session expired. Created at {}", session.createdAt)
             return null
         }
         logger.atDebug().withSession(session).log("Retrieved session from auth token")
@@ -73,42 +73,40 @@ class OAuthSessionService(private val dbPool: DbPool, private val timeSource: Ti
     private fun insert(authCode: AuthCode, client: DeltaLoginEnabledClient, token: String, now: Instant): OAuthSession {
         return dbPool.useConnectionBlocking("Insert delta_session") {
             val stmt = it.prepareStatement(
-                "INSERT INTO delta_session (username, client_id, auth_token_hash, created_at, trace_id, is_sso, user_guid) " +
-                    "VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id"
+                "INSERT INTO delta_session (client_id, auth_token_hash, created_at, trace_id, is_sso, user_guid) " +
+                    "VALUES (?, ?, ?, ?, ?, ?) RETURNING id"
             )
-            stmt.setString(1, authCode.userCn)
-            stmt.setString(2, client.clientId)
-            stmt.setBytes(3, hashBase64String(token))
-            stmt.setTimestamp(4, Timestamp.from(now))
-            stmt.setString(5, authCode.traceId)
-            stmt.setBoolean(6, authCode.isSso)
-            stmt.setObject(7, authCode.userGUID)
+            stmt.setString(1, client.clientId)
+            stmt.setBytes(2, hashBase64String(token))
+            stmt.setTimestamp(3, Timestamp.from(now))
+            stmt.setString(4, authCode.traceId)
+            stmt.setBoolean(5, authCode.isSso)
+            stmt.setObject(6, authCode.userGUID)
             val result = stmt.executeQuery()
             if (!result.next()) throw Exception("Expected one result")
             val id = result.getInt(1)
+            val userCN = userGUIDMapRepo.getCNForUser(it, authCode.userGUID)
             it.commit()
             OAuthSession(
                 id = id,
-                userCn = authCode.userCn,
+                userCn = userCN,
                 userGUID = authCode.userGUID,
                 client = client,
                 authToken = token,
                 createdAt = now,
                 traceId = authCode.traceId,
                 isSso = authCode.isSso,
-                impersonatedUserCn = null,
                 impersonatedUserGUID = null,
             )
         }
     }
 
     @Blocking
-    fun updateWithImpersonatedCn(sessionId: Int, impersonatedUserCn: String, impersonatedUserGUID: UUID?) {
+    fun updateWithImpersonatedGUID(sessionId: Int, impersonatedUserGUID: UUID?) {
         dbPool.useConnectionBlocking("impersonate_user") {
-            val stmt = it.prepareStatement("UPDATE delta_session SET impersonated_user_cn = ?, impersonated_user_guid = ? WHERE id = ?")
-            stmt.setString(1, impersonatedUserCn)
-            stmt.setObject(2, impersonatedUserGUID)
-            stmt.setInt(3, sessionId)
+            val stmt = it.prepareStatement("UPDATE delta_session SET impersonated_user_guid = ? WHERE id = ?")
+            stmt.setObject(1, impersonatedUserGUID)
+            stmt.setInt(2, sessionId)
             val result = stmt.executeUpdate()
             if (result != 1) throw Exception("Expected to change only 1 row but was $result")
             it.commit()
@@ -120,8 +118,11 @@ class OAuthSessionService(private val dbPool: DbPool, private val timeSource: Ti
         return dbPool.useConnectionBlocking("Read delta_session") {
             val stmt =
                 it.prepareStatement(
-                    "SELECT id, username, client_id, created_at, trace_id, is_sso, impersonated_user_cn, user_guid, impersonated_user_guid " +
-                            "FROM delta_session WHERE auth_token_hash = ? AND client_id = ?"
+                    "SELECT id, client_id, created_at, trace_id, is_sso, delta_session.user_guid, " +
+                        "user_guid_map.user_cn AS user_cn, impersonated_user_guid " +
+                        "FROM delta_session " +
+                        "LEFT JOIN user_guid_map ON delta_session.user_guid = user_guid_map.user_guid " +
+                        "WHERE auth_token_hash = ? AND client_id = ?"
                 )
             stmt.setBytes(1, hashBase64String(authToken))
             stmt.setString(2, client.clientId)
@@ -133,14 +134,13 @@ class OAuthSessionService(private val dbPool: DbPool, private val timeSource: Ti
 
                 OAuthSession(
                     id = result.getInt("id"),
-                    userCn = result.getString("username"),
                     userGUID = result.getObject("user_guid", UUID::class.java),
+                    userCn = result.getString("user_cn"),
                     client = client,
                     authToken = authToken,
                     createdAt = result.getTimestamp("created_at").toInstant(),
                     traceId = result.getString("trace_id"),
                     isSso = result.getBoolean("is_sso"),
-                    impersonatedUserCn = result.getString("impersonated_user_cn"),
                     impersonatedUserGUID = result.getObject("impersonated_user_guid", UUID::class.java),
                 )
             }
@@ -150,5 +150,6 @@ class OAuthSessionService(private val dbPool: DbPool, private val timeSource: Ti
 
 fun LoggingEventBuilder.withSession(session: OAuthSession): LoggingEventBuilder =
     addKeyValue("username", session.userCn)
+        .addKeyValue("userGUID", session.userGUID)
         .addKeyValue("oauthSession", session.id)
         .addKeyValue("trace", session.traceId)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserGUIDMapService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserGUIDMapService.kt
@@ -1,0 +1,77 @@
+package uk.gov.communities.delta.auth.services
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.slf4j.LoggerFactory
+import uk.gov.communities.delta.auth.config.LDAPConfig
+import uk.gov.communities.delta.auth.plugins.NoUserException
+import uk.gov.communities.delta.auth.repositories.DbPool
+import uk.gov.communities.delta.auth.repositories.LdapUser
+import uk.gov.communities.delta.auth.repositories.UserGUIDMapRepo
+import java.util.*
+
+class UserGUIDMapService(
+    private val userGUIDMapRepo: UserGUIDMapRepo,
+    private val userLookupService: UserLookupService,
+    private val dbPool: DbPool
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    suspend fun userGUIDIfExists(userEmail: String): UUID? {
+        return try {
+            getGUIDFromEmail(userEmail)
+        } catch (e: NoUserException) {
+            null
+        }
+    }
+
+    suspend fun getGUIDFromEmail(email: String): UUID {
+        return getGUID(LDAPConfig.emailToCN(email))
+    }
+
+    suspend fun getGUID(userCN: String): UUID {
+        try {
+            return withContext(Dispatchers.IO) {
+                dbPool.useConnectionBlocking("user_guid_read") {
+                    userGUIDMapRepo.getGUIDForUser(it, userCN)
+                }
+            }
+        } catch (e: NoUserException) {
+            val user = userLookupService.lookupUserByCN(userCN)
+            // NB: this should not be used in production or staging but may occur on test or dev due to shared AD
+            logger.atWarn().log("User with GUID {} existed in AD but was not found in user_guid_map", user.getGUID())
+            addMissingUser(user)
+            return user.getGUID()
+        }
+    }
+
+    suspend fun updateUserCN(
+        user: LdapUser,
+        newUserCN: String,
+    ) {
+        withContext(Dispatchers.IO) {
+            dbPool.useConnectionBlocking("updating_user_cn") {
+                userGUIDMapRepo.updateUser(it, user, newUserCN)
+                it.commit()
+            }
+        }
+    }
+
+    suspend fun addNewUser(user: LdapUser) {
+        withContext(Dispatchers.IO) {
+            dbPool.useConnectionBlocking("updating_user_cn") {
+                userGUIDMapRepo.newUser(it, user)
+                it.commit()
+            }
+        }
+    }
+
+    private suspend fun addMissingUser(user: LdapUser) {
+        withContext(Dispatchers.IO) {
+            dbPool.useConnectionBlocking("add_missing_user") {
+                userGUIDMapRepo.addMissingUser(it, user)
+                it.commit()
+            }
+        }
+    }
+}

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserLookupService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserLookupService.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import org.slf4j.LoggerFactory
-import uk.gov.communities.delta.auth.config.LDAPConfig
+import uk.gov.communities.delta.auth.plugins.NoUserException
 import uk.gov.communities.delta.auth.repositories.LdapRepository
 import uk.gov.communities.delta.auth.repositories.LdapUser
 import java.util.*
@@ -20,60 +20,36 @@ class UserLookupService(
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    suspend fun userIfExists(email: String): LdapUser? {
-        return try {
-            lookupUserByEmail(email)
-        } catch (e: LdapRepository.NoUserException) {
-            null
-        }
-    }
-
-    suspend fun lookupUserByEmail(email: String): LdapUser {
-        val cn = LDAPConfig.emailToCN(email)
-        return lookupUserByCn(cn)
-    }
-
-    suspend fun lookupUserByCn(cn: String): LdapUser {
-        // TODO DT-1022 - delete/combine with above once not used
-        val dn = userDnFormat.format(cn)
-        return lookupUserByDN(dn)
-    }
-
-    suspend fun lookupUserByDN(dn: String): LdapUser {
-        logger.atInfo().addKeyValue("userDN", dn).log("Looking up user in AD")
+    suspend fun lookupUserByCN(userCN: String): LdapUser {
+        val userDN = userDnFormat.format(userCN)
+        logger.atInfo().addKeyValue("userDN", userDN).log("Looking up user in AD")
         try {
             return ldapServiceUserBind.useServiceUserBind {
-                ldapRepository.mapUserFromContext(it, dn)
+                ldapRepository.mapUserFromContext(it, userDN)
             }
         } catch (e: NameNotFoundException) {
-            logger.atInfo().addKeyValue("userDN", dn).log("User not found in Active Directory", e)
-            throw LdapRepository.NoUserException("No user with dn $dn")
+            logger.atInfo().addKeyValue("userDN", userDN).log("User not found in Active Directory", e)
+            throw NoUserException("No user with dn $userDN")
         }
     }
 
     suspend fun lookupUserByGUID(userGUID: UUID): LdapUser {
-        logger.atInfo().addKeyValue("userGUID", userGUID).log("Looking up user in AD")
+        logger.atInfo().log("Looking up user with GUID {} in AD ", userGUID)
         try {
             return ldapServiceUserBind.useServiceUserBind {
                 ldapRepository.mapUserFromContext(it, userGUID)
             }
-        } catch (e: LdapRepository.NoUserException) {
-            throw LdapRepository.NoUserException("No user with GUID $userGUID")
+        } catch (e: NoUserException) {
+            throw NoUserException("No user with GUID $userGUID")
         }
     }
 
     suspend fun lookupCurrentUser(session: OAuthSession): LdapUser {
-        return if (session.userGUID != null)  // TODO DT-976-2 - no longer need this if
-            lookupUserByGUID(session.userGUID)
-        else
-            lookupUserByCn(session.userCn)
+        return lookupUserByGUID(session.userGUID)
     }
 
     suspend fun lookupCurrentUserAndLoadRoles(session: OAuthSession): LdapUserWithRoles {
-        return if (session.userGUID != null) // TODO DT-976-2 - no longer need this if
-            lookupUserByGUIDAndLoadRoles(session.userGUID)
-        else
-            lookupUserByCNAndLoadRoles(session.userCn)
+        return lookupUserByGUIDAndLoadRoles(session.userGUID)
     }
 
     private suspend fun loadUserRoles(user: Deferred<LdapUser>): LdapUserWithRoles = coroutineScope {
@@ -82,7 +58,7 @@ class UserLookupService(
 
         val awaitedUser = user.await()
         val roles = memberOfToDeltaRolesMapperFactory(
-            awaitedUser.cn,
+            awaitedUser.getGUID(),
             allOrganisations.await(),
             allAccessGroups.await()
         ).map(awaitedUser.memberOfCNs)
@@ -90,28 +66,8 @@ class UserLookupService(
         LdapUserWithRoles(awaitedUser, roles)
     }
 
-    // TODO DT-1022 - no longer needed
-    suspend fun loadUserRoles(user: LdapUser): LdapUserWithRoles = coroutineScope {
-        val allOrganisations = async { organisationService.findAllNamesAndCodes() }
-        val allAccessGroups = async { accessGroupsService.getAllAccessGroups() }
-
-        val roles = memberOfToDeltaRolesMapperFactory(
-            user.cn,
-            allOrganisations.await(),
-            allAccessGroups.await()
-        ).map(user.memberOfCNs)
-
-        LdapUserWithRoles(user, roles)
-    }
-
     suspend fun lookupUserByGUIDAndLoadRoles(guid: UUID): LdapUserWithRoles = coroutineScope {
         val user = async { lookupUserByGUID(guid) }
-        loadUserRoles(user)
-    }
-
-    suspend fun lookupUserByCNAndLoadRoles(cn: String): LdapUserWithRoles = coroutineScope {
-        // TODO DT-1022 - delete once not used
-        val user = async { lookupUserByCn(cn) }
         loadUserRoles(user)
     }
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/tasks/UpdateUserGUIDMap.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/tasks/UpdateUserGUIDMap.kt
@@ -14,6 +14,7 @@ import kotlin.time.Duration.Companion.minutes
 
 /*
  * Update the user_guid_map table to contain latest up to date userGUIDs and userCNs from Active Directory
+ * Should not be run on production as we will lose record of users deleted from AD
  */
 class UpdateUserGUIDMap(
     private val ldapConfig: LDAPConfig,

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/utils/Parameters.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/utils/Parameters.kt
@@ -4,9 +4,10 @@ import com.google.common.base.Strings
 import io.ktor.http.*
 import uk.gov.communities.delta.auth.config.LDAPConfig
 import uk.gov.communities.delta.auth.plugins.ApiError
+import uk.gov.communities.delta.auth.plugins.NoUserException
 import uk.gov.communities.delta.auth.plugins.UserVisibleServerError
-import uk.gov.communities.delta.auth.repositories.LdapRepository
 import uk.gov.communities.delta.auth.repositories.LdapUser
+import uk.gov.communities.delta.auth.services.UserGUIDMapService
 import uk.gov.communities.delta.auth.services.UserLookupService
 import java.util.*
 
@@ -24,16 +25,16 @@ private fun validateCN(userCN: String) {
 
 suspend fun getUserGUIDFromCallParameters(
     parameters: Parameters,
-    userLookupService: UserLookupService,
+    userGUIDMapService: UserGUIDMapService,
     userVisibleErrorMessage: String,
     action: String
 ): UUID {
-    val userCN = parameters["userCN"] ?: parameters["userCn"].orEmpty()
+    val userCN = parameters["userCN"] ?: parameters["userCn"] ?: parameters["cn"].orEmpty()
     val userGUIDString = parameters["userGUID"].orEmpty()
-    val user: LdapUser
 
     // During transition from userCN to userGUID exactly one should be non-empty
-    // TODO DT-1022 - simplify this to just get GUID directly
+    // TODO DT-1022 - simplify this to just get GUID from call once receiving GUID in all places
+    //  NB: Password flow used to send userCN and some people may still have (expired) links using that
     return if (Strings.isNullOrEmpty(userGUIDString)) {
         if (Strings.isNullOrEmpty(userCN)) throw UserVisibleServerError(
             action + "_no_user_cn_or_guid",
@@ -41,8 +42,7 @@ suspend fun getUserGUIDFromCallParameters(
             userVisibleErrorMessage
         )
         validateCN(userCN)
-        user = userLookupService.lookupUserByCn(userCN)
-        user.getGUID()
+        userGUIDMapService.getGUID(userCN)
     } else {
         if (!Strings.isNullOrEmpty(userCN)) throw UserVisibleServerError(
             action + "_both_user_cn_and_guid",
@@ -58,39 +58,15 @@ suspend fun getUserGUIDFromCallParameters(
 suspend fun getUserFromCallParameters(
     parameters: Parameters,
     userLookupService: UserLookupService,
+    userGUIDMapService: UserGUIDMapService,
     userVisibleErrorMessage: String,
     action: String
 ): LdapUser {
-    val userCN = parameters["userCN"] ?: parameters["userCn"].orEmpty()
-    val userGUIDString = parameters["userGUID"].orEmpty()
-    val userGUID: UUID
+    val userGUID = getUserGUIDFromCallParameters(parameters, userGUIDMapService, userVisibleErrorMessage, action)
 
-    // During transition from userCN to userGUID exactly one should be non-empty
-    // TODO DT-1022 - simplify this to just look for GUID
-    if (Strings.isNullOrEmpty(userGUIDString)) {
-        if (Strings.isNullOrEmpty(userCN)) throw UserVisibleServerError(
-            action + "_no_user_cn_or_guid",
-            "User CN and GUID both not present on $action",
-            userVisibleErrorMessage
-        )
-        validateCN(userCN)
-        try {
-            return userLookupService.lookupUserByCn(userCN)
-        } catch (e: LdapRepository.NoUserException) {
-            throw ApiError(HttpStatusCode.BadRequest, "user_not_found", "User not found")
-        }
-    } else {
-        if (!Strings.isNullOrEmpty(userCN)) throw UserVisibleServerError(
-            action + "_both_user_cn_and_guid",
-            "User CN and GUID both present on $action",
-            userVisibleErrorMessage
-        )
-        validateGUID(userGUIDString)
-        userGUID = UUID.fromString(userGUIDString)
-        try {
-            return userLookupService.lookupUserByGUID(userGUID)
-        } catch (e: LdapRepository.NoUserException) {
-            throw ApiError(HttpStatusCode.BadRequest, "user_not_found", "User not found")
-        }
+    try {
+        return userLookupService.lookupUserByGUID(userGUID)
+    } catch (e: NoUserException) {
+        throw ApiError(HttpStatusCode.BadRequest, "user_not_found", "User not found")
     }
 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/utils/Parameters.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/utils/Parameters.kt
@@ -23,6 +23,10 @@ private fun validateCN(userCN: String) {
     }
 }
 
+fun getIdentifyingParameterOrEmpty(parameters: Parameters) :String {
+    return parameters["userCN"] ?: parameters["userCn"] ?: parameters["cn"] ?: parameters["userGUID"].orEmpty()
+}
+
 suspend fun getUserGUIDFromCallParameters(
     parameters: Parameters,
     userGUIDMapService: UserGUIDMapService,

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/utils/UUIDUtils.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/utils/UUIDUtils.kt
@@ -33,7 +33,7 @@ fun UUID.toActiveDirectoryGUIDSearchString(): String {
 @OptIn(ExperimentalStdlibApi::class)
 fun String.toActiveDirectoryGUIDSearchString(): String {
     if (LDAPConfig.VALID_USER_GUID_REGEX.matchEntire(this)==null){
-        throw IllegalArgumentException("GUID must have format 00112233-4455-6677-8899-aabbccddeeff")
+        throw IllegalArgumentException("GUID must have format 00112233-4455-1677-8899-aabbccddeeff")
     }
     val hexBytesString = this.replace("-", "")
     val oldOrderBytes = hexBytesString.hexToByteArray()

--- a/auth-service/src/main/resources/db/migration/V10__backfill_guids_make_required_and_remove_cn.sql
+++ b/auth-service/src/main/resources/db/migration/V10__backfill_guids_make_required_and_remove_cn.sql
@@ -1,0 +1,89 @@
+UPDATE delta_session
+SET user_guid = ugm.newguid
+FROM user_guid_map ugm
+WHERE delta_session.username = ugm.cn
+  AND delta_session.user_guid IS NULL;
+
+UPDATE delta_session
+SET impersonated_user_guid = ugm.newguid
+FROM user_guid_map ugm
+WHERE delta_session.impersonated_user_cn IS NOT NULL
+  AND delta_session.impersonated_user_cn = ugm.cn
+  AND delta_session.impersonated_user_guid IS NULL;
+
+UPDATE authorization_code
+SET user_guid = ugm.newguid
+FROM user_guid_map ugm
+WHERE authorization_code.username = ugm.cn
+  AND authorization_code.user_guid IS NULL;
+
+UPDATE reset_password_tokens
+SET user_guid = ugm.newguid
+FROM user_guid_map ugm
+WHERE reset_password_tokens.user_cn = ugm.cn
+  AND reset_password_tokens.user_guid IS NULL;
+
+UPDATE set_password_tokens
+SET user_guid = ugm.newguid
+FROM user_guid_map ugm
+WHERE set_password_tokens.user_cn = ugm.cn
+  AND set_password_tokens.user_guid IS NULL;
+
+UPDATE user_audit
+SET user_guid = ugm.newguid
+FROM user_guid_map ugm
+WHERE user_audit.user_cn = ugm.cn
+  AND user_audit.user_guid IS NULL;
+
+UPDATE user_audit
+SET editing_user_guid = ugm.newguid
+FROM user_guid_map ugm
+WHERE user_audit.editing_user_cn IS NOT NULL
+  AND user_audit.editing_user_guid IS NULL
+  AND user_audit.editing_user_cn = ugm.cn;
+
+ALTER TABLE delta_session
+    ALTER COLUMN user_guid SET NOT NULL;
+ALTER TABLE delta_session
+    DROP COLUMN username;
+ALTER TABLE delta_session
+    DROP COLUMN impersonated_user_cn;
+
+ALTER TABLE authorization_code
+    ALTER COLUMN user_guid SET NOT NULL;
+ALTER TABLE authorization_code
+    DROP COLUMN username;
+
+ALTER TABLE reset_password_tokens
+    ALTER COLUMN user_guid SET NOT NULL;
+ALTER TABLE reset_password_tokens
+    DROP CONSTRAINT reset_password_tokens_pkey;
+ALTER TABLE reset_password_tokens
+    ADD PRIMARY KEY (user_guid);
+ALTER TABLE reset_password_tokens
+    DROP COLUMN user_cn;
+
+ALTER TABLE set_password_tokens
+    ALTER COLUMN user_guid SET NOT NULL;
+ALTER TABLE set_password_tokens
+    DROP CONSTRAINT set_password_tokens_pkey;
+ALTER TABLE set_password_tokens
+    ADD PRIMARY KEY (user_guid);
+ALTER TABLE set_password_tokens
+    DROP COLUMN user_cn;
+
+ALTER TABLE user_audit
+    ALTER COLUMN user_guid SET NOT NULL;
+DROP INDEX user_audit_user_timestamp;
+CREATE INDEX user_audit_user_guid_timestamp ON user_audit (user_guid, timestamp);
+ALTER TABLE user_audit
+    DROP COLUMN user_cn;
+ALTER TABLE user_audit
+    DROP COLUMN editing_user_cn;
+
+ALTER TABLE user_guid_map
+    DROP COLUMN oldguid;
+ALTER TABLE user_guid_map
+    RENAME COLUMN newguid TO user_guid;
+ALTER TABLE user_guid_map
+    RENAME COLUMN cn TO user_cn;

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEditUserControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEditUserControllerTest.kt
@@ -24,6 +24,7 @@ import uk.gov.communities.delta.auth.config.DeltaConfig
 import uk.gov.communities.delta.auth.controllers.internal.AdminEditUserController
 import uk.gov.communities.delta.auth.controllers.internal.DeltaUserPermissionsRequestMapper
 import uk.gov.communities.delta.auth.plugins.ApiError
+import uk.gov.communities.delta.auth.plugins.NoUserException
 import uk.gov.communities.delta.auth.plugins.configureSerialization
 import uk.gov.communities.delta.auth.security.CLIENT_HEADER_AUTH_NAME
 import uk.gov.communities.delta.auth.security.OAUTH_ACCESS_BEARER_TOKEN_AUTH_NAME
@@ -59,7 +60,7 @@ class AdminEditUserControllerTest {
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
             coVerify(exactly = 1) {
-                userService.updateUser(user, capture(modifications), adminSession, userLookupService, any())
+                userService.updateUser(user, capture(modifications), adminSession, any())
             }
 
             // Verify the correct changes are made to the user's details
@@ -81,10 +82,10 @@ class AdminEditUserControllerTest {
                 "datamart-delta-data-certifiers-orgCode3"
             )
             expectedAddedGroups.forEach {
-                coVerify(exactly = 1) { groupService.addUserToGroup(user, it, any(), adminSession, userLookupService) }
+                coVerify(exactly = 1) { groupService.addUserToGroup(user, it, any(), adminSession) }
             }
             coVerify(exactly = expectedAddedGroups.size) {
-                groupService.addUserToGroup(user, any(), any(), adminSession, userLookupService)
+                groupService.addUserToGroup(user, any(), any(), adminSession)
             }
 
             val expectedRemovedGroups = arrayOf(
@@ -96,11 +97,11 @@ class AdminEditUserControllerTest {
             )
             expectedRemovedGroups.forEach {
                 coVerify(exactly = 1) {
-                    groupService.removeUserFromGroup(user, it, any(), adminSession, userLookupService)
+                    groupService.removeUserFromGroup(user, it, any(), adminSession)
                 }
             }
             coVerify(exactly = expectedRemovedGroups.size) {
-                groupService.removeUserFromGroup(user, any(), any(), adminSession, userLookupService)
+                groupService.removeUserFromGroup(user, any(), any(), adminSession)
             }
             coVerify(exactly = 1) {
                 accessGroupDCLGMembershipUpdateEmailService.sendNotificationEmailsForChangeToUserAccessGroups(
@@ -122,9 +123,10 @@ class AdminEditUserControllerTest {
             }
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
-            coVerify(exactly = 0) { userService.updateUser(any(), any(), any(), any(), any()) }
-            coVerify(exactly = 0) { groupService.addUserToGroup(any(), any(), any(), any(), any()) }
-            coVerify(exactly = 0) { groupService.removeUserFromGroup(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { userService.updateUser(any(), any(), any(), any()) }
+            coVerify(exactly = 0) { userGUIDMapService.updateUserCN(any(), any())}
+            coVerify(exactly = 0) { groupService.addUserToGroup(any(), any(), any(), any()) }
+            coVerify(exactly = 0) { groupService.removeUserFromGroup(any(), any(), any(), any()) }
             assertEquals("{\"message\":\"No changes were made to the user\"}", bodyAsText())
         }
     }
@@ -145,9 +147,10 @@ class AdminEditUserControllerTest {
         }.apply {
             assertEquals("username_changed", errorCode)
             assertEquals(HttpStatusCode.BadRequest, statusCode)
-            coVerify(exactly = 0) { userService.updateUser(any(), any(), any(), any(), any()) }
-            coVerify(exactly = 0) { groupService.addUserToGroup(any(), any(), any(), any(), any()) }
-            coVerify(exactly = 0) { groupService.removeUserFromGroup(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { userService.updateUser(any(), any(), any(), any()) }
+            coVerify(exactly = 0) { userGUIDMapService.updateUserCN(any(), any())}
+            coVerify(exactly = 0) { groupService.addUserToGroup(any(), any(), any(), any()) }
+            coVerify(exactly = 0) { groupService.removeUserFromGroup(any(), any(), any(), any()) }
         }
     }
 
@@ -165,11 +168,12 @@ class AdminEditUserControllerTest {
                 }
             }
         }.apply {
-            assertEquals("user_not_found", errorCode)
+            assertEquals("no_user", errorCode)
             assertEquals(HttpStatusCode.BadRequest, statusCode)
-            coVerify(exactly = 0) { userService.updateUser(any(), any(), any(), any(), any()) }
-            coVerify(exactly = 0) { groupService.addUserToGroup(any(), any(), any(), any(), any()) }
-            coVerify(exactly = 0) { groupService.removeUserFromGroup(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { userService.updateUser(any(), any(), any(), any()) }
+            coVerify(exactly = 0) { userGUIDMapService.updateUserCN(any(), any())}
+            coVerify(exactly = 0) { groupService.addUserToGroup(any(), any(), any(), any()) }
+            coVerify(exactly = 0) { groupService.removeUserFromGroup(any(), any(), any(), any()) }
         }
     }
 
@@ -189,9 +193,10 @@ class AdminEditUserControllerTest {
         }.apply {
             assertEquals("forbidden", errorCode)
             assertEquals(HttpStatusCode.Forbidden, statusCode)
-            coVerify(exactly = 0) { userService.updateUser(any(), any(), any(), any(), any()) }
-            coVerify(exactly = 0) { groupService.addUserToGroup(any(), any(), any(), any(), any()) }
-            coVerify(exactly = 0) { groupService.removeUserFromGroup(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { userService.updateUser(any(), any(), any(), any()) }
+            coVerify(exactly = 0) { userGUIDMapService.updateUserCN(any(), any())}
+            coVerify(exactly = 0) { groupService.addUserToGroup(any(), any(), any(), any()) }
+            coVerify(exactly = 0) { groupService.removeUserFromGroup(any(), any(), any(), any()) }
         }
     }
 
@@ -211,9 +216,10 @@ class AdminEditUserControllerTest {
         }.apply {
             assertEquals("forbidden", errorCode)
             assertEquals(HttpStatusCode.Forbidden, statusCode)
-            coVerify(exactly = 0) { userService.updateUser(any(), any(), any(), any(), any()) }
-            coVerify(exactly = 0) { groupService.addUserToGroup(any(), any(), any(), any(), any()) }
-            coVerify(exactly = 0) { groupService.removeUserFromGroup(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { userService.updateUser(any(), any(), any(), any()) }
+            coVerify(exactly = 0) { userGUIDMapService.updateUserCN(any(), any())}
+            coVerify(exactly = 0) { groupService.addUserToGroup(any(), any(), any(), any()) }
+            coVerify(exactly = 0) { groupService.removeUserFromGroup(any(), any(), any(), any()) }
         }
     }
 
@@ -233,9 +239,10 @@ class AdminEditUserControllerTest {
         }.apply {
             assertEquals("forbidden", errorCode)
             assertEquals(HttpStatusCode.Forbidden, statusCode)
-            coVerify(exactly = 0) { userService.updateUser(any(), any(), any(), any(), any()) }
-            coVerify(exactly = 0) { groupService.addUserToGroup(any(), any(), any(), any(), any()) }
-            coVerify(exactly = 0) { groupService.removeUserFromGroup(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { userService.updateUser(any(), any(), any(), any()) }
+            coVerify(exactly = 0) { userGUIDMapService.updateUserCN(any(), any())}
+            coVerify(exactly = 0) { groupService.addUserToGroup(any(), any(), any(), any()) }
+            coVerify(exactly = 0) { groupService.removeUserFromGroup(any(), any(), any(), any()) }
         }
     }
 
@@ -243,18 +250,17 @@ class AdminEditUserControllerTest {
     fun resetMocks() {
         modifications.clear()
         clearAllMocks()
-        coEvery { oauthSessionService.retrieveFomAuthToken(adminSession.authToken, client) } answers { adminSession }
+        coEvery { oauthSessionService.retrieveFromAuthToken(adminSession.authToken, client) } answers { adminSession }
         coEvery {
-            oauthSessionService.retrieveFomAuthToken(disabledAdminSession.authToken, client)
+            oauthSessionService.retrieveFromAuthToken(disabledAdminSession.authToken, client)
         } answers { disabledAdminSession }
         coEvery {
-            oauthSessionService.retrieveFomAuthToken(readOnlyAdminSession.authToken, client)
+            oauthSessionService.retrieveFromAuthToken(readOnlyAdminSession.authToken, client)
         } answers { readOnlyAdminSession }
         coEvery {
-            oauthSessionService.retrieveFomAuthToken(regularUserSession.authToken, client)
+            oauthSessionService.retrieveFromAuthToken(regularUserSession.authToken, client)
         } answers { regularUserSession }
         coEvery { organisationService.findAllNamesAndCodes() } returns organisations
-        @Suppress("BooleanLiteralArgument")
         coEvery { accessGroupsService.getAllAccessGroups() } returns accessGroups
         mockUserLookupService(
             userLookupService,
@@ -269,19 +275,12 @@ class AdminEditUserControllerTest {
             runBlocking { organisationService.findAllNamesAndCodes() },
             runBlocking { accessGroupsService.getAllAccessGroups() }
         )
-        coEvery { userLookupService.loadUserRoles(user) } returns LdapUserWithRoles(
-            user,
-            MemberOfToDeltaRolesMapper(user.cn, organisations, accessGroups).map(user.memberOfCNs)
-        )
-        coEvery { userLookupService.loadUserRoles(unchangedUser) } returns LdapUserWithRoles(
-            unchangedUser,
-            MemberOfToDeltaRolesMapper(unchangedUser.cn, organisations, accessGroups).map(unchangedUser.memberOfCNs)
-        )
-        coEvery {
-            userService.updateUser(user, capture(modifications), adminSession, userLookupService, any())
-        } just runs
-        coEvery { groupService.addUserToGroup(user, any(), any(), adminSession, userLookupService) } just runs
-        coEvery { groupService.removeUserFromGroup(user, any(), any(), adminSession, userLookupService) } just runs
+        coEvery { userGUIDMapService.getGUID(any()) } throws NoUserException("Test exception")
+        coEvery { userGUIDMapService.getGUID(user.cn) } returns user.getGUID()
+        coEvery { userGUIDMapService.getGUID(unchangedUser.cn) } returns unchangedUser.getGUID()
+        coEvery { userService.updateUser(user, capture(modifications), adminSession, any()) } just runs
+        coEvery { groupService.addUserToGroup(user, any(), any(), adminSession) } just runs
+        coEvery { groupService.removeUserFromGroup(user, any(), any(), adminSession) } just runs
     }
 
     companion object {
@@ -291,6 +290,7 @@ class AdminEditUserControllerTest {
 
         private lateinit var oauthSessionService: OAuthSessionService
         private lateinit var userLookupService: UserLookupService
+        private lateinit var userGUIDMapService: UserGUIDMapService
         private lateinit var userService: UserService
         private lateinit var groupService: GroupService
         private lateinit var organisationService: OrganisationService
@@ -386,6 +386,7 @@ class AdminEditUserControllerTest {
         private val organisations = listOf(
             OrganisationNameAndCode("orgCode2", "Org 2"), OrganisationNameAndCode("orgCode3", "Org 3")
         )
+        @Suppress("BooleanLiteralArgument")
         private val accessGroups = listOf(
             AccessGroup("access-group-1", "STATS", "access group 1", false, false),
             AccessGroup("access-group-2", "STATS", "access group 2", false, false),
@@ -417,6 +418,7 @@ class AdminEditUserControllerTest {
         fun setup() {
             oauthSessionService = mockk<OAuthSessionService>()
             userLookupService = mockk<UserLookupService>()
+            userGUIDMapService = mockk<UserGUIDMapService>()
             userService = mockk<UserService>()
             groupService = mockk<GroupService>()
             organisationService = mockk<OrganisationService>()
@@ -428,6 +430,7 @@ class AdminEditUserControllerTest {
             )
             controller = AdminEditUserController(
                 userLookupService,
+                userGUIDMapService,
                 userService,
                 groupService,
                 requestBodyMapper,
@@ -440,7 +443,7 @@ class AdminEditUserControllerTest {
                     authentication {
                         bearer(OAUTH_ACCESS_BEARER_TOKEN_AUTH_NAME) {
                             realm = "auth-service"
-                            authenticate { oauthSessionService.retrieveFomAuthToken(it.token, client) }
+                            authenticate { oauthSessionService.retrieveFromAuthToken(it.token, client) }
                         }
                         clientHeaderAuth(CLIENT_HEADER_AUTH_NAME) {
                             headerName = "Delta-Client"

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEditUserEmailControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEditUserEmailControllerTest.kt
@@ -19,10 +19,7 @@ import uk.gov.communities.delta.auth.plugins.configureSerialization
 import uk.gov.communities.delta.auth.security.CLIENT_HEADER_AUTH_NAME
 import uk.gov.communities.delta.auth.security.OAUTH_ACCESS_BEARER_TOKEN_AUTH_NAME
 import uk.gov.communities.delta.auth.security.clientHeaderAuth
-import uk.gov.communities.delta.auth.services.OAuthSession
-import uk.gov.communities.delta.auth.services.OAuthSessionService
-import uk.gov.communities.delta.auth.services.UserLookupService
-import uk.gov.communities.delta.auth.services.UserService
+import uk.gov.communities.delta.auth.services.*
 import uk.gov.communities.delta.auth.withBearerTokenAuth
 import uk.gov.communities.delta.helper.testLdapUser
 import uk.gov.communities.delta.helper.testServiceClient
@@ -89,6 +86,7 @@ class AdminEditUserEmailControllerTest {
         }.apply {
             assertEquals("empty_username", errorCode)
             coVerify(exactly = 0) { userService.updateEmail(any(), any(), any(), any()) }
+            coVerify(exactly = 0) { userGUIDMapService.updateUserCN(any(), any()) }
         }
     }
 
@@ -96,18 +94,19 @@ class AdminEditUserEmailControllerTest {
     fun resetMocks() {
         clearAllMocks()
         coEvery {
-            oauthSessionService.retrieveFomAuthToken(
+            oauthSessionService.retrieveFromAuthToken(
                 adminSession.authToken,
                 client
             )
         } answers { adminSession }
         coEvery {
-            oauthSessionService.retrieveFomAuthToken(
+            oauthSessionService.retrieveFromAuthToken(
                 nonAdminSession.authToken,
                 client
             )
         } answers { nonAdminSession }
-        coEvery { userLookupService.lookupUserByCn(userToUpdate.cn) } returns userToUpdate
+        coEvery { userGUIDMapService.getGUID(userToUpdate.cn) } returns userToUpdate.getGUID()
+        coEvery { userLookupService.lookupUserByGUID(userToUpdate.getGUID()) } returns userToUpdate
         coEvery { userLookupService.lookupCurrentUser(adminSession) } returns adminUser
         coEvery { userLookupService.lookupCurrentUser(nonAdminSession) } returns nonAdminUser
         coEvery { userService.updateEmail(userToUpdate, any(), any(), any()) } just runs
@@ -121,6 +120,7 @@ class AdminEditUserEmailControllerTest {
         private val oauthSessionService = mockk<OAuthSessionService>()
 
         private val userLookupService = mockk<UserLookupService>()
+        private val userGUIDMapService = mockk<UserGUIDMapService>()
         private val userService = mockk<UserService>()
 
         private val client = testServiceClient()
@@ -131,22 +131,13 @@ class AdminEditUserEmailControllerTest {
         private val userToUpdate = testLdapUser(
             cn = "test!user.com",
             email = "test@user.com",
-            memberOfCNs = listOf(
-                DeltaConfig.DATAMART_DELTA_USER,
-            ),
+            memberOfCNs = listOf(DeltaConfig.DATAMART_DELTA_USER),
         )
 
         private val adminSession =
             OAuthSession(1, adminUser.cn, adminUser.getGUID(), client, "adminToken", Instant.now(), "trace", false)
         private val nonAdminSession = OAuthSession(
-            1,
-            nonAdminUser.cn,
-            nonAdminUser.getGUID(),
-            client,
-            "nonAdminToken",
-            Instant.now(),
-            "trace",
-            false
+            1, nonAdminUser.cn, nonAdminUser.getGUID(), client, "nonAdminToken", Instant.now(), "trace", false
         )
 
         @BeforeClass
@@ -154,6 +145,7 @@ class AdminEditUserEmailControllerTest {
         fun setup() {
             controller = AdminEditUserEmailController(
                 userLookupService,
+                userGUIDMapService,
                 userService,
             )
 
@@ -163,7 +155,7 @@ class AdminEditUserEmailControllerTest {
                     authentication {
                         bearer(OAUTH_ACCESS_BEARER_TOKEN_AUTH_NAME) {
                             realm = "auth-service"
-                            authenticate { oauthSessionService.retrieveFomAuthToken(it.token, client) }
+                            authenticate { oauthSessionService.retrieveFromAuthToken(it.token, client) }
                         }
                         clientHeaderAuth(CLIENT_HEADER_AUTH_NAME) {
                             headerName = "Delta-Client"

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEmailControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEmailControllerTest.kt
@@ -35,14 +35,14 @@ class AdminEmailControllerTest {
                 append("Authorization", "Bearer ${adminSession.authToken}")
                 append("Delta-Client", "${client.clientId}:${client.clientSecret}")
             }
-            parameter("userEmail", disabledReceivingUserEmail)
+            parameter("userEmail", disabledReceivingUser.email)
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
             coVerify(exactly = 1) {
-                emailService.sendSetPasswordEmail(disabledReceivingUser, any(), adminSession, userLookupService, any())
+                emailService.sendSetPasswordEmail(disabledReceivingUser, any(), adminSession, any())
             }
             coVerify(exactly = 1) {
-                setPasswordTokenService.createToken(disabledReceivingUser.cn, disabledReceivingUser.getGUID())
+                setPasswordTokenService.createToken(disabledReceivingUser.getGUID())
             }
         }
     }
@@ -54,17 +54,13 @@ class AdminEmailControllerTest {
                 append("Authorization", "Bearer ${readOnlyAdminSession.authToken}")
                 append("Delta-Client", "${client.clientId}:${client.clientSecret}")
             }
-            parameter("userEmail", disabledReceivingUserEmail)
+            parameter("userEmail", disabledReceivingUser.email)
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
             coVerify(exactly = 1) {
-                emailService.sendSetPasswordEmail(
-                    disabledReceivingUser, any(), readOnlyAdminSession, userLookupService, any()
-                )
+                emailService.sendSetPasswordEmail(disabledReceivingUser, any(), readOnlyAdminSession, any())
             }
-            coVerify(exactly = 1) {
-                setPasswordTokenService.createToken(disabledReceivingUser.cn, disabledReceivingUser.getGUID())
-            }
+            coVerify(exactly = 1) { setPasswordTokenService.createToken(disabledReceivingUser.getGUID()) }
         }
     }
 
@@ -77,14 +73,14 @@ class AdminEmailControllerTest {
                         append("Authorization", "Bearer ${adminSession.authToken}")
                         append("Delta-Client", "${client.clientId}:${client.clientSecret}")
                     }
-                    parameter("userEmail", enabledReceivingUserEmail)
+                    parameter("userEmail", enabledReceivingUser.email)
                 }
             }
         }.apply {
             assertEquals("already_enabled", errorCode)
         }
-        coVerify(exactly = 0) { emailService.sendSetPasswordEmail(any(), any(), any(), any(), any()) }
-        coVerify(exactly = 0) { setPasswordTokenService.createToken(any(), any()) }
+        coVerify(exactly = 0) { emailService.sendSetPasswordEmail(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { setPasswordTokenService.createToken(any()) }
     }
 
     @Test
@@ -96,14 +92,14 @@ class AdminEmailControllerTest {
                         append("Authorization", "Bearer ${userSession.authToken}")
                         append("Delta-Client", "${client.clientId}:${client.clientSecret}")
                     }
-                    parameter("userEmail", disabledReceivingUserEmail)
+                    parameter("userEmail", disabledReceivingUser.email)
                 }
             }
         }.apply {
             assertEquals("forbidden", errorCode)
         }
-        coVerify(exactly = 0) { emailService.sendSetPasswordEmail(any(), any(), any(), any(), any()) }
-        coVerify(exactly = 0) { setPasswordTokenService.createToken(any(), any()) }
+        coVerify(exactly = 0) { emailService.sendSetPasswordEmail(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { setPasswordTokenService.createToken(any()) }
     }
 
     @Test
@@ -115,14 +111,14 @@ class AdminEmailControllerTest {
                         append("Authorization", "Bearer ${adminSession.authToken}")
                         append("Delta-Client", "${client.clientId}:${client.clientSecret}")
                     }
-                    parameter("userEmail", disabledReceivingSSOUserEmail)
+                    parameter("userEmail", disabledReceivingSSOUser.email)
                 }
             }
         }.apply {
             assertEquals("no_emails_to_sso_users", errorCode)
         }
-        coVerify(exactly = 0) { emailService.sendSetPasswordEmail(any(), any(), any(), any(), any()) }
-        coVerify(exactly = 0) { setPasswordTokenService.createToken(any(), any()) }
+        coVerify(exactly = 0) { emailService.sendSetPasswordEmail(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { setPasswordTokenService.createToken(any()) }
     }
 
     @Test
@@ -132,15 +128,13 @@ class AdminEmailControllerTest {
                 append("Authorization", "Bearer ${adminSession.authToken}")
                 append("Delta-Client", "${client.clientId}:${client.clientSecret}")
             }
-            parameter("userEmail", enabledReceivingUserEmail)
+            parameter("userEmail", enabledReceivingUser.email)
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
             coVerify(exactly = 1) {
-                emailService.sendResetPasswordEmail(
-                    enabledReceivingUser, "token", adminSession, userLookupService, any()
-                )
+                emailService.sendResetPasswordEmail(enabledReceivingUser, "token", adminSession, any())
             }
-            coVerify(exactly = 1) { resetPasswordTokenService.createToken(any(), any()) }
+            coVerify(exactly = 1) { resetPasswordTokenService.createToken(any()) }
         }
     }
 
@@ -151,15 +145,13 @@ class AdminEmailControllerTest {
                 append("Authorization", "Bearer ${readOnlyAdminSession.authToken}")
                 append("Delta-Client", "${client.clientId}:${client.clientSecret}")
             }
-            parameter("userEmail", enabledReceivingUserEmail)
+            parameter("userEmail", enabledReceivingUser.email)
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
             coVerify(exactly = 1) {
-                emailService.sendResetPasswordEmail(
-                    enabledReceivingUser, "token", readOnlyAdminSession, userLookupService, any()
-                )
+                emailService.sendResetPasswordEmail(enabledReceivingUser, "token", readOnlyAdminSession, any())
             }
-            coVerify(exactly = 1) { resetPasswordTokenService.createToken(any(), any()) }
+            coVerify(exactly = 1) { resetPasswordTokenService.createToken(any()) }
         }
     }
 
@@ -172,14 +164,14 @@ class AdminEmailControllerTest {
                         append("Authorization", "Bearer ${adminSession.authToken}")
                         append("Delta-Client", "${client.clientId}:${client.clientSecret}")
                     }
-                    parameter("userEmail", disabledReceivingUserEmail)
+                    parameter("userEmail", disabledReceivingUser.email)
                 }
             }
         }.apply {
             assertEquals("not_enabled", errorCode)
         }
-        coVerify(exactly = 0) { emailService.sendResetPasswordEmail(any(), any(), any(), any(), any()) }
-        coVerify(exactly = 0) { resetPasswordTokenService.createToken(any(), any()) }
+        coVerify(exactly = 0) { emailService.sendResetPasswordEmail(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { resetPasswordTokenService.createToken(any()) }
     }
 
     @Test
@@ -191,14 +183,14 @@ class AdminEmailControllerTest {
                         append("Authorization", "Bearer ${userSession.authToken}")
                         append("Delta-Client", "${client.clientId}:${client.clientSecret}")
                     }
-                    parameter("userEmail", enabledReceivingUserEmail)
+                    parameter("userEmail", enabledReceivingUser.email)
                 }
             }
         }.apply {
             assertEquals("forbidden", errorCode)
         }
-        coVerify(exactly = 0) { emailService.sendResetPasswordEmail(any(), any(), any(), any(), any()) }
-        coVerify(exactly = 0) { resetPasswordTokenService.createToken(any(), any()) }
+        coVerify(exactly = 0) { emailService.sendResetPasswordEmail(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { resetPasswordTokenService.createToken(any()) }
     }
 
     @Test
@@ -210,29 +202,29 @@ class AdminEmailControllerTest {
                         append("Authorization", "Bearer ${adminSession.authToken}")
                         append("Delta-Client", "${client.clientId}:${client.clientSecret}")
                     }
-                    parameter("userEmail", enabledReceivingSSOUserEmail)
+                    parameter("userEmail", enabledReceivingSSOUser.email)
                 }
             }
         }.apply {
             assertEquals("no_emails_to_sso_users", errorCode)
         }
-        coVerify(exactly = 0) { emailService.sendResetPasswordEmail(any(), any(), any(), any(), any()) }
-        coVerify(exactly = 0) { resetPasswordTokenService.createToken(any(), any()) }
+        coVerify(exactly = 0) { emailService.sendResetPasswordEmail(any(), any(), any(), any()) }
+        coVerify(exactly = 0) { resetPasswordTokenService.createToken(any()) }
     }
 
     @Before
     fun resetMocks() {
         clearAllMocks()
-        coEvery { oauthSessionService.retrieveFomAuthToken(any(), client) } answers { null }
+        coEvery { oauthSessionService.retrieveFromAuthToken(any(), client) } answers { null }
         coEvery {
-            oauthSessionService.retrieveFomAuthToken(
+            oauthSessionService.retrieveFromAuthToken(
                 adminSession.authToken,
                 client
             )
         } answers { adminSession }
-        coEvery { oauthSessionService.retrieveFomAuthToken(userSession.authToken, client) } answers { userSession }
+        coEvery { oauthSessionService.retrieveFromAuthToken(userSession.authToken, client) } answers { userSession }
         coEvery {
-            oauthSessionService.retrieveFomAuthToken(
+            oauthSessionService.retrieveFromAuthToken(
                 readOnlyAdminSession.authToken,
                 client
             )
@@ -240,31 +232,27 @@ class AdminEmailControllerTest {
         coEvery { userLookupService.lookupCurrentUser(adminSession) } returns adminUser
         coEvery { userLookupService.lookupCurrentUser(userSession) } returns regularUser
         coEvery { userLookupService.lookupCurrentUser(readOnlyAdminSession) } returns readOnlyAdminUser
-        coEvery { userLookupService.lookupUserByEmail(enabledReceivingUser.email!!) } returns enabledReceivingUser
-        coEvery { userLookupService.lookupUserByEmail(enabledReceivingSSOUser.email!!) } returns enabledReceivingSSOUser
-        coEvery { userLookupService.lookupUserByEmail(disabledReceivingUser.email!!) } returns disabledReceivingUser
-        coEvery { userLookupService.lookupUserByEmail(disabledReceivingSSOUser.email!!) } returns disabledReceivingSSOUser
-        coEvery { resetPasswordTokenService.createToken(any(), any()) } returns "token"
-        coEvery { setPasswordTokenService.createToken(any(), any()) } returns "token"
+        coEvery { userGUIDMapService.getGUIDFromEmail(enabledReceivingUser.email!!) } returns enabledReceivingUser.getGUID()
+        coEvery { userGUIDMapService.getGUIDFromEmail(disabledReceivingUser.email!!) } returns disabledReceivingUser.getGUID()
+        coEvery { userGUIDMapService.getGUIDFromEmail(enabledReceivingSSOUser.email!!) } returns enabledReceivingSSOUser.getGUID()
+        coEvery { userGUIDMapService.getGUIDFromEmail(disabledReceivingSSOUser.email!!) } returns disabledReceivingSSOUser.getGUID()
+        coEvery { userLookupService.lookupUserByGUID(enabledReceivingUser.getGUID()) } returns enabledReceivingUser
+        coEvery { userLookupService.lookupUserByGUID(enabledReceivingSSOUser.getGUID()) } returns enabledReceivingSSOUser
+        coEvery { userLookupService.lookupUserByGUID(disabledReceivingUser.getGUID()) } returns disabledReceivingUser
+        coEvery { userLookupService.lookupUserByGUID(disabledReceivingSSOUser.getGUID()) } returns disabledReceivingSSOUser
+        coEvery { resetPasswordTokenService.createToken(any()) } returns "token"
+        coEvery { setPasswordTokenService.createToken(any()) } returns "token"
         coEvery {
-            emailService.sendSetPasswordEmail(
-                disabledReceivingUser, "token", adminSession, userLookupService, any()
-            )
+            emailService.sendSetPasswordEmail(disabledReceivingUser, "token", adminSession, any())
         } just runs
         coEvery {
-            emailService.sendResetPasswordEmail(
-                enabledReceivingUser, "token", adminSession, userLookupService, any()
-            )
+            emailService.sendResetPasswordEmail(enabledReceivingUser, "token", adminSession, any())
         } just runs
         coEvery {
-            emailService.sendSetPasswordEmail(
-                disabledReceivingUser, "token", readOnlyAdminSession, userLookupService, any()
-            )
+            emailService.sendSetPasswordEmail(disabledReceivingUser, "token", readOnlyAdminSession, any())
         } just runs
         coEvery {
-            emailService.sendResetPasswordEmail(
-                enabledReceivingUser, "token", readOnlyAdminSession, userLookupService, any()
-            )
+            emailService.sendResetPasswordEmail(enabledReceivingUser, "token", readOnlyAdminSession, any())
         } just runs
     }
 
@@ -275,6 +263,7 @@ class AdminEmailControllerTest {
 
         private val oauthSessionService = mockk<OAuthSessionService>()
         private val userLookupService = mockk<UserLookupService>()
+        private val userGUIDMapService = mockk<UserGUIDMapService>()
         private val resetPasswordTokenService = mockk<ResetPasswordTokenService>()
         private val setPasswordTokenService = mockk<SetPasswordTokenService>()
         private val emailService = mockk<EmailService>()
@@ -284,29 +273,25 @@ class AdminEmailControllerTest {
         private val readOnlyAdminUser =
             testLdapUser(cn = "read-only-admin", memberOfCNs = listOf(DeltaSystemRole.READ_ONLY_ADMIN.adCn()))
         private val regularUser = testLdapUser(cn = "user", memberOfCNs = emptyList())
-        private const val enabledReceivingUserEmail = "enabled-receiving-user@test.com"
-        private const val enabledReceivingSSOUserEmail = "enabled-receiving-user@sso.domain"
-        private const val disabledReceivingUserEmail = "disabled-receiving-user@test.com"
-        private const val disabledReceivingSSOUserEmail = "disabled-receiving-user@sso.domain"
 
         private val enabledReceivingUser = testLdapUser(
-            email = enabledReceivingUserEmail,
-            cn = LDAPConfig.emailToCN(enabledReceivingUserEmail),
+            email = "enabled-receiving-user@test.com",
+            cn = LDAPConfig.emailToCN("enabled-receiving-user@test.com"),
             accountEnabled = true
         )
         private val enabledReceivingSSOUser = testLdapUser(
-            email = enabledReceivingSSOUserEmail,
-            cn = LDAPConfig.emailToCN(enabledReceivingSSOUserEmail),
+            email = "enabled-receiving-user@sso.domain",
+            cn = LDAPConfig.emailToCN("enabled-receiving-user@sso.domain"),
             accountEnabled = true
         )
         private val disabledReceivingUser = testLdapUser(
-            email = disabledReceivingUserEmail,
-            cn = LDAPConfig.emailToCN(disabledReceivingUserEmail),
+            email = "disabled-receiving-user@test.com",
+            cn = LDAPConfig.emailToCN("disabled-receiving-user@test.com"),
             accountEnabled = false
         )
         private val disabledReceivingSSOUser = testLdapUser(
-            email = disabledReceivingSSOUserEmail,
-            cn = LDAPConfig.emailToCN(disabledReceivingSSOUserEmail),
+            email = "disabled-receiving-user@sso.domain",
+            cn = LDAPConfig.emailToCN("disabled-receiving-user@sso.domain"),
             accountEnabled = false
         )
         private val adminSession = OAuthSession(
@@ -334,6 +319,7 @@ class AdminEmailControllerTest {
                 AzureADSSOConfig(listOf(AzureADSSOClient("dev", "", "", "", "@sso.domain", required = true))),
                 emailService,
                 userLookupService,
+                userGUIDMapService,
                 setPasswordTokenService,
                 resetPasswordTokenService,
             )
@@ -344,7 +330,7 @@ class AdminEmailControllerTest {
                     authentication {
                         bearer(OAUTH_ACCESS_BEARER_TOKEN_AUTH_NAME) {
                             realm = "auth-service"
-                            authenticate { oauthSessionService.retrieveFomAuthToken(it.token, client) }
+                            authenticate { oauthSessionService.retrieveFromAuthToken(it.token, client) }
                         }
                         clientHeaderAuth(CLIENT_HEADER_AUTH_NAME) {
                             headerName = "Delta-Client"

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaLoginControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaLoginControllerTest.kt
@@ -91,7 +91,7 @@ class DeltaLoginControllerTest {
             assertContains(bodyAsText(), "Your account has been disabled")
             verify(exactly = 1) { failedLoginCounter.increment(1.0) }
             verify(exactly = 0) { successfulLoginCounter.increment(1.0) }
-            coVerify(exactly = 0) { userAuditService.userFormLoginAudit(any(), any(), any()) }
+            coVerify(exactly = 0) { userAuditService.userFormLoginAudit(any(), any()) }
         }
     }
 
@@ -111,7 +111,7 @@ class DeltaLoginControllerTest {
             assertContains(bodyAsText(), "Your account exists but is not set up to access Delta.")
             verify(exactly = 1) { failedLoginCounter.increment(1.0) }
             verify(exactly = 0) { successfulLoginCounter.increment(1.0) }
-            coVerify(exactly = 0) { userAuditService.userFormLoginAudit(any(), any(), any()) }
+            coVerify(exactly = 0) { userAuditService.userFormLoginAudit(any(), any()) }
         }
     }
 
@@ -134,7 +134,7 @@ class DeltaLoginControllerTest {
             )
             verify(exactly = 1) { failedLoginCounter.increment(1.0) }
             verify(exactly = 0) { successfulLoginCounter.increment(1.0) }
-            coVerify(exactly = 0) { userAuditService.userFormLoginAudit(any(), any(), any()) }
+            coVerify(exactly = 0) { userAuditService.userFormLoginAudit(any(), any()) }
         }
     }
 
@@ -155,7 +155,7 @@ class DeltaLoginControllerTest {
             )
             verify(exactly = 1) { failedLoginCounter.increment(1.0) }
             verify(exactly = 0) { successfulLoginCounter.increment(1.0) }
-            coVerify(exactly = 0) { userAuditService.userFormLoginAudit(any(), any(), any()) }
+            coVerify(exactly = 0) { userAuditService.userFormLoginAudit(any(), any()) }
         }
     }
 
@@ -176,8 +176,8 @@ class DeltaLoginControllerTest {
             }
             verify(exactly = 0) { failedLoginCounter.increment(1.0) }
             verify(exactly = 1) { successfulLoginCounter.increment(1.0) }
-            coVerify(exactly = 1) { authorizationCodeService.generateAndStore(any(), any(), any(), any(), false)}
-            coVerify(exactly = 1) { userAuditService.userFormLoginAudit(testUser.cn, testUser.getGUID(), any()) }
+            coVerify(exactly = 1) { authorizationCodeService.generateAndStore(any(), any(), any(), false) }
+            coVerify(exactly = 1) { userAuditService.userFormLoginAudit(testUser.getGUID(), any()) }
         }
     }
 
@@ -221,9 +221,9 @@ class DeltaLoginControllerTest {
         clearAllMocks()
         every { failedLoginCounter.increment(1.0) } returns Unit
         every { successfulLoginCounter.increment(1.0) } returns Unit
-        coEvery { userAuditService.userFormLoginAudit(any(), any(), any()) } returns Unit
-        coEvery { authorizationCodeService.generateAndStore(any(), any(), any(), any(), any()) } answers {
-            AuthCode("test-auth-code", user.cn, user.getGUID(), client, Instant.now(), "trace", false)
+        coEvery { userAuditService.userFormLoginAudit(any(), any()) } returns Unit
+        coEvery { authorizationCodeService.generateAndStore(any(), any(), any(), any()) } answers {
+            AuthCode("test-auth-code", user.getGUID(), client, Instant.now(), "trace", false)
         }
     }
 

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/EditAccessGroupsControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/EditAccessGroupsControllerTest.kt
@@ -51,22 +51,22 @@ class EditAccessGroupsControllerTest {
             assertEquals(HttpStatusCode.OK, status)
             coVerify(exactly = 1) {
                 groupService.addUserToGroup(
-                    externalUser, "datamart-delta-access-group-1-orgCode2", any(), null, userLookupService,
+                    externalUser, "datamart-delta-access-group-1-orgCode2", any(), null,
                 )
             }
             coVerify(exactly = 1) {
                 groupService.addUserToGroup(
-                    externalUser, "datamart-delta-access-group-2-orgCode2", any(), null, userLookupService
+                    externalUser, "datamart-delta-access-group-2-orgCode2", any(), null
                 )
             }
             coVerify(exactly = 1) {
                 groupService.removeUserFromGroup(
-                    externalUser, "datamart-delta-access-group-1-orgCode3", any(), null, userLookupService
+                    externalUser, "datamart-delta-access-group-1-orgCode3", any(), null
                 )
             }
             coVerify(exactly = 1) {
                 groupService.removeUserFromGroup(
-                    externalUser, "datamart-delta-access-group-2-orgCode1", any(), null, userLookupService
+                    externalUser, "datamart-delta-access-group-2-orgCode1", any(), null
                 )
             }
             confirmVerified(groupService, accessGroupDCLGMembershipUpdateEmailService)
@@ -99,7 +99,7 @@ class EditAccessGroupsControllerTest {
             assertEquals(HttpStatusCode.OK, status)
             coVerify(exactly = 1) {
                 groupService.addUserToGroup(
-                    internalUser, "datamart-delta-access-group-3-dclg", any(), null, userLookupService
+                    internalUser, "datamart-delta-access-group-3-dclg", any(), null
                 )
             }
             verify(exactly = 1) {
@@ -156,17 +156,17 @@ class EditAccessGroupsControllerTest {
             assertEquals(HttpStatusCode.OK, status)
             coVerify(exactly = 1) {
                 groupService.addUserToGroup(
-                    externalUser, "datamart-delta-access-group-1-orgCode2", any(), null, userLookupService
+                    externalUser, "datamart-delta-access-group-1-orgCode2", any(), null
                 )
             }
             coVerify(exactly = 1) {
                 groupService.removeUserFromGroup(
-                    externalUser, "datamart-delta-access-group-2", any(), null, userLookupService
+                    externalUser, "datamart-delta-access-group-2", any(), null
                 )
             }
             coVerify(exactly = 1) {
                 groupService.removeUserFromGroup(
-                    externalUser, "datamart-delta-access-group-2-orgCode1", any(), null, userLookupService
+                    externalUser, "datamart-delta-access-group-2-orgCode1", any(), null
                 )
             }
             confirmVerified(groupService, accessGroupDCLGMembershipUpdateEmailService)
@@ -314,7 +314,7 @@ class EditAccessGroupsControllerTest {
             assertEquals(HttpStatusCode.OK, status)
             coVerify(exactly = 1) {
                 groupService.addUserToGroup(
-                    externalUser, "datamart-delta-access-group-3", any(), internalUserSession, userLookupService
+                    externalUser, "datamart-delta-access-group-3", any(), internalUserSession,
                 )
             }
             coVerify(exactly = 1) {
@@ -323,7 +323,6 @@ class EditAccessGroupsControllerTest {
                     "datamart-delta-access-group-3-orgCode1",
                     any(),
                     internalUserSession,
-                    userLookupService
                 )
             }
             coVerify(exactly = 1) {
@@ -332,7 +331,6 @@ class EditAccessGroupsControllerTest {
                     "datamart-delta-access-group-3-orgCode2",
                     any(),
                     internalUserSession,
-                    userLookupService
                 )
             }
             confirmVerified(groupService, accessGroupDCLGMembershipUpdateEmailService)
@@ -366,7 +364,7 @@ class EditAccessGroupsControllerTest {
             assertEquals(HttpStatusCode.OK, status)
             coVerify(exactly = 1) {
                 groupService.addUserToGroup(
-                    internalUser, "datamart-delta-access-group-3-dclg", any(), internalUserSession, userLookupService,
+                    internalUser, "datamart-delta-access-group-3-dclg", any(), internalUserSession,
                 )
             }
             verify(exactly = 1) {
@@ -434,7 +432,7 @@ class EditAccessGroupsControllerTest {
             assertEquals(HttpStatusCode.OK, status)
             coVerify(exactly = 1) {
                 groupService.removeUserFromGroup(
-                    externalUser, "datamart-delta-access-group-2", any(), internalUserSession, userLookupService
+                    externalUser, "datamart-delta-access-group-2", any(), internalUserSession,
                 )
             }
             coVerify(exactly = 1) {
@@ -443,7 +441,6 @@ class EditAccessGroupsControllerTest {
                     "datamart-delta-access-group-2-orgCode1",
                     any(),
                     internalUserSession,
-                    userLookupService
                 )
             }
             confirmVerified(groupService, accessGroupDCLGMembershipUpdateEmailService)
@@ -454,19 +451,19 @@ class EditAccessGroupsControllerTest {
     fun resetMocks() {
         clearAllMocks()
         coEvery {
-            oauthSessionService.retrieveFomAuthToken(
+            oauthSessionService.retrieveFromAuthToken(
                 externalUserSession.authToken,
                 client
             )
         } answers { externalUserSession }
         coEvery {
-            oauthSessionService.retrieveFomAuthToken(
+            oauthSessionService.retrieveFromAuthToken(
                 internalUserSession.authToken,
                 client
             )
         } answers { internalUserSession }
-        coEvery { userLookupService.lookupUserByCn(externalUser.cn) } returns externalUser
-        coEvery { userLookupService.lookupUserByCn(internalUser.cn) } returns internalUser
+        coEvery { userGUIDMapService.getGUID(externalUser.cn) } returns externalUser.getGUID()
+        coEvery { userGUIDMapService.getGUID(internalUser.cn) } returns internalUser.getGUID()
         coEvery { organisationService.findAllNamesAndCodes() } returns listOf(
             OrganisationNameAndCode("orgCode1", "Organisation Name 1"),
             OrganisationNameAndCode("orgCode2", "Organisation Name 2"),
@@ -498,10 +495,10 @@ class EditAccessGroupsControllerTest {
             runBlocking { organisationService.findAllNamesAndCodes() },
             runBlocking { accessGroupsService.getAllAccessGroups() },
         )
-        coEvery { groupService.addUserToGroup(externalUser, any(), any(), any(), userLookupService) } just runs
-        coEvery { groupService.removeUserFromGroup(externalUser, any(), any(), any(), userLookupService) } just runs
-        coEvery { groupService.addUserToGroup(internalUser, any(), any(), any(), userLookupService) } just runs
-        coEvery { groupService.removeUserFromGroup(internalUser, any(), any(), any(), userLookupService) } just runs
+        coEvery { groupService.addUserToGroup(externalUser, any(), any(), any()) } just runs
+        coEvery { groupService.removeUserFromGroup(externalUser, any(), any(), any()) } just runs
+        coEvery { groupService.addUserToGroup(internalUser, any(), any(), any()) } just runs
+        coEvery { groupService.removeUserFromGroup(internalUser, any(), any(), any()) } just runs
     }
 
     companion object {
@@ -512,6 +509,7 @@ class EditAccessGroupsControllerTest {
         private val oauthSessionService = mockk<OAuthSessionService>()
 
         private val userLookupService = mockk<UserLookupService>()
+        private val userGUIDMapService = mockk<UserGUIDMapService>()
         private val groupService = mockk<GroupService>()
         private val organisationService = mockk<OrganisationService>()
         private val accessGroupsService = mockk<AccessGroupsService>()
@@ -575,7 +573,7 @@ class EditAccessGroupsControllerTest {
             OAuthSession(
                 1,
                 internalUser.cn,
-                externalUser.getGUID(),
+                internalUser.getGUID(),
                 client,
                 "internalUserToken",
                 Instant.now(),
@@ -588,6 +586,7 @@ class EditAccessGroupsControllerTest {
         fun setup() {
             controller = EditAccessGroupsController(
                 userLookupService,
+                userGUIDMapService,
                 groupService,
                 organisationService,
                 accessGroupsService,
@@ -601,7 +600,7 @@ class EditAccessGroupsControllerTest {
                     authentication {
                         bearer(OAUTH_ACCESS_BEARER_TOKEN_AUTH_NAME) {
                             realm = "auth-service"
-                            authenticate { oauthSessionService.retrieveFomAuthToken(it.token, client) }
+                            authenticate { oauthSessionService.retrieveFromAuthToken(it.token, client) }
                         }
                         clientHeaderAuth(CLIENT_HEADER_AUTH_NAME) {
                             headerName = "Delta-Client"

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/EditOrganisationsControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/EditOrganisationsControllerTest.kt
@@ -40,21 +40,11 @@ class EditOrganisationsControllerTest {
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
             coVerify(exactly = 1) {
-                groupService.addUserToGroup(
-                    testUser, "datamart-delta-user-orgCode3", any(), null, userLookupService
-                )
-                groupService.addUserToGroup(
-                    testUser, "datamart-delta-data-certifiers-orgCode3", any(), null, userLookupService
-                )
-                groupService.removeUserFromGroup(
-                    testUser, "datamart-delta-user-orgCode2", any(), null, userLookupService
-                )
-                groupService.removeUserFromGroup(
-                    testUser, "datamart-delta-access-group-3-orgCode2", any(), null, userLookupService
-                )
-                groupService.removeUserFromGroup(
-                    testUser, "datamart-delta-data-certifiers-orgCode2", any(), null, userLookupService
-                )
+                groupService.addUserToGroup(testUser, "datamart-delta-user-orgCode3", any(), null)
+                groupService.addUserToGroup(testUser, "datamart-delta-data-certifiers-orgCode3", any(), null)
+                groupService.removeUserFromGroup(testUser, "datamart-delta-user-orgCode2", any(), null)
+                groupService.removeUserFromGroup(testUser, "datamart-delta-access-group-3-orgCode2", any(), null)
+                groupService.removeUserFromGroup(testUser, "datamart-delta-data-certifiers-orgCode2", any(), null)
             }
             confirmVerified(groupService)
         }
@@ -70,7 +60,7 @@ class EditOrganisationsControllerTest {
             contentType(ContentType.Application.Json)
             setBody("{\"selectedDomainOrganisationCodes\": [\"orgCode1\", \"orgCode2\"]}")
         }.apply {
-            coVerify(exactly = 0) { groupService.removeUserFromGroup(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { groupService.removeUserFromGroup(any(), any(), any(), any()) }
         }
     }
 
@@ -86,12 +76,8 @@ class EditOrganisationsControllerTest {
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
             coVerify(exactly = 1) {
-                groupService.addUserToGroup(
-                    testUser, "datamart-delta-user-orgCode3", any(), null, userLookupService
-                )
-                groupService.addUserToGroup(
-                    testUser, "datamart-delta-data-certifiers-orgCode3", any(), null, userLookupService
-                )
+                groupService.addUserToGroup(testUser, "datamart-delta-user-orgCode3", any(), null)
+                groupService.addUserToGroup(testUser, "datamart-delta-data-certifiers-orgCode3", any(), null)
             }
             confirmVerified(groupService)
         }
@@ -109,15 +95,9 @@ class EditOrganisationsControllerTest {
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
             coVerify(exactly = 1) {
-                groupService.removeUserFromGroup(
-                    testUser, "datamart-delta-user-orgCode2", any(), null, userLookupService
-                )
-                groupService.removeUserFromGroup(
-                    testUser, "datamart-delta-access-group-3-orgCode2", any(), null, userLookupService
-                )
-                groupService.removeUserFromGroup(
-                    testUser, "datamart-delta-data-certifiers-orgCode2", any(), null, userLookupService
-                )
+                groupService.removeUserFromGroup(testUser, "datamart-delta-user-orgCode2", any(), null)
+                groupService.removeUserFromGroup(testUser, "datamart-delta-access-group-3-orgCode2", any(), null)
+                groupService.removeUserFromGroup(testUser, "datamart-delta-data-certifiers-orgCode2", any(), null)
             }
             confirmVerified(groupService)
         }
@@ -159,7 +139,7 @@ class EditOrganisationsControllerTest {
     fun resetMocks() {
         clearAllMocks()
         coEvery {
-            oauthSessionService.retrieveFomAuthToken(
+            oauthSessionService.retrieveFromAuthToken(
                 testUserSession.authToken,
                 client
             )
@@ -186,8 +166,8 @@ class EditOrganisationsControllerTest {
             runBlocking { organisationService.findAllNamesAndCodes() },
             accessGroups,
         )
-        coEvery { groupService.addUserToGroup(testUser, any(), any(), null, userLookupService) } just runs
-        coEvery { groupService.removeUserFromGroup(testUser, any(), any(), null, userLookupService) } just runs
+        coEvery { groupService.addUserToGroup(testUser, any(), any(), null) } just runs
+        coEvery { groupService.removeUserFromGroup(testUser, any(), any(), null) } just runs
     }
 
     companion object {
@@ -244,7 +224,7 @@ class EditOrganisationsControllerTest {
                     authentication {
                         bearer(OAUTH_ACCESS_BEARER_TOKEN_AUTH_NAME) {
                             realm = "auth-service"
-                            authenticate { oauthSessionService.retrieveFomAuthToken(it.token, client) }
+                            authenticate { oauthSessionService.retrieveFromAuthToken(it.token, client) }
                         }
                         clientHeaderAuth(CLIENT_HEADER_AUTH_NAME) {
                             headerName = "Delta-Client"

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/EditRolesControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/EditRolesControllerTest.kt
@@ -44,34 +44,22 @@ class EditRolesControllerTest {
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
             coVerify(exactly = 1) {
-                groupService.addUserToGroup(
-                    externalUser, "datamart-delta-data-providers", any(), null, userLookupService
-                )
+                groupService.addUserToGroup(externalUser, "datamart-delta-data-providers", any(), null)
             }
             coVerify(exactly = 1) {
-                groupService.addUserToGroup(
-                    externalUser, "datamart-delta-data-providers-orgCode1", any(), null, userLookupService
-                )
+                groupService.addUserToGroup(externalUser, "datamart-delta-data-providers-orgCode1", any(), null)
             }
             coVerify(exactly = 1) {
-                groupService.addUserToGroup(
-                    externalUser, "datamart-delta-data-providers-orgCode2", any(), null, userLookupService
-                )
+                groupService.addUserToGroup(externalUser, "datamart-delta-data-providers-orgCode2", any(), null)
             }
             coVerify(exactly = 1) {
-                groupService.removeUserFromGroup(
-                    externalUser, "datamart-delta-data-certifiers", any(), null, userLookupService
-                )
+                groupService.removeUserFromGroup(externalUser, "datamart-delta-data-certifiers", any(), null)
             }
             coVerify(exactly = 1) {
-                groupService.removeUserFromGroup(
-                    externalUser, "datamart-delta-data-certifiers-orgCode1", any(), null, userLookupService
-                )
+                groupService.removeUserFromGroup(externalUser, "datamart-delta-data-certifiers-orgCode1", any(), null)
             }
             coVerify(exactly = 1) {
-                groupService.removeUserFromGroup(
-                    externalUser, "datamart-delta-data-certifiers-orgCode2", any(), null, userLookupService
-                )
+                groupService.removeUserFromGroup(externalUser, "datamart-delta-data-certifiers-orgCode2", any(), null)
             }
             confirmVerified(groupService)
         }
@@ -109,34 +97,22 @@ class EditRolesControllerTest {
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
             coVerify(exactly = 1) {
-                groupService.addUserToGroup(
-                    internalUser, "datamart-delta-payments-reviewers", any(), null, userLookupService
-                )
+                groupService.addUserToGroup(internalUser, "datamart-delta-payments-reviewers", any(), null)
             }
             coVerify(exactly = 1) {
-                groupService.addUserToGroup(
-                    internalUser, "datamart-delta-payments-reviewers-orgCode1", any(), null, userLookupService
-                )
+                groupService.addUserToGroup(internalUser, "datamart-delta-payments-reviewers-orgCode1", any(), null)
             }
             coVerify(exactly = 1) {
-                groupService.addUserToGroup(
-                    internalUser, "datamart-delta-payments-reviewers-orgCode2", any(), null, userLookupService
-                )
+                groupService.addUserToGroup(internalUser, "datamart-delta-payments-reviewers-orgCode2", any(), null)
             }
             coVerify(exactly = 1) {
-                groupService.removeUserFromGroup(
-                    internalUser, "datamart-delta-data-certifiers", any(), null, userLookupService
-                )
+                groupService.removeUserFromGroup(internalUser, "datamart-delta-data-certifiers", any(), null)
             }
             coVerify(exactly = 1) {
-                groupService.removeUserFromGroup(
-                    internalUser, "datamart-delta-data-certifiers-orgCode1", any(), null, userLookupService
-                )
+                groupService.removeUserFromGroup(internalUser, "datamart-delta-data-certifiers-orgCode1", any(), null)
             }
             coVerify(exactly = 1) {
-                groupService.removeUserFromGroup(
-                    internalUser, "datamart-delta-data-certifiers-orgCode2", any(), null, userLookupService
-                )
+                groupService.removeUserFromGroup(internalUser, "datamart-delta-data-certifiers-orgCode2", any(), null)
             }
             confirmVerified(groupService)
         }
@@ -181,18 +157,18 @@ class EditRolesControllerTest {
     @Before
     fun resetMocks() {
         clearAllMocks()
-        coEvery { oauthSessionService.retrieveFomAuthToken(externalUserSession.authToken, client) } answers { externalUserSession }
-        coEvery { oauthSessionService.retrieveFomAuthToken(internalUserSession.authToken, client) } answers { internalUserSession }
+        coEvery { oauthSessionService.retrieveFromAuthToken(externalUserSession.authToken, client) } answers { externalUserSession }
+        coEvery { oauthSessionService.retrieveFromAuthToken(internalUserSession.authToken, client) } answers { internalUserSession }
         mockUserLookupService(
             userLookupService,
             listOf(Pair(internalUser, internalUserSession), Pair(externalUser, externalUserSession)),
             organisations,
             accessGroups
         )
-        coEvery { groupService.addUserToGroup(externalUser, any(), any(), null, userLookupService) } just runs
-        coEvery { groupService.removeUserFromGroup(externalUser, any(), any(), null, userLookupService) } just runs
-        coEvery { groupService.addUserToGroup(internalUser, any(), any(), null, userLookupService) } just runs
-        coEvery { groupService.removeUserFromGroup(internalUser, any(), any(), null, userLookupService) } just runs
+        coEvery { groupService.addUserToGroup(externalUser, any(), any(), null) } just runs
+        coEvery { groupService.removeUserFromGroup(externalUser, any(), any(), null) } just runs
+        coEvery { groupService.addUserToGroup(internalUser, any(), any(), null) } just runs
+        coEvery { groupService.removeUserFromGroup(internalUser, any(), any(), null) } just runs
     }
 
     companion object {
@@ -282,7 +258,7 @@ class EditRolesControllerTest {
         private val internalUserSession = OAuthSession(
             1,
             internalUser.cn,
-            externalUser.getGUID(),
+            internalUser.getGUID(),
             client,
             "internalUserToken",
             Instant.now(),
@@ -304,7 +280,7 @@ class EditRolesControllerTest {
                     authentication {
                         bearer(OAUTH_ACCESS_BEARER_TOKEN_AUTH_NAME) {
                             realm = "auth-service"
-                            authenticate { oauthSessionService.retrieveFomAuthToken(it.token, client) }
+                            authenticate { oauthSessionService.retrieveFromAuthToken(it.token, client) }
                         }
                         clientHeaderAuth(CLIENT_HEADER_AUTH_NAME) {
                             headerName = "Delta-Client"

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/EditUserDetailsControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/EditUserDetailsControllerTest.kt
@@ -22,7 +22,10 @@ import uk.gov.communities.delta.auth.plugins.configureSerialization
 import uk.gov.communities.delta.auth.security.CLIENT_HEADER_AUTH_NAME
 import uk.gov.communities.delta.auth.security.OAUTH_ACCESS_BEARER_TOKEN_AUTH_NAME
 import uk.gov.communities.delta.auth.security.clientHeaderAuth
-import uk.gov.communities.delta.auth.services.*
+import uk.gov.communities.delta.auth.services.OAuthSession
+import uk.gov.communities.delta.auth.services.OAuthSessionService
+import uk.gov.communities.delta.auth.services.UserLookupService
+import uk.gov.communities.delta.auth.services.UserService
 import uk.gov.communities.delta.auth.withBearerTokenAuth
 import uk.gov.communities.delta.helper.testLdapUser
 import uk.gov.communities.delta.helper.testServiceClient
@@ -44,7 +47,7 @@ class EditUserDetailsControllerTest {
         }.apply {
             assertEquals(HttpStatusCode.OK, status)
             coVerify(exactly = 1) {
-                userService.updateUser(testUser, capture(modifications), null, userLookupService, any())
+                userService.updateUser(testUser, capture(modifications), null, any())
             }
 
             assertEquals(4, modifications.captured.size)
@@ -72,7 +75,7 @@ class EditUserDetailsControllerTest {
             }
         }.apply {
             assertEquals("non_numeric_telephone_number", errorCode)
-            coVerify(exactly = 0) { userService.updateUser(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { userService.updateUser(any(), any(), any(), any()) }
         }
     }
 
@@ -80,13 +83,13 @@ class EditUserDetailsControllerTest {
     fun resetMocks() {
         clearAllMocks()
         coEvery {
-            oauthSessionService.retrieveFomAuthToken(
+            oauthSessionService.retrieveFromAuthToken(
                 testUserSession.authToken,
                 client
             )
         } answers { testUserSession }
         coEvery { userLookupService.lookupCurrentUser(testUserSession) } returns testUser
-        coEvery { userService.updateUser(testUser, any(), null, userLookupService, any()) } just runs
+        coEvery { userService.updateUser(testUser, any(), null, any()) } just runs
     }
 
 
@@ -148,7 +151,7 @@ class EditUserDetailsControllerTest {
                     authentication {
                         bearer(OAUTH_ACCESS_BEARER_TOKEN_AUTH_NAME) {
                             realm = "auth-service"
-                            authenticate { oauthSessionService.retrieveFomAuthToken(it.token, client) }
+                            authenticate { oauthSessionService.retrieveFromAuthToken(it.token, client) }
                         }
                         clientHeaderAuth(CLIENT_HEADER_AUTH_NAME) {
                             headerName = "Delta-Client"

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/OAuthTokenControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/OAuthTokenControllerTest.kt
@@ -22,7 +22,6 @@ import uk.gov.communities.delta.auth.services.*
 import uk.gov.communities.delta.helper.testLdapUser
 import uk.gov.communities.delta.helper.testServiceClient
 import java.time.Instant
-import java.util.*
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
@@ -83,10 +82,10 @@ class OAuthTokenControllerTest {
         private lateinit var controller: OAuthTokenController
         private val client = testServiceClient()
 
-        private val userGUID = UUID.randomUUID()
         private val user = testLdapUser(cn = "user")
-        private val authCode = AuthCode("code", user.cn, userGUID, client, Instant.now(), "trace", false)
-        private val session = OAuthSession(1, user.cn, userGUID, client, "accessToken", Instant.now(), "trace", false)
+        private val authCode = AuthCode("code", user.getGUID(), client, Instant.now(), "trace", false)
+        private val session =
+            OAuthSession(1, user.cn, user.getGUID(), client, "accessToken", Instant.now(), "trace", false)
 
         private val authorizationCodeService = mockk<AuthorizationCodeService>()
         private val userLookupService = mockk<UserLookupService>()

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/AuthorizationCodeServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/AuthorizationCodeServiceTest.kt
@@ -21,17 +21,17 @@ class AuthorizationCodeServiceTest {
 
     @Test
     fun testLookupCodeWrongClientFails() = testSuspend {
-        val code = service.generateAndStore("some.user", userGUID, client, "traceId", false)
+        val code = service.generateAndStore(userGUID, client, "traceId", false)
         val result = service.lookupAndInvalidate(code.code, testServiceClient("wrong-client"))
         assertNull(result)
     }
 
     @Test
     fun testRetrieveValidCode() = testSuspend {
-        val code = service.generateAndStore("some.user", userGUID, client, "traceId", true)
+        val code = service.generateAndStore(userGUID, client, "traceId", true)
         val result = service.lookupAndInvalidate(code.code, client)
         assertNotNull(result)
-        assertEquals(result.userCn, "some.user")
+        assertEquals(result.userGUID, userGUID)
         assertEquals(result.traceId, "traceId")
         assertEquals(result.isSso, true)
         assertNull(service.lookupAndInvalidate(code.code, client), "Each code should only be usable once")
@@ -40,7 +40,7 @@ class AuthorizationCodeServiceTest {
     companion object {
         lateinit var service: AuthorizationCodeService
         val client = testServiceClient()
-        val userGUID = UUID.fromString("00112233-4455-6677-8899-aabbccddeeff")
+        val userGUID: UUID = UUID.randomUUID()
 
         @BeforeClass
         @JvmStatic

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/OAuthSessionServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/OAuthSessionServiceTest.kt
@@ -1,14 +1,17 @@
 package uk.gov.communities.delta.dbintegration
 
 import io.ktor.test.dispatcher.*
+import io.mockk.mockk
 import org.junit.BeforeClass
 import org.junit.Test
+import uk.gov.communities.delta.auth.repositories.UserGUIDMapRepo
 import uk.gov.communities.delta.auth.services.AuthCode
 import uk.gov.communities.delta.auth.services.OAuthSessionService
+import uk.gov.communities.delta.auth.services.UserGUIDMapService
 import uk.gov.communities.delta.auth.utils.TimeSource
+import uk.gov.communities.delta.helper.testLdapUser
 import uk.gov.communities.delta.helper.testServiceClient
 import java.time.Instant
-import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -16,46 +19,54 @@ import kotlin.test.assertNull
 class OAuthSessionServiceTest {
     @Test
     fun testLookupInvalidTokenFails() = testSuspend {
-        val result = service.retrieveFomAuthToken("invalidToken", client)
+        val result = service.retrieveFromAuthToken("invalidToken", client)
         assertNull(result)
     }
 
     @Test
     fun testLookupInvalidClientFails() = testSuspend {
-        val authCode = AuthCode("code", "userCn", userGUID, client, Instant.now(), "trace", false)
+        val authCode = AuthCode("code", user.getGUID(), client, Instant.now(), "trace", false)
+        userGUIDMapService.addNewUser(user)
         val createResult = service.create(authCode, client)
 
-        val result = service.retrieveFomAuthToken(createResult.authToken, testServiceClient("wrong-client"))
+        val result = service.retrieveFromAuthToken(createResult.authToken, testServiceClient("wrong-client"))
         assertNull(result)
     }
 
     @Test
     fun testCreateAndRetrieveSession() = testSuspend {
-        val authCode = AuthCode("code", "userCn", userGUID, client, Instant.now(), "trace", false)
+        val authCode = AuthCode("code", user.getGUID(), client, Instant.now(), "trace", false)
+        userGUIDMapService.addNewUser(user)
         val createResult = service.create(authCode, client)
 
         assertNotNull(createResult.id)
-        assertEquals(authCode.userCn, createResult.userCn)
+        assertEquals(authCode.userGUID, createResult.userGUID)
+        assertEquals(user.cn, createResult.userCn)
         assertEquals(authCode.traceId, createResult.traceId)
 
-        val lookupResult = service.retrieveFomAuthToken(createResult.authToken, client)
+        val lookupResult = service.retrieveFromAuthToken(createResult.authToken, client)
         assertNotNull(lookupResult)
         // The created at timestamp loses some precision in the database so will not be exactly the same
         assertEquals(createResult.id, lookupResult.id)
         assertEquals(createResult.userCn, lookupResult.userCn)
+        assertEquals(createResult.userGUID, lookupResult.userGUID)
         assertEquals(createResult.authToken, lookupResult.authToken)
         assertEquals(createResult.traceId, lookupResult.traceId)
     }
 
     companion object {
         lateinit var service: OAuthSessionService
-        private val userGUID = UUID.fromString("00112233-4455-6677-8899-aabbccddeeff")
+        lateinit var userGUIDMapService: UserGUIDMapService
+        private lateinit var userGUIDMapRepo: UserGUIDMapRepo
+        private val user = testLdapUser(cn = "OAuthSessionServiceTestUserCN")
         val client = testServiceClient()
 
         @BeforeClass
         @JvmStatic
         fun setup() {
-            service = OAuthSessionService(testDbPool, TimeSource.System)
+            userGUIDMapRepo = UserGUIDMapRepo()
+            service = OAuthSessionService(testDbPool, TimeSource.System, userGUIDMapRepo)
+            userGUIDMapService = UserGUIDMapService(userGUIDMapRepo, mockk(), testDbPool)
         }
     }
 }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/PasswordTokenServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/PasswordTokenServiceTest.kt
@@ -17,107 +17,107 @@ import kotlin.test.*
 class PasswordTokenServiceTest {
     @Test
     fun testLookupInvalidTokenOnSetFails() = testSuspend {
-        val result = setPasswordTokenService.validateToken("invalidToken", userCN, userGUID)
+        val result = setPasswordTokenService.validateToken("invalidToken", userGUID)
         assertTrue(result is PasswordTokenService.NoSuchToken)
     }
 
     @Test
     fun testLookupInvalidTokenOnResetFails() = testSuspend {
-        val result = resetPasswordTokenService.validateToken("invalidToken", userCN, userGUID)
+        val result = resetPasswordTokenService.validateToken("invalidToken", userGUID)
         assertTrue(result is PasswordTokenService.NoSuchToken)
     }
 
     @Test
     fun testLookupWrongUserOnSetFails() = testSuspend {
-        val token = setPasswordTokenService.createToken(userCN, userGUID)
-        val result = setPasswordTokenService.validateToken(token, "not$userCN", UUID.randomUUID())
+        val token = setPasswordTokenService.createToken(userGUID)
+        val result = setPasswordTokenService.validateToken(token, UUID.randomUUID())
         assertTrue(result is PasswordTokenService.NoSuchToken)
     }
 
     @Test
     fun testLookupWrongUserOnResetFails() = testSuspend {
-        val token = setPasswordTokenService.createToken(userCN, userGUID)
-        val result = resetPasswordTokenService.validateToken(token, "not$userCN", UUID.randomUUID())
+        val token = setPasswordTokenService.createToken(userGUID)
+        val result = resetPasswordTokenService.validateToken(token, UUID.randomUUID())
         assertTrue(result is PasswordTokenService.NoSuchToken)
     }
 
     @Test
     fun testLookupCorrectUserForSetWithoutDelete() = testSuspend {
-        val token = setPasswordTokenService.createToken(userCN, userGUID)
-        val result = setPasswordTokenService.validateToken(token, userCN, userGUID)
+        val token = setPasswordTokenService.createToken(userGUID)
+        val result = setPasswordTokenService.validateToken(token, userGUID)
         assertTrue(result is PasswordTokenService.ValidToken)
     }
 
     @Test
     fun testLookupCorrectUserForResetWithoutDelete() = testSuspend {
-        val token = resetPasswordTokenService.createToken(userCN, userGUID)
-        val result = resetPasswordTokenService.validateToken(token, userCN, userGUID)
+        val token = resetPasswordTokenService.createToken(userGUID)
+        val result = resetPasswordTokenService.validateToken(token, userGUID)
         assertTrue(result is PasswordTokenService.ValidToken)
     }
 
     @Test
     fun testLookupForSetWithDelete() = testSuspend {
-        val token = setPasswordTokenService.createToken(userCN, userGUID)
-        var result = setPasswordTokenService.consumeTokenIfValid(token, userCN, userGUID)
+        val token = setPasswordTokenService.createToken(userGUID)
+        var result = setPasswordTokenService.consumeTokenIfValid(token, userGUID)
         assertTrue(result is PasswordTokenService.ValidToken)
-        result = setPasswordTokenService.validateToken(token, userCN, userGUID)
+        result = setPasswordTokenService.validateToken(token, userGUID)
         assertTrue(result is PasswordTokenService.NoSuchToken)
     }
 
     @Test
     fun testLookupForResetWithDelete() = testSuspend {
-        val token = resetPasswordTokenService.createToken(userCN, userGUID)
-        var result = resetPasswordTokenService.consumeTokenIfValid(token, userCN, userGUID)
+        val token = resetPasswordTokenService.createToken(userGUID)
+        var result = resetPasswordTokenService.consumeTokenIfValid(token, userGUID)
         assertTrue(result is PasswordTokenService.ValidToken)
-        result = resetPasswordTokenService.validateToken(token, userCN, userGUID)
+        result = resetPasswordTokenService.validateToken(token, userGUID)
         assertTrue(result is PasswordTokenService.NoSuchToken)
     }
 
     @Test
     fun testLookupForSetWithoutDelete() = testSuspend {
-        val token = setPasswordTokenService.createToken(userCN, userGUID)
-        var result = setPasswordTokenService.validateToken(token, userCN, userGUID)
+        val token = setPasswordTokenService.createToken(userGUID)
+        var result = setPasswordTokenService.validateToken(token, userGUID)
         assertTrue(result is PasswordTokenService.ValidToken)
-        result = setPasswordTokenService.validateToken(token, userCN, userGUID)
+        result = setPasswordTokenService.validateToken(token, userGUID)
         assertTrue(result is PasswordTokenService.ValidToken)
     }
 
     @Test
     fun testLookupForResetWithoutDelete() = testSuspend {
-        val token = resetPasswordTokenService.createToken(userCN, userGUID)
-        var result = resetPasswordTokenService.validateToken(token, userCN, userGUID)
+        val token = resetPasswordTokenService.createToken(userGUID)
+        var result = resetPasswordTokenService.validateToken(token, userGUID)
         assertTrue(result is PasswordTokenService.ValidToken)
-        result = resetPasswordTokenService.validateToken(token, userCN, userGUID)
+        result = resetPasswordTokenService.validateToken(token, userGUID)
         assertTrue(result is PasswordTokenService.ValidToken)
     }
 
     @Test
     fun testOnlyOneTokenPerUserForSet() = testSuspend {
-        val originalToken = setPasswordTokenService.createToken(userCN, userGUID)
-        val replacementToken = setPasswordTokenService.createToken(userCN, userGUID)
-        var result = setPasswordTokenService.validateToken(originalToken, userCN, userGUID)
+        val originalToken = setPasswordTokenService.createToken(userGUID)
+        val replacementToken = setPasswordTokenService.createToken(userGUID)
+        var result = setPasswordTokenService.validateToken(originalToken, userGUID)
         assertTrue(result is PasswordTokenService.NoSuchToken)
-        result = setPasswordTokenService.consumeTokenIfValid(replacementToken, userCN, userGUID)
+        result = setPasswordTokenService.consumeTokenIfValid(replacementToken, userGUID)
         assertTrue(result is PasswordTokenService.ValidToken)
     }
 
     @Test
     fun testOnlyOneTokenPerUserForReset() = testSuspend {
-        val originalToken = resetPasswordTokenService.createToken(userCN, userGUID)
-        val replacementToken = resetPasswordTokenService.createToken(userCN, userGUID)
-        var result = resetPasswordTokenService.validateToken(originalToken, userCN, userGUID)
+        val originalToken = resetPasswordTokenService.createToken(userGUID)
+        val replacementToken = resetPasswordTokenService.createToken(userGUID)
+        var result = resetPasswordTokenService.validateToken(originalToken, userGUID)
         assertTrue(result is PasswordTokenService.NoSuchToken)
-        result = resetPasswordTokenService.consumeTokenIfValid(replacementToken, userCN, userGUID)
+        result = resetPasswordTokenService.consumeTokenIfValid(replacementToken, userGUID)
         assertTrue(result is PasswordTokenService.ValidToken)
     }
 
     @Test
     fun testLookupExpiredTokenForSet() = testSuspend {
-        val token = setPasswordTokenService.createToken(userCN, userGUID)
+        val token = setPasswordTokenService.createToken(userGUID)
         withContext(Dispatchers.IO) {
             testDbPool.useConnectionBlocking("Test make set password token expire") {
                 val stmt = it.prepareStatement(
-                    "UPDATE set_password_tokens SET created_at = ? WHERE user_cn = ? "
+                    "UPDATE set_password_tokens SET created_at = ? WHERE user_guid = ? "
                 )
                 stmt.setTimestamp(
                     1,
@@ -125,22 +125,22 @@ class PasswordTokenServiceTest {
                         TimeSource.System.now().minusSeconds(PasswordTokenService.TOKEN_VALID_DURATION_SECONDS)
                     )
                 )
-                stmt.setString(2, userCN)
+                stmt.setObject(2, userGUID)
                 stmt.executeUpdate()
                 it.commit()
             }
         }
-        val result = setPasswordTokenService.validateToken(token, userCN, userGUID)
+        val result = setPasswordTokenService.validateToken(token, userGUID)
         assertTrue(result is PasswordTokenService.ExpiredToken)
     }
 
     @Test
     fun testLookupExpiredTokenForReset() = testSuspend {
-        val token = resetPasswordTokenService.createToken(userCN, userGUID)
+        val token = resetPasswordTokenService.createToken(userGUID)
         withContext(Dispatchers.IO) {
             testDbPool.useConnectionBlocking("Test make reset password token expire") {
                 val stmt = it.prepareStatement(
-                    "UPDATE reset_password_tokens SET created_at = ? WHERE user_cn = ? "
+                    "UPDATE reset_password_tokens SET created_at = ? WHERE user_guid = ? "
                 )
                 stmt.setTimestamp(
                     1,
@@ -148,75 +148,73 @@ class PasswordTokenServiceTest {
                         TimeSource.System.now().minusSeconds(PasswordTokenService.TOKEN_VALID_DURATION_SECONDS)
                     )
                 )
-                stmt.setString(2, userCN)
+                stmt.setObject(2, userGUID)
                 stmt.executeUpdate()
                 it.commit()
             }
         }
-        val result = resetPasswordTokenService.validateToken(token, userCN, userGUID)
+        val result = resetPasswordTokenService.validateToken(token, userGUID)
         assertTrue(result is PasswordTokenService.ExpiredToken)
     }
 
     @Test
     fun testTokenCreationForSet() = testSuspend {
-        val token = setPasswordTokenService.createToken(userCN, userGUID)
+        val token = setPasswordTokenService.createToken(userGUID)
         assertEquals(PasswordTokenService.TOKEN_LENGTH_BYTES * 8 / 6, token.length)
     }
 
     @Test
     fun testTokenCreationForReset() = testSuspend {
-        val token = resetPasswordTokenService.createToken(userCN, userGUID)
+        val token = resetPasswordTokenService.createToken(userGUID)
         assertEquals(PasswordTokenService.TOKEN_LENGTH_BYTES * 8 / 6, token.length)
     }
 
     @Test
     fun testTablesAreIndependent() = testSuspend {
-        val setToken = setPasswordTokenService.createToken(userCN, userGUID)
-        val resetToken = resetPasswordTokenService.createToken(userCN, userGUID)
-        var setTokenResult = setPasswordTokenService.validateToken(setToken, userCN, userGUID)
+        val setToken = setPasswordTokenService.createToken(userGUID)
+        val resetToken = resetPasswordTokenService.createToken(userGUID)
+        var setTokenResult = setPasswordTokenService.validateToken(setToken, userGUID)
         assertTrue(setTokenResult is PasswordTokenService.ValidToken)
-        val setTokenAsResetTokenResult = resetPasswordTokenService.validateToken(setToken, userCN, userGUID)
+        val setTokenAsResetTokenResult = resetPasswordTokenService.validateToken(setToken, userGUID)
         assertEquals(PasswordTokenService.NoSuchToken, setTokenAsResetTokenResult)
-        val resetTokenResult = resetPasswordTokenService.consumeTokenIfValid(resetToken, userCN, userGUID)
+        val resetTokenResult = resetPasswordTokenService.consumeTokenIfValid(resetToken, userGUID)
         assertTrue(resetTokenResult is PasswordTokenService.ValidToken)
-        setTokenResult = setPasswordTokenService.validateToken(setToken, userCN, userGUID)
+        setTokenResult = setPasswordTokenService.validateToken(setToken, userGUID)
         assertTrue(setTokenResult is PasswordTokenService.ValidToken)
     }
 
     @Test
     fun testPasswordNeverSetChecksForSetPasswordToken() = testSuspend {
-        val otherUserCN = "other-$userCN"
         val otherUserGUID = UUID.randomUUID()
-        var passwordSet = setPasswordTokenService.passwordNeverSetForUserCN(otherUserCN)
+        var passwordSet = setPasswordTokenService.passwordNeverSetForUserCN(otherUserGUID)
         assertFalse(passwordSet)
-        resetPasswordTokenService.createToken(otherUserCN, otherUserGUID)
-        passwordSet = setPasswordTokenService.passwordNeverSetForUserCN(otherUserCN)
+        resetPasswordTokenService.createToken(otherUserGUID)
+        passwordSet = setPasswordTokenService.passwordNeverSetForUserCN(otherUserGUID)
         assertFalse(passwordSet)
-        setPasswordTokenService.createToken(otherUserCN, otherUserGUID)
-        passwordSet = setPasswordTokenService.passwordNeverSetForUserCN(otherUserCN)
+        setPasswordTokenService.createToken(otherUserGUID)
+        passwordSet = setPasswordTokenService.passwordNeverSetForUserCN(otherUserGUID)
         assertTrue(passwordSet)
     }
 
     @Test
     fun testClearTokenForUserCn() = testSuspend {
-        val clearTokenUserCn = "clear-token-$userCN"
         val clearTokenUserGUID = UUID.randomUUID()
 
-        val token = setPasswordTokenService.createToken(clearTokenUserCn, clearTokenUserGUID)
+        val token = setPasswordTokenService.createToken(clearTokenUserGUID)
         assertIs<PasswordTokenService.ValidToken>(
-            setPasswordTokenService.validateToken(token, clearTokenUserCn, clearTokenUserGUID)
+            setPasswordTokenService.validateToken(token, clearTokenUserGUID)
         )
 
-        setPasswordTokenService.clearTokenForUserCn(clearTokenUserCn)
+        setPasswordTokenService.clearTokenForUserGUID(clearTokenUserGUID)
 
         assertIsNot<PasswordTokenService.ValidToken>(
-            setPasswordTokenService.validateToken(token, clearTokenUserCn, clearTokenUserGUID)
+            setPasswordTokenService.validateToken(token, clearTokenUserGUID)
         )
     }
 
     companion object {
         private const val userCN = "user!example.com"
-        private val userGUID = UUID.fromString("00112233-4455-6677-8899-aabbccddeeff")
+        private val userGUID = UUID.randomUUID()
         lateinit var setPasswordTokenService: SetPasswordTokenService
         lateinit var resetPasswordTokenService: ResetPasswordTokenService
         val client = testServiceClient()

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditServiceTest.kt
@@ -10,8 +10,10 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.junit.BeforeClass
 import org.junit.Test
 import uk.gov.communities.delta.auth.config.AzureADSSOClient
-import uk.gov.communities.delta.auth.services.UserAuditService
 import uk.gov.communities.delta.auth.repositories.UserAuditTrailRepo
+import uk.gov.communities.delta.auth.repositories.UserGUIDMapRepo
+import uk.gov.communities.delta.auth.services.UserAuditService
+import uk.gov.communities.delta.helper.testLdapUser
 import uk.gov.communities.delta.helper.testServiceClient
 import java.util.*
 import kotlin.test.assertEquals
@@ -20,32 +22,45 @@ import kotlin.test.assertNull
 class UserAuditServiceTest {
     @Test
     fun testUserLoginAudit() = testSuspend {
-        assertEquals(0, service.getAuditForUser("login.user!example.com").size)
+        val userGUID = UUID.fromString("aa11bb22-cc33-dd44-ee55-ff6677889900")
+        val userCN = "auditServiceLoginTestCN"
+        testDbPool.useConnectionBlocking("add_test_user_to_guid_map") {
+            userGUIDMapRepo.newUser(it, testLdapUser(cn = userCN, javaUUIDObjectGuid = userGUID.toString()))
+            it.commit()
+            assertEquals(userGUID, userGUIDMapRepo.getGUIDForUser(it, userCN))
+        }
+        assertEquals(0, service.getAuditForUser(userGUID).size)
 
-        service.userFormLoginAudit("login.user!example.com", userGUID, call)
+        service.userFormLoginAudit(userGUID, call)
 
-        val audit = service.getAuditForUser("login.user!example.com")
+        val audit = service.getAuditForUser(userGUID)
         assertEquals(1, audit.size)
-        assertEquals("login.user!example.com", audit[0].userCn)
+        assertEquals(userCN, audit[0].userCN)
         assertEquals(call.callId, audit[0].requestId)
-        assertNull(audit[0].editingUserCn)
+        assertNull(audit[0].editingUserCN)
         assertEquals(UserAuditTrailRepo.AuditAction.FORM_LOGIN, audit[0].action)
     }
 
     @Test
     fun testSSOLoginAudit() = testSuspend {
+        val userGUID = UUID.randomUUID()
+        val userCN = "auditServiceSSOLoginTestCN"
+        testDbPool.useConnectionBlocking("add_test_user_to_guid_map") {
+            userGUIDMapRepo.newUser(it, testLdapUser(cn = userCN, javaUUIDObjectGuid = userGUID.toString()))
+            it.commit()
+            assertEquals(userGUID, userGUIDMapRepo.getGUIDForUser(it, userCN))
+        }
         service.userSSOLoginAudit(
-            "sso.user!example.com",
             userGUID,
                 AzureADSSOClient("sso-id", "", "", "", "@example.com"),
                 "az-123", call,
             )
 
-        val audit = service.getAuditForUser("sso.user!example.com")
+        val audit = service.getAuditForUser(userGUID)
         assertEquals(1, audit.size)
-        assertEquals("sso.user!example.com", audit[0].userCn)
+        assertEquals(userCN, audit[0].userCN)
         assertEquals(call.callId, audit[0].requestId)
-        assertNull(audit[0].editingUserCn)
+        assertNull(audit[0].editingUserCN)
         assertEquals(UserAuditTrailRepo.AuditAction.SSO_LOGIN, audit[0].action)
         assertEquals("az-123", audit[0].actionData.jsonObject["azureUserObjectId"]!!.jsonPrimitive.content)
     }
@@ -53,14 +68,16 @@ class UserAuditServiceTest {
     companion object {
         lateinit var service: UserAuditService
         val client = testServiceClient()
-        private val userGUID = UUID.fromString("00112233-4455-6677-8899-aabbccddeeff")
         val call = mockk<ApplicationCall>()
+        private lateinit var userGUIDMapRepo: UserGUIDMapRepo
+
 
         @BeforeClass
         @JvmStatic
         fun setup() {
             val repo = UserAuditTrailRepo()
             service = UserAuditService(repo, testDbPool)
+            userGUIDMapRepo = UserGUIDMapRepo()
             every { call.callId } returns "request-id-1234"
         }
     }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditTrailRepoTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditTrailRepoTest.kt
@@ -5,7 +5,8 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.junit.BeforeClass
 import org.junit.Test
 import uk.gov.communities.delta.auth.repositories.UserAuditTrailRepo
-import java.util.*
+import uk.gov.communities.delta.auth.repositories.UserGUIDMapRepo
+import uk.gov.communities.delta.helper.testLdapUser
 import java.time.Instant
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -14,11 +15,11 @@ class UserAuditTrailRepoTest {
     @Test
     fun testRetrievesAuditValues() {
         testDbPool.useConnectionBlocking("test_login_audit") {
-            val audit = repo.getAuditForUser(it, userCN)
+            val audit = repo.getAuditForUser(it, user.getGUID())
             assertEquals(2, audit.size)
-            assertEquals(userCN, audit[1].userCn)
+            assertEquals(user.getGUID(), audit[1].userGUID)
             assertEquals("requestId", audit[1].requestId)
-            assertNull(audit[1].editingUserCn)
+            assertNull(audit[1].editingUserCN)
             assertEquals(UserAuditTrailRepo.AuditAction.FORM_LOGIN, audit[1].action)
             assertEquals("value", audit[1].actionData.jsonObject["key"]!!.jsonPrimitive.content)
         }
@@ -27,16 +28,16 @@ class UserAuditTrailRepoTest {
     @Test
     fun testOtherUserAuditIsEmpty() {
         testDbPool.useConnectionBlocking("test_login_audit") {
-            assertEquals(0, repo.getAuditForUser(it, otherUserCN).size)
+            assertEquals(0, repo.getAuditForUser(it, otherUser.getGUID()).size)
         }
     }
 
     @Test
     fun testPagination() {
         testDbPool.useConnectionBlocking("test_login_audit") {
-            val firstPage = repo.getAuditForUser(it, userCN, Pair(1, 0))
-            val secondPage = repo.getAuditForUser(it, userCN, Pair(1, 1))
-            val thirdPage = repo.getAuditForUser(it, userCN, Pair(1, 2))
+            val firstPage = repo.getAuditForUser(it, user.getGUID(), Pair(1, 0))
+            val secondPage = repo.getAuditForUser(it, user.getGUID(), Pair(1, 1))
+            val thirdPage = repo.getAuditForUser(it, user.getGUID(), Pair(1, 2))
             assertEquals(UserAuditTrailRepo.AuditAction.RESET_PASSWORD_EMAIL, firstPage.single().action)
             assertEquals(UserAuditTrailRepo.AuditAction.FORM_LOGIN, secondPage.single().action)
             assertEquals(0, thirdPage.size)
@@ -46,7 +47,7 @@ class UserAuditTrailRepoTest {
     @Test
     fun testRecordCount() {
         testDbPool.useConnectionBlocking("test_login_audit") {
-            assertEquals(2, repo.getAuditItemCount(it, "some.user!audit-test.com"))
+            assertEquals(2, repo.getAuditItemCount(it, user.getGUID()))
         }
     }
 
@@ -54,7 +55,7 @@ class UserAuditTrailRepoTest {
     fun testAllUserAudit() {
         testDbPool.useConnectionBlocking("test_login_audit") { conn ->
             val all = repo.getAuditForAllUsers(conn, Instant.now().minusSeconds(60), Instant.now().plusSeconds(10))
-            assertEquals(2, all.filter { it.userCn == "some.user!audit-test.com" }.size)
+            assertEquals(2, all.filter { it.userGUID == user.getGUID() }.size)
             val allAfterNow = repo.getAuditForAllUsers(conn, Instant.now().plusSeconds(60), Instant.now().plusSeconds(100))
             assertEquals(0, allAfterNow.size)
         }
@@ -62,23 +63,22 @@ class UserAuditTrailRepoTest {
 
     companion object {
         lateinit var repo: UserAuditTrailRepo
-        private const val userCN = "some.user!audit-test.com"
-        private const val otherUserCN = "other.user!audit-test.com"
-        private val userGUID = UUID.fromString("00112233-4455-6677-8899-aabbccddeeff")
+        private lateinit var userGUIDMapRepo: UserGUIDMapRepo
+        private val user = testLdapUser(cn = "testUser")
+        private val otherUser = testLdapUser(cn = "otherTestUser")
 
         @BeforeClass
         @JvmStatic
         fun setup() {
             repo = UserAuditTrailRepo()
+            userGUIDMapRepo = UserGUIDMapRepo()
             testDbPool.useConnectionBlocking("test_login_audit") {
-                assertEquals(0, repo.getAuditForUser(it, "some.user!audit-test.com").size)
+                assertEquals(0, repo.getAuditForUser(it, user.getGUID()).size)
 
                 repo.insertAuditRow(
                     it,
                     UserAuditTrailRepo.AuditAction.FORM_LOGIN,
-                    userCN,
-                    userGUID,
-                    null,
+                    user.getGUID(),
                     null,
                     "requestId",
                     "{\"key\": \"value\"}"
@@ -88,13 +88,13 @@ class UserAuditTrailRepoTest {
                 repo.insertAuditRow(
                     it,
                     UserAuditTrailRepo.AuditAction.RESET_PASSWORD_EMAIL,
-                    userCN,
-                    userGUID,
-                    null,
+                    user.getGUID(),
                     null,
                     "requestId2",
                     "{}"
                 )
+                userGUIDMapRepo.newUser(it, user)
+                userGUIDMapRepo.newUser(it, otherUser)
                 it.commit()
             }
         }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserGUIDMapTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserGUIDMapTest.kt
@@ -1,0 +1,92 @@
+package uk.gov.communities.delta.dbintegration
+
+import io.ktor.server.application.*
+import io.ktor.test.dispatcher.*
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import uk.gov.communities.delta.auth.plugins.NoUserException
+import uk.gov.communities.delta.auth.repositories.UserGUIDMapRepo
+import uk.gov.communities.delta.auth.services.UserGUIDMapService
+import uk.gov.communities.delta.auth.services.UserLookupService
+import uk.gov.communities.delta.helper.testLdapUser
+import uk.gov.communities.delta.helper.testServiceClient
+import kotlin.test.assertEquals
+
+class UserGUIDMapTest {
+
+    @Test
+    fun testGetGUID() = testSuspend {
+        val user = testLdapUser(email = "getGUID@test.com", cn = "getGUID!test.com")
+        coEvery { userLookupService.lookupUserByCN(user.cn) } throws NoUserException("Test exception")
+        assertEquals(null, service.userGUIDIfExists(user.email!!))
+        coVerify(exactly = 1) { userLookupService.lookupUserByCN(user.cn) }
+        service.addNewUser(user)
+        assertEquals(user.getGUID(), service.userGUIDIfExists(user.email!!))
+        confirmVerified(userLookupService)
+    }
+
+    @Test
+    fun testThrowsErrorIfNoUser() = testSuspend {
+        val user = testLdapUser(email = "throwError@test.com", cn = "throwError!test.com")
+        Assert.assertThrows(NoUserException::class.java) {
+            runBlocking {
+                coEvery { userLookupService.lookupUserByCN(user.cn) } throws NoUserException("Test exception")
+                service.getGUID(user.cn)
+            }
+        }.apply {
+            coVerify(exactly = 1) { userLookupService.lookupUserByCN(user.cn) }
+        }
+    }
+
+    @Test
+    fun testAddRowIfInADButNotInTable() = testSuspend {
+        val user = testLdapUser(email = "addRow@test.com", cn = "addRow!test.com")
+        coEvery { userLookupService.lookupUserByCN(user.cn) } returns user
+        assertEquals(user.getGUID(), service.userGUIDIfExists(user.email!!))
+        coVerify(exactly = 1) { userLookupService.lookupUserByCN(user.cn) }
+        assertEquals(user.getGUID(), service.userGUIDIfExists(user.email!!))
+        confirmVerified(userLookupService)
+    }
+
+    @Test
+    fun testUpdateUserCN() = testSuspend {
+        val user = testLdapUser(email = "toUpdate@test.com", cn = "toUpdate!test.com")
+        service.addNewUser(user)
+        assertEquals(user.getGUID(), service.userGUIDIfExists(user.email!!))
+        service.updateUserCN(user, "updatedUser!test.com")
+        assertEquals(user.getGUID(), service.getGUIDFromEmail("updatedUser@test.com"))
+        assertEquals(user.getGUID(), service.getGUID("updatedUser!test.com"))
+    }
+
+    @Test
+    fun testUpdateNotExistingUserCN() = testSuspend {
+        val user = testLdapUser(email = "toUpdateNotExisting@test.com", cn = "toUpdateNotExisting!test.com")
+        service.updateUserCN(user, "updatedNotExistingUser!test.com")
+        assertEquals(user.getGUID(), service.getGUIDFromEmail("updatedNotExistingUser@test.com"))
+        assertEquals(user.getGUID(), service.getGUID("updatedNotExistingUser!test.com"))
+    }
+
+    @Before
+    fun resetMocks() {
+        clearAllMocks()
+    }
+
+    companion object {
+        lateinit var service: UserGUIDMapService
+        val userLookupService = mockk<UserLookupService>()
+        val client = testServiceClient()
+        val call = mockk<ApplicationCall>()
+
+        @BeforeClass
+        @JvmStatic
+        fun setup() {
+            val repo = UserGUIDMapRepo()
+            service = UserGUIDMapService(repo, userLookupService, testDbPool)
+        }
+    }
+
+}

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/helper/MockUserLookupService.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/helper/MockUserLookupService.kt
@@ -1,8 +1,6 @@
 package uk.gov.communities.delta.helper
 
 import io.mockk.coEvery
-import io.mockk.mockk
-import uk.gov.communities.delta.auth.repositories.LdapRepository
 import uk.gov.communities.delta.auth.repositories.LdapUser
 import uk.gov.communities.delta.auth.services.*
 
@@ -12,32 +10,18 @@ fun mockUserLookupService(
     organisations: List<OrganisationNameAndCode>,
     accessGroups: List<AccessGroup>,
 ) {
-    coEvery { service.lookupUserByCn(any()) } throws mockk<LdapRepository.NoUserException>()
-    coEvery { service.lookupUserByDN(any()) } throws mockk<LdapRepository.NoUserException>()
-    coEvery { service.lookupUserByCNAndLoadRoles(any()) } throws mockk<LdapRepository.NoUserException>()
     for ((user, session) in users) {
-        coEvery { service.lookupUserByCn(user.cn) } returns user
-        coEvery { service.lookupUserByDN(user.dn) } returns user
-        coEvery {
-            service.lookupUserByCNAndLoadRoles(user.cn)
-        } coAnswers {
-            LdapUserWithRoles(
-                user,
-                MemberOfToDeltaRolesMapper(user.cn, organisations, accessGroups).map(user.memberOfCNs)
-            )
-        }
-        coEvery { service.lookupUserByEmail(user.email!!) } returns user
         coEvery { service.lookupUserByGUID(user.getGUID()) } returns user
         coEvery { service.lookupUserByGUIDAndLoadRoles(user.getGUID()) } coAnswers {
             LdapUserWithRoles(
-                user, MemberOfToDeltaRolesMapper(user.cn, organisations, accessGroups).map(user.memberOfCNs)
+                user, MemberOfToDeltaRolesMapper(user.getGUID(), organisations, accessGroups).map(user.memberOfCNs)
             )
         }
 
         if (session != null) {
             coEvery { service.lookupCurrentUser(session) } returns user
             coEvery { service.lookupCurrentUserAndLoadRoles(session) } returns LdapUserWithRoles(
-                user, MemberOfToDeltaRolesMapper(user.cn, organisations, accessGroups).map(user.memberOfCNs)
+                user, MemberOfToDeltaRolesMapper(user.getGUID(), organisations, accessGroups).map(user.memberOfCNs)
             )
         }
     }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/helper/TestLdapUser.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/helper/TestLdapUser.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.delta.helper
 
 import uk.gov.communities.delta.auth.repositories.LdapUser
 import java.time.Instant
+import java.util.*
 
 fun testLdapUser(
     dn: String = "dn",
@@ -14,7 +15,7 @@ fun testLdapUser(
     fullName: String = "Test Surname",
     accountEnabled: Boolean = true,
     mangledDeltaObjectGuid: String? = null,
-    javaUUIDObjectGuid: String? = "00112233-4455-6677-8899-aabbccddeeff",
+    javaUUIDObjectGuid: String? = UUID.randomUUID().toString(),
     telephone: String? = null,
     mobile: String? = null,
     positionInOrganisation: String? = null,

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/ADLdapLoginServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/ADLdapLoginServiceTest.kt
@@ -5,9 +5,10 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Before
+import uk.gov.communities.delta.auth.repositories.LdapRepository
+import uk.gov.communities.delta.auth.repositories.LdapUser
 import uk.gov.communities.delta.auth.security.ADLdapLoginService
 import uk.gov.communities.delta.auth.security.IADLdapLoginService
-import uk.gov.communities.delta.auth.repositories.LdapRepository
 import uk.gov.communities.delta.helper.testLdapUser
 import javax.naming.ldap.InitialLdapContext
 import kotlin.test.Test
@@ -17,6 +18,7 @@ import kotlin.test.assertTrue
 class ADLdapLoginServiceTest {
     private lateinit var loginService: ADLdapLoginService
     private lateinit var ldapRepository: LdapRepository
+    private lateinit var user: LdapUser
 
     @Before
     fun setup() {
@@ -26,8 +28,9 @@ class ADLdapLoginServiceTest {
             ldapRepository,
         )
         val mockContext = mockk<InitialLdapContext>(relaxed = true)
+        user = testLdapUser()
         every { ldapRepository.bind("CN=username,OU=Users,DC=test", "password") }.returns(mockContext)
-        every { ldapRepository.mapUserFromContext(mockContext, "CN=username,OU=Users,DC=test") }.returns(testLdapUser())
+        every { ldapRepository.mapUserFromContext(mockContext, "CN=username,OU=Users,DC=test") }.returns(user)
     }
 
     @Test
@@ -35,7 +38,7 @@ class ADLdapLoginServiceTest {
         val result = loginService.ldapLogin("username", "password")
 
         assertTrue(result is IADLdapLoginService.LdapLoginSuccess)
-        assertEquals(result.user, testLdapUser())
+        assertEquals(result.user, user)
     }
 
     @Test

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/service/MemberOfToDeltaRolesMapperTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/service/MemberOfToDeltaRolesMapperTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.delta.service
 
 import uk.gov.communities.delta.auth.services.*
+import java.util.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -131,7 +132,7 @@ class MemberOfToDeltaRolesMapperTest {
         assertEquals(listOf("dclg", "E1234"), result.organisations.map { it.code })
     }
 
-    private fun mapper() = MemberOfToDeltaRolesMapper("username", organisations, accessGroups)
+    private fun mapper() = MemberOfToDeltaRolesMapper(UUID.randomUUID(), organisations, accessGroups)
 
     private val accessGroups = listOf(
         AccessGroup("access-group", "STATS", null, enableOnlineRegistration = false, enableInternalUser = false),

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/service/UserLookupServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/service/UserLookupServiceTest.kt
@@ -18,17 +18,16 @@ class UserLookupServiceTest {
     @Test
     fun testLookupUser() = testSuspend {
         val testUser = testLdapUser()
-        every { ldapRepository.mapUserFromContext(any(), "CN=some!user") } returns testUser
-        val result = userLookupService.lookupUserByCn("some!user")
+        every { ldapRepository.mapUserFromContext(any(), testUser.getGUID()) } returns testUser
+        val result = userLookupService.lookupUserByGUID(testUser.getGUID())
         assertTrue { testUser === result }
     }
 
     @Test
     fun testMapUser() = testSuspend {
         val testUser = testLdapUser(memberOfCNs = listOf("datamart-delta-user", "datamart-delta-user-orgCode1", "datamart-delta-access-group-1"))
-        every { ldapRepository.mapUserFromContext(any(), "CN=some!user") } returns testUser
-
-        val result = userLookupService.lookupUserByCNAndLoadRoles("some!user")
+        every { ldapRepository.mapUserFromContext(any(), testUser.getGUID()) } returns testUser
+        val result = userLookupService.lookupUserByGUIDAndLoadRoles(testUser.getGUID())
         assertTrue { testUser === result.user }
         assertEquals(DeltaSystemRole.USER, result.roles.systemRoles.single().role)
         assertEquals("orgCode1", result.roles.organisations.single().code)

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/tasks/DeleteOldAuthCodesTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/tasks/DeleteOldAuthCodesTest.kt
@@ -9,7 +9,7 @@ import uk.gov.communities.delta.dbintegration.testDbPool
 import uk.gov.communities.delta.helper.testServiceClient
 import java.time.Instant
 import java.time.temporal.ChronoUnit
-import java.util.UUID
+import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
@@ -22,15 +22,15 @@ class DeleteOldAuthCodesTest {
     }
     private val underTest = DeleteOldAuthCodes(testDbPool)
     private val authorizationCodeService = AuthorizationCodeService(testDbPool, timeSource)
-    private val oldUUID = UUID.fromString("00112233-4455-6677-8899-aabbccddeeff")
-    private val newUUID = UUID.fromString("ffeeddcc-bbaa-9988-7766-554433221100")
+    private val oldUUID = UUID.randomUUID()
+    private val newUUID = UUID.randomUUID()
 
     @Test
     fun deleteOldAuthCodesTest() = testSuspend {
         val newCode =
-            authorizationCodeService.generateAndStore("DeleteOldAuthCodesTest-new-user", newUUID,  testServiceClient(), "trace", false)
+            authorizationCodeService.generateAndStore(newUUID, testServiceClient(), "trace", false)
         time = { Instant.now().minus(2, ChronoUnit.DAYS) }
-        authorizationCodeService.generateAndStore("DeleteOldAuthCodesTest-old-user", oldUUID, testServiceClient(), "old-trace", false)
+        authorizationCodeService.generateAndStore(oldUUID, testServiceClient(), "old-trace", false)
         time = { Instant.now() }
 
         testDbPool.useConnectionBlocking("test") {
@@ -53,7 +53,7 @@ class DeleteOldAuthCodesTest {
 
     private fun countOldAuthCodes(): Int {
         return testDbPool.useConnectionBlocking("test") {
-            val stmt = it.prepareStatement("SELECT COUNT(*) FROM authorization_code WHERE username = 'DeleteOldAuthCodesTest-old-user' AND user_guid = ?")
+            val stmt = it.prepareStatement("SELECT COUNT(*) FROM authorization_code WHERE user_guid = ?")
             stmt.setObject(1, oldUUID)
             val resultSet = stmt.executeQuery()
             resultSet.next()


### PR DESCRIPTION
**Description**
(Second half of DT-976, being tracked by DT-1044)
Delete the user cn columns from the database tables
Introduce the user_guid_map table as a way to get user_cn from guid and vice versa without an AD lookup
Uses SQL to get the cns corresponding to the auditted guids so that the audits can still show readable cns but the cns are not auditted -> audit is no longer useless after an email change and also doesn't rely on personal data as the identifying piece of information
Remove the additional code that was introduced in DT-976 (part 1) for the transition period.
Remove any possible uses of userCN, update logs to use userGUID where possible. 
I have raised https://dluhcdigital.atlassian.net/browse/DT-1043 to make the GUID a searchable term on the frontend so that we can easier reverse look up a user from their GUID, until this is done username and guid are both logged by MDC logs.

**Local testing** 
I have tested the audits and register/set password flow as well as lots of other changes along the way. I have run the playwright tests locally and they pass (after a change to the set password url - PR in delta repo to follow)
I have updated all auth service tests and they all pass. I have also added a few tests for untested user flows.

Testing directions:
Test all auth service user flows and ensure they are audited correctly, this should include:

- Login - standard user and SSO
- Edit user - self (non admin), self (admin), other user (as admin)
- Disable/enable user (as admin)
- Reset MFA (as admin)
- New User as admin
- Register self
- SSO registration
- Sending emails as admin
- Forgot password flow
- Updating username (as admin)
- Update user notification status (as admin)
- Impersonating a user (as admin)
- Audits - one user as admin and all users as admin and self (for actions before and after the code was released)

**Release** 

Must be released after (separately from) DT-976 (part 1)

Between the two releases the top 43 lines of the migration (V10) should be run 

UPDATE delta_session
SET user_guid = ugm.newguid
FROM user_guid_map ugm
WHERE delta_session.username = ugm.cn
  AND delta_session.user_guid IS NULL;

UPDATE delta_session
SET impersonated_user_guid = ugm.newguid
FROM user_guid_map ugm
WHERE delta_session.impersonated_user_cn IS NOT NULL
  AND delta_session.impersonated_user_cn = ugm.cn
  AND delta_session.impersonated_user_guid IS NULL;

UPDATE authorization_code
SET user_guid = ugm.newguid
FROM user_guid_map ugm
WHERE authorization_code.username = ugm.cn
  AND authorization_code.user_guid IS NULL;

UPDATE reset_password_tokens
SET user_guid = ugm.newguid
FROM user_guid_map ugm
WHERE reset_password_tokens.user_cn = ugm.cn
  AND reset_password_tokens.user_guid IS NULL;

UPDATE set_password_tokens
SET user_guid = ugm.newguid
FROM user_guid_map ugm
WHERE set_password_tokens.user_cn = ugm.cn
  AND set_password_tokens.user_guid IS NULL;

UPDATE user_audit
SET user_guid = ugm.newguid
FROM user_guid_map ugm
WHERE user_audit.user_cn = ugm.cn
  AND user_audit.user_guid IS NULL;

UPDATE user_audit
SET editing_user_guid = ugm.newguid
FROM user_guid_map ugm
WHERE user_audit.editing_user_cn IS NOT NULL
  AND user_audit.editing_user_guid IS NULL
  AND user_audit.editing_user_cn = ugm.cn;

After running this for the first time the UpdateUserGUIDMap task should be run on production so that it is up to date with the latest versions and then the above SQL should be run again.

Any remaining rows with user_guid (or editing_user_guid etc) that are NULL need to be resolved before the second release. This is because the migration will remove the user cn column from the user audit (and other database tables) there are some user_cns that no longer map to a user_guid since the user's name has been changed. There are ~50 of these on production. So, before this is released (and thus before the full migration is run and the columns deleted) the relevant rows should either be backfilled with the correct user_guid (if we can find it manually) or deleted and noted in the ticket (DT-976) if we can't find it manually.

The SQL to find the list of user_cns for which this is an issue is 

SELECT DISTINCT * FROM (
                           SELECT DISTINCT user_cn
                           FROM user_audit
                                    LEFT JOIN user_guid_map ON user_audit.user_cn = user_guid_map.cn
                           WHERE user_guid_map.cn IS NULL
                           UNION ALL
                           SELECT DISTINCT editing_user_cn
                           FROM user_audit
                                    LEFT JOIN user_guid_map ON user_audit.editing_user_cn = user_guid_map.cn
                           WHERE user_guid_map.cn IS NULL
                           UNION ALL
                           SELECT DISTINCT username
                           FROM delta_session
                                    LEFT JOIN user_guid_map ON delta_session.username = user_guid_map.cn
                           WHERE user_guid_map.cn IS NULL
                           UNION ALL
                           SELECT DISTINCT impersonated_user_cn
                           FROM delta_session
                                    LEFT JOIN user_guid_map ON delta_session.impersonated_user_cn = user_guid_map.cn
                           WHERE user_guid_map.cn IS NULL
                           UNION ALL
                           SELECT DISTINCT username
                           FROM authorization_code
                                    LEFT JOIN user_guid_map ON authorization_code.username = user_guid_map.cn
                           WHERE user_guid_map.cn IS NULL
                           UNION ALL
                           SELECT DISTINCT user_cn
                           FROM reset_password_tokens
                                    LEFT JOIN user_guid_map ON reset_password_tokens.user_cn = user_guid_map.cn
                           WHERE user_guid_map.cn IS NULL
                           UNION ALL
                           SELECT DISTINCT user_cn
                           FROM set_password_tokens
                                    LEFT JOIN user_guid_map ON set_password_tokens.user_cn = user_guid_map.cn
                           WHERE user_guid_map.cn IS NULL
                       )

If this returns any users before the migration has run then the migration will fail.

After the second release the UpdateUserGUIDMap task should be run on production so that it is up to date with the latest versions.

I will put these directions in the ticket specific release actions upon merge - let me know if anything needs clarifying :) 

I have not updated any further documentation - let me know if there is any that could be relevant!
