### PR TITLE
DT-976 Case insensitive GUID lookup by email

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_ci }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_key_ci }}
       AWS_REGION: "eu-west-1"
-      VERSION: "11.0"
+      VERSION: "11.1"
       REPOSITORY: "delta-auth-service"
       ECR_PATH: "468442790030.dkr.ecr.eu-west-1.amazonaws.com"
     outputs:

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSSOLoginController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSSOLoginController.kt
@@ -79,7 +79,7 @@ class DeltaSSOLoginController(
 
         logger.info("OAuth callback successfully authenticated user with email {}, checking in on-prem AD", email)
 
-        var userGUID = userGUIDMapService.userGUIDIfExists(email)
+        var userGUID = userGUIDMapService.userGUIDFromEmailIfExists(email)
         if (userGUID == null) {
             if (!ssoClient.required) {
                 logger.info("User {} not found in AD, and SSO is not required, so redirecting to register page", email)
@@ -100,7 +100,7 @@ class DeltaSSOLoginController(
                 logger.error("Error creating SSO User, result was {}", registrationResult.toString())
                 throw Exception("Error creating SSO User")
             }
-            userGUID = userGUIDMapService.userGUIDIfExists(email)!!
+            userGUID = userGUIDMapService.userGUIDFromEmailIfExists(email)!!
         }
 
         val user = ldapLookupService.lookupUserByGUID(userGUID)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminEditUserEmailController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminEditUserEmailController.kt
@@ -36,7 +36,7 @@ class AdminEditUserEmailController(
         val requestedEmail = requestData.newEmail
 
         // TODO DT-1022 - get GUID from request directly
-        val userToEditGUID = userGUIDMapService.getGUID(requestData.userToEditCn)
+        val userToEditGUID = userGUIDMapService.getGUIDFromCN(requestData.userToEditCn)
         val userToEdit = userLookupService.lookupUserByGUID(userToEditGUID)
 
         validateEmail(requestedEmail)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminEditUserNotificationStatusController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminEditUserNotificationStatusController.kt
@@ -30,7 +30,7 @@ class AdminEditUserNotificationStatusController(
 
         val requestData = call.receive<DeltaChangeNotificationStatusRequest>()
 
-        val userToEditGUID = userGUIDMapService.getGUID(requestData.userToEditCn)
+        val userToEditGUID = userGUIDMapService.getGUIDFromCN(requestData.userToEditCn)
         val userToEdit = userLookupService.lookupUserByGUID(userToEditGUID)
         logger.atInfo().log(
             "Updating notification status for user {} to {}",

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminResetMfaTokenController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminResetMfaTokenController.kt
@@ -30,7 +30,7 @@ class AdminResetMfaTokenController (
 
         val requestData = call.receive<DeltaResetMfaTokenRequest>()
 
-        val userToEditGUID = userGUIDMapService.getGUID(requestData.userToEditCn) // TODO DT-1022 - get GUID directly
+        val userToEditGUID = userGUIDMapService.getGUIDFromCN(requestData.userToEditCn) // TODO DT-1022 - get GUID directly
         val userToEdit = userLookupService.lookupUserByGUID(userToEditGUID)
         logger.atInfo().log("Resetting MFA token for user {}", userToEdit.getGUID())
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminUserCreationController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminUserCreationController.kt
@@ -48,7 +48,7 @@ class AdminUserCreationController(
             ssoClient,
         )
 
-        when (userGUIDMapService.userGUIDIfExists(adUser.mail)) {
+        when (userGUIDMapService.userGUIDFromEmailIfExists(adUser.mail)) {
             is UUID -> {
                 logger.atWarn().addKeyValue("email", adUser.mail).addKeyValue("UserDN", adUser.dn)
                     .log("User being made by admin already exists")

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/EditAccessGroupsController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/EditAccessGroupsController.kt
@@ -35,7 +35,7 @@ class EditAccessGroupsController(
 
         val addGroupRequest = call.receive<DeltaUserSingleAccessGroupOrganisationsRequest>()
         // TODO DT-1022 - get GUID directly from call
-        val targetUserGUID = userGUIDMapService.getGUID(addGroupRequest.userToEditCn)
+        val targetUserGUID = userGUIDMapService.getGUIDFromCN(addGroupRequest.userToEditCn)
         val (targetUser, targetUserRoles) = userLookupService.lookupUserByGUIDAndLoadRoles(targetUserGUID)
 
         val targetGroupName = addGroupRequest.accessGroupName
@@ -90,7 +90,7 @@ class EditAccessGroupsController(
 
         val removeGroupRequest = call.receive<DeltaUserSingleAccessGroupRequest>()
         // TODO DT-1022 - get GUID directly from call
-        val targetUserGUID = userGUIDMapService.getGUID(removeGroupRequest.userToEditCn)
+        val targetUserGUID = userGUIDMapService.getGUIDFromCN(removeGroupRequest.userToEditCn)
         val targetUser = userLookupService.lookupUserByGUID(targetUserGUID)
 
         val targetGroupName = removeGroupRequest.accessGroupName

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/RefreshUserInfoController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/RefreshUserInfoController.kt
@@ -78,7 +78,7 @@ class RefreshUserInfoController(
                 "User CN and GUID both not present on impersonating_user",
                 "Something went wrong, please try again"
             )
-            impersonatedUserGUID = userGUIDMapService.getGUID(impersonatedUsersCn)
+            impersonatedUserGUID = userGUIDMapService.getGUIDFromCN(impersonatedUsersCn)
         } else {
             if (!Strings.isNullOrEmpty(impersonatedUsersCn)) throw UserVisibleServerError(
                 "impersonating_user_both_user_cn_and_guid",

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/UserGUIDMapRepo.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/UserGUIDMapRepo.kt
@@ -17,7 +17,16 @@ class UserGUIDMapRepo {
     }
 
     @Blocking
-    fun getGUIDForUser(conn: Connection, userCN: String): UUID {
+    fun getGUIDForUserCNCaseInsensitive(conn: Connection, userCN: String): UUID {
+        val stmt = conn.prepareStatement("SELECT user_guid FROM user_guid_map WHERE lowercase_user_cn = ?")
+        stmt.setObject(1, userCN.lowercase())
+        val result = stmt.executeQuery()
+        if (!result.next()) throw NoUserException("No user found with lowercased userCN $userCN")
+        else return result.getObject("user_guid", UUID::class.java)
+    }
+
+    @Blocking
+    fun getGUIDForUserCNCaseSensitive(conn: Connection, userCN: String): UUID {
         val stmt = conn.prepareStatement("SELECT user_guid FROM user_guid_map WHERE user_cn = ?")
         stmt.setObject(1, userCN)
         val result = stmt.executeQuery()

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/RegistrationService.kt
@@ -42,7 +42,7 @@ class RegistrationService(
     ): RegistrationResult {
         val adUser = UserService.ADUser(ldapConfig, registration, ssoClient)
 
-        when (val userGUID = userGUIDMapService.userGUIDIfExists(adUser.mail)) {
+        when (val userGUID = userGUIDMapService.userGUIDFromEmailIfExists(adUser.mail)) {
             is UUID -> {
                 logger.atWarn().addKeyValue("UserDN", adUser.dn).log("User tried to register but user already exists")
                 val user = userLookupService.lookupUserByGUID(userGUID)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/utils/Parameters.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/utils/Parameters.kt
@@ -46,7 +46,7 @@ suspend fun getUserGUIDFromCallParameters(
             userVisibleErrorMessage
         )
         validateCN(userCN)
-        userGUIDMapService.getGUID(userCN)
+        userGUIDMapService.getGUIDFromCN(userCN)
     } else {
         if (!Strings.isNullOrEmpty(userCN)) throw UserVisibleServerError(
             action + "_both_user_cn_and_guid",

--- a/auth-service/src/main/resources/db/migration/V11__lowercase_cn.sql
+++ b/auth-service/src/main/resources/db/migration/V11__lowercase_cn.sql
@@ -1,0 +1,4 @@
+ALTER TABLE user_guid_map
+    ADD COLUMN lowercase_user_cn text NOT NULL GENERATED ALWAYS AS (LOWER(user_cn)) STORED;
+
+CREATE UNIQUE INDEX user_guid_map_lowercase_cn ON user_guid_map (lowercase_user_cn);

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEditUserControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEditUserControllerTest.kt
@@ -275,9 +275,9 @@ class AdminEditUserControllerTest {
             runBlocking { organisationService.findAllNamesAndCodes() },
             runBlocking { accessGroupsService.getAllAccessGroups() }
         )
-        coEvery { userGUIDMapService.getGUID(any()) } throws NoUserException("Test exception")
-        coEvery { userGUIDMapService.getGUID(user.cn) } returns user.getGUID()
-        coEvery { userGUIDMapService.getGUID(unchangedUser.cn) } returns unchangedUser.getGUID()
+        coEvery { userGUIDMapService.getGUIDFromCN(any()) } throws NoUserException("Test exception")
+        coEvery { userGUIDMapService.getGUIDFromCN(user.cn) } returns user.getGUID()
+        coEvery { userGUIDMapService.getGUIDFromCN(unchangedUser.cn) } returns unchangedUser.getGUID()
         coEvery { userService.updateUser(user, capture(modifications), adminSession, any()) } just runs
         coEvery { groupService.addUserToGroup(user, any(), any(), adminSession) } just runs
         coEvery { groupService.removeUserFromGroup(user, any(), any(), adminSession) } just runs

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEditUserEmailControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEditUserEmailControllerTest.kt
@@ -105,7 +105,7 @@ class AdminEditUserEmailControllerTest {
                 client
             )
         } answers { nonAdminSession }
-        coEvery { userGUIDMapService.getGUID(userToUpdate.cn) } returns userToUpdate.getGUID()
+        coEvery { userGUIDMapService.getGUIDFromCN(userToUpdate.cn) } returns userToUpdate.getGUID()
         coEvery { userLookupService.lookupUserByGUID(userToUpdate.getGUID()) } returns userToUpdate
         coEvery { userLookupService.lookupCurrentUser(adminSession) } returns adminUser
         coEvery { userLookupService.lookupCurrentUser(nonAdminSession) } returns nonAdminUser

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEditUserNotificationStatusControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEditUserNotificationStatusControllerTest.kt
@@ -117,7 +117,7 @@ class AdminEditUserNotificationStatusControllerTest {
             ), organisations = listOf(), accessGroups = listOf()
         )
         coEvery { userService.updateNotificationStatus(userToUpdate, any(), any(), any()) } just runs
-        coEvery { userGUIDMapService.getGUID(userToUpdate.cn) } returns userToUpdate.getGUID()
+        coEvery { userGUIDMapService.getGUIDFromCN(userToUpdate.cn) } returns userToUpdate.getGUID()
     }
 
     companion object {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEnableDisableUserControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEnableDisableUserControllerTest.kt
@@ -34,7 +34,7 @@ class AdminEnableDisableUserControllerTest {
     @Test
     fun testEnableUser() = testSuspend {
         val user = testLdapUser(cn = "user!example.com", accountEnabled = false)
-        coEvery { userGUIDMapService.getGUID(user.cn) } returns user.getGUID()
+        coEvery { userGUIDMapService.getGUIDFromCN(user.cn) } returns user.getGUID()
         coEvery { userLookupService.lookupUserByGUID(user.getGUID()) } returns user
 
         enableRequestAsAdminUser(user).apply {
@@ -50,7 +50,7 @@ class AdminEnableDisableUserControllerTest {
     @Test
     fun testUserAlreadyEnabled() = testSuspend {
         val user = testLdapUser(cn = "user!example.com", accountEnabled = true)
-        coEvery { userGUIDMapService.getGUID(user.cn) } returns user.getGUID()
+        coEvery { userGUIDMapService.getGUIDFromCN(user.cn) } returns user.getGUID()
         coEvery { userLookupService.lookupUserByGUID(user.getGUID()) } returns user
 
         enableRequestAsAdminUser(user).apply {
@@ -62,7 +62,7 @@ class AdminEnableDisableUserControllerTest {
     @Test
     fun testUserNoPassword() {
         val user = testLdapUser(cn = "user!example.com", passwordLastSet = null, accountEnabled = false)
-        coEvery { userGUIDMapService.getGUID(user.cn) } returns user.getGUID()
+        coEvery { userGUIDMapService.getGUIDFromCN(user.cn) } returns user.getGUID()
         coEvery { userLookupService.lookupUserByGUID(user.getGUID()) } returns user
 
         Assert.assertThrows(ApiError::class.java) {
@@ -83,7 +83,7 @@ class AdminEnableDisableUserControllerTest {
             passwordLastSet = null,
             accountEnabled = false
         )
-        coEvery { userGUIDMapService.getGUID(user.cn) } returns user.getGUID()
+        coEvery { userGUIDMapService.getGUIDFromCN(user.cn) } returns user.getGUID()
         coEvery { userLookupService.lookupUserByGUID(user.getGUID()) } returns user
 
         enableRequestAsAdminUser(user).apply {
@@ -118,7 +118,7 @@ class AdminEnableDisableUserControllerTest {
     @Test
     fun testDisableUser() = testSuspend {
         val user = testLdapUser(cn = "user!example.com")
-        coEvery { userGUIDMapService.getGUID(user.cn) } returns user.getGUID()
+        coEvery { userGUIDMapService.getGUIDFromCN(user.cn) } returns user.getGUID()
         coEvery { userLookupService.lookupUserByGUID(user.getGUID()) } returns user
         coEvery { setPasswordTokenService.clearTokenForUserGUID(user.getGUID()) } just runs
 
@@ -140,7 +140,7 @@ class AdminEnableDisableUserControllerTest {
     @Test
     fun testUserAlreadyDisabled() = testSuspend {
         val user = testLdapUser(cn = "user!example.com", accountEnabled = false)
-        coEvery { userGUIDMapService.getGUID(user.cn) } returns user.getGUID()
+        coEvery { userGUIDMapService.getGUIDFromCN(user.cn) } returns user.getGUID()
         coEvery { userLookupService.lookupUserByGUID(user.getGUID()) } returns user
         disableRequestAsAdminUser(user).apply {
             assertEquals(HttpStatusCode.OK, status)

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminGetUserControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminGetUserControllerTest.kt
@@ -122,8 +122,8 @@ class AdminGetUserControllerTest {
             ),
             organisations, accessGroups
         )
-        coEvery { userGUIDMapService.getGUID(any()) } throws NoUserException("Test exception")
-        coEvery { userGUIDMapService.getGUID(user.cn) } returns user.getGUID()
+        coEvery { userGUIDMapService.getGUIDFromCN(any()) } throws NoUserException("Test exception")
+        coEvery { userGUIDMapService.getGUIDFromCN(user.cn) } returns user.getGUID()
     }
 
     companion object {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminResetMfaTokenControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminResetMfaTokenControllerTest.kt
@@ -89,7 +89,7 @@ class AdminResetMfaTokenControllerTest {
             ), listOf(), listOf()
         )
         coEvery { userService.resetMfaToken(userToUpdate, any(), any()) } just runs
-        coEvery { userGUIDMapService.getGUID(userToUpdate.cn) } returns userToUpdate.getGUID()
+        coEvery { userGUIDMapService.getGUIDFromCN(userToUpdate.cn) } returns userToUpdate.getGUID()
     }
 
     companion object {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminUserCreationControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminUserCreationControllerTest.kt
@@ -292,12 +292,12 @@ class AdminUserCreationControllerTest {
         coEvery { oauthSessionService.retrieveFromAuthToken(userSession.authToken, client) } answers { userSession }
         coEvery { userLookupService.lookupCurrentUser(adminSession) } returns adminUser
         coEvery { userLookupService.lookupCurrentUser(userSession) } returns regularUser
-        coEvery { userGUIDMapService.userGUIDIfExists(NEW_STANDARD_USER_EMAIL) } returns null
-        coEvery { userGUIDMapService.userGUIDIfExists(NEW_INVALID_USER_EMAIL) } returns null
-        coEvery { userGUIDMapService.userGUIDIfExists(NEW_SSO_USER_EMAIL) } returns null
-        coEvery { userGUIDMapService.userGUIDIfExists(NEW_NOT_REQUIRED_SSO_USER) } returns null
+        coEvery { userGUIDMapService.userGUIDFromEmailIfExists(NEW_STANDARD_USER_EMAIL) } returns null
+        coEvery { userGUIDMapService.userGUIDFromEmailIfExists(NEW_INVALID_USER_EMAIL) } returns null
+        coEvery { userGUIDMapService.userGUIDFromEmailIfExists(NEW_SSO_USER_EMAIL) } returns null
+        coEvery { userGUIDMapService.userGUIDFromEmailIfExists(NEW_NOT_REQUIRED_SSO_USER) } returns null
         coEvery {
-            userGUIDMapService.userGUIDIfExists(OLD_STANDARD_USER_EMAIL)
+            userGUIDMapService.userGUIDFromEmailIfExists(OLD_STANDARD_USER_EMAIL)
         } returns getLdapUserWithDetails(OLD_STANDARD_USER_EMAIL).getGUID()
         coEvery { groupService.addUserToGroup(any(), any(), any(), any()) } just runs
         coEvery { emailService.sendSetPasswordEmail(any(), any(), any(), any()) } just runs

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaResetPasswordControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaResetPasswordControllerTest.kt
@@ -219,7 +219,7 @@ class DeltaResetPasswordControllerTest {
         coEvery { resetPasswordTokenService.createToken(user.getGUID()) } returns "token"
         coEvery { userService.resetPassword(user.getGUID(), validPassword) } just runs
         coEvery { emailService.sendResetPasswordEmail(any(), any(), null, any()) } just runs
-        coEvery { userGUIDMapService.getGUID(user.cn) } returns user.getGUID()
+        coEvery { userGUIDMapService.getGUIDFromCN(user.cn) } returns user.getGUID()
         coEvery { userLookupService.lookupUserByGUID(user.getGUID()) } returns user
     }
 

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaSetPasswordControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaSetPasswordControllerTest.kt
@@ -216,7 +216,7 @@ class DeltaSetPasswordControllerTest {
         coEvery { setPasswordTokenService.createToken(user.getGUID()) } returns "token"
         coEvery { userService.setPasswordAndEnable(user.dn, validPassword) } just runs
         coEvery { emailService.sendNotYetEnabledEmail(any(), any(), any()) } just runs
-        coEvery { userGUIDMapService.getGUID(user.cn) } returns user.getGUID()
+        coEvery { userGUIDMapService.getGUIDFromCN(user.cn) } returns user.getGUID()
         coEvery { userLookupService.lookupUserByGUID(user.getGUID()) } returns user
     }
 

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaUserRegistrationControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaUserRegistrationControllerTest.kt
@@ -52,7 +52,7 @@ class DeltaUserRegistrationControllerTest {
     @Test
     fun testRegistrationForNewStandardUser() = testSuspend {
         val user = testLdapUser(email = emailStart + standardDomain, cn = cnStart + standardDomain)
-        coEvery { userGUIDMapService.userGUIDIfExists(user.email!!) } returns null
+        coEvery { userGUIDMapService.userGUIDFromEmailIfExists(user.email!!) } returns null
         coEvery { userService.createUser(any(), any(), any(), any()) } returns user
         testClient.submitForm(
             url = "/register",
@@ -116,7 +116,7 @@ class DeltaUserRegistrationControllerTest {
     @Test
     fun testRegistrationForAlreadyExistingStandardUser() = testSuspend {
         val user = testLdapUser(email = emailStart + standardDomain)
-        coEvery { userGUIDMapService.userGUIDIfExists(user.email!!) } returns user.getGUID()
+        coEvery { userGUIDMapService.userGUIDFromEmailIfExists(user.email!!) } returns user.getGUID()
         coEvery { userLookupService.lookupUserByGUID(user.getGUID()) } returns user
         testClient.submitForm(
             url = "/register",
@@ -150,7 +150,7 @@ class DeltaUserRegistrationControllerTest {
 
     @Test
     fun testRegistrationOfNewNotRequiredSSOUser() = testSuspend {
-        coEvery { userGUIDMapService.userGUIDIfExists(emailStart + notRequiredDomain) } returns null
+        coEvery { userGUIDMapService.userGUIDFromEmailIfExists(emailStart + notRequiredDomain) } returns null
         val user = testLdapUser(email = emailStart + notRequiredDomain, cn = cnStart + notRequiredDomain)
         coEvery { userService.createUser(any(), any(), any(), any()) } returns user
         testClient.submitForm(
@@ -171,7 +171,7 @@ class DeltaUserRegistrationControllerTest {
     @Test
     fun testRegistrationOfExistingNotRequiredSSOUser() = testSuspend {
         val user = testLdapUser(email = emailStart + notRequiredDomain, cn = cnStart + notRequiredDomain)
-        coEvery { userGUIDMapService.userGUIDIfExists(user.email!!) } returns user.getGUID()
+        coEvery { userGUIDMapService.userGUIDFromEmailIfExists(user.email!!) } returns user.getGUID()
         coEvery { userLookupService.lookupUserByGUID(user.getGUID()) } returns user
         testClient.submitForm(
             url = "/register",

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/EditAccessGroupsControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/EditAccessGroupsControllerTest.kt
@@ -462,8 +462,8 @@ class EditAccessGroupsControllerTest {
                 client
             )
         } answers { internalUserSession }
-        coEvery { userGUIDMapService.getGUID(externalUser.cn) } returns externalUser.getGUID()
-        coEvery { userGUIDMapService.getGUID(internalUser.cn) } returns internalUser.getGUID()
+        coEvery { userGUIDMapService.getGUIDFromCN(externalUser.cn) } returns externalUser.getGUID()
+        coEvery { userGUIDMapService.getGUIDFromCN(internalUser.cn) } returns internalUser.getGUID()
         coEvery { organisationService.findAllNamesAndCodes() } returns listOf(
             OrganisationNameAndCode("orgCode1", "Organisation Name 1"),
             OrganisationNameAndCode("orgCode2", "Organisation Name 2"),

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/FetchUserAuditControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/FetchUserAuditControllerTest.kt
@@ -254,8 +254,8 @@ class FetchUserAuditControllerTest {
                 50
             )
             coEvery { userAuditService.getAuditForAllUsers(any(), any()) } returns listOf(userAudit, adminAudit)
-            coEvery { userGUIDMapService.getGUID(adminUser.cn) } returns adminUser.getGUID()
-            coEvery { userGUIDMapService.getGUID(regularUser.cn) } returns regularUser.getGUID()
+            coEvery { userGUIDMapService.getGUIDFromCN(adminUser.cn) } returns adminUser.getGUID()
+            coEvery { userGUIDMapService.getGUIDFromCN(regularUser.cn) } returns regularUser.getGUID()
 
             controller = FetchUserAuditController(
                 userLookupService,

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/RefreshUserInfoControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/RefreshUserInfoControllerTest.kt
@@ -136,7 +136,7 @@ class RefreshUserInfoControllerTest {
 
             coEvery { userLookupService.lookupCurrentUser(session) } answers { user }
             coEvery { userLookupService.lookupCurrentUser(adminSession) } answers { adminUser }
-            coEvery { userGUIDMapService.getGUID(userToImpersonate.cn) } returns userToImpersonate.getGUID()
+            coEvery { userGUIDMapService.getGUIDFromCN(userToImpersonate.cn) } returns userToImpersonate.getGUID()
             coEvery { userLookupService.lookupUserByGUID(userToImpersonate.getGUID()) } returns userToImpersonate
             every {
                 samlTokenService.generate(

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditServiceTest.kt
@@ -27,7 +27,7 @@ class UserAuditServiceTest {
         testDbPool.useConnectionBlocking("add_test_user_to_guid_map") {
             userGUIDMapRepo.newUser(it, testLdapUser(cn = userCN, javaUUIDObjectGuid = userGUID.toString()))
             it.commit()
-            assertEquals(userGUID, userGUIDMapRepo.getGUIDForUser(it, userCN))
+            assertEquals(userGUID, userGUIDMapRepo.getGUIDForUserCNCaseSensitive(it, userCN))
         }
         assertEquals(0, service.getAuditForUser(userGUID).size)
 
@@ -48,7 +48,7 @@ class UserAuditServiceTest {
         testDbPool.useConnectionBlocking("add_test_user_to_guid_map") {
             userGUIDMapRepo.newUser(it, testLdapUser(cn = userCN, javaUUIDObjectGuid = userGUID.toString()))
             it.commit()
-            assertEquals(userGUID, userGUIDMapRepo.getGUIDForUser(it, userCN))
+            assertEquals(userGUID, userGUIDMapRepo.getGUIDForUserCNCaseSensitive(it, userCN))
         }
         service.userSSOLoginAudit(
             userGUID,

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthSSOLoginTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/OAuthSSOLoginTest.kt
@@ -141,7 +141,7 @@ class OAuthSSOLoginTest {
 
     @Test
     fun `Callback redirects to register page if no ldap user for non-required SSO client`() = testSuspend {
-        coEvery { userGUIDMapService.userGUIDIfExists(testUser.email!!) } returns null andThen testUser.getGUID()
+        coEvery { userGUIDMapService.userGUIDFromEmailIfExists(testUser.email!!) } returns null andThen testUser.getGUID()
         val organisations = listOf(Organisation("E1234", "Test Organisation"))
         coEvery { organisationService.findAllByDomain("example.com") } returns organisations
         coEvery {
@@ -161,7 +161,7 @@ class OAuthSSOLoginTest {
     fun `Callback calls register function if no ldap user for required SSO client`() = testSuspend {
         val requiredSsoClient = ssoClient.copy(required = true)
         every { ssoConfig.ssoClients } answers { listOf(requiredSsoClient) }
-        coEvery { userGUIDMapService.userGUIDIfExists(testUser.email!!) } returns null andThen testUser.getGUID()
+        coEvery { userGUIDMapService.userGUIDFromEmailIfExists(testUser.email!!) } returns null andThen testUser.getGUID()
         val organisations = listOf(Organisation("E1234", "Test Organisation"))
         coEvery { organisationService.findAllByDomain("example.com") } returns organisations
         coEvery {
@@ -186,7 +186,7 @@ class OAuthSSOLoginTest {
             memberOfCNs = listOf(DeltaConfig.DATAMART_DELTA_USER),
             accountEnabled = false
         )
-        coEvery { userGUIDMapService.userGUIDIfExists(disabledUser.email!!) } returns disabledUser.getGUID()
+        coEvery { userGUIDMapService.userGUIDFromEmailIfExists(disabledUser.email!!) } returns disabledUser.getGUID()
         coEvery { ldapUserLookupServiceMock.lookupUserByGUID(disabledUser.getGUID()) } returns disabledUser
         Assert.assertThrows(DeltaSSOLoginController.OAuthLoginException::class.java) {
             runBlocking { testClient(loginState.cookie).get("/delta/oauth/test/callback?code=auth-code&state=${loginState.state}") }
@@ -198,7 +198,7 @@ class OAuthSSOLoginTest {
     @Test
     fun `Callback returns error if user has no email`() {
         val noEmailUser = testLdapUser(memberOfCNs = listOf(DeltaConfig.DATAMART_DELTA_USER), email = null)
-        coEvery { userGUIDMapService.userGUIDIfExists(tokenEmail) } returns noEmailUser.getGUID()
+        coEvery { userGUIDMapService.userGUIDFromEmailIfExists(tokenEmail) } returns noEmailUser.getGUID()
         coEvery { ldapUserLookupServiceMock.lookupUserByGUID(noEmailUser.getGUID()) } returns noEmailUser
         Assert.assertThrows(DeltaSSOLoginController.OAuthLoginException::class.java) {
             runBlocking { testClient(loginState.cookie).get("/delta/oauth/test/callback?code=auth-code&state=${loginState.state}") }
@@ -210,7 +210,7 @@ class OAuthSSOLoginTest {
     @Test
     fun `Callback returns error if user is not in Delta users group`() {
         val userNotInUserGroup = testLdapUser(memberOfCNs = listOf("some-other-group"))
-        coEvery { userGUIDMapService.userGUIDIfExists(tokenEmail) } returns userNotInUserGroup.getGUID()
+        coEvery { userGUIDMapService.userGUIDFromEmailIfExists(tokenEmail) } returns userNotInUserGroup.getGUID()
         coEvery { ldapUserLookupServiceMock.lookupUserByGUID(userNotInUserGroup.getGUID()) } returns userNotInUserGroup
         Assert.assertThrows(DeltaSSOLoginController.OAuthLoginException::class.java) {
             runBlocking { testClient(loginState.cookie).get("/delta/oauth/test/callback?code=auth-code&state=${loginState.state}") }
@@ -245,7 +245,7 @@ class OAuthSSOLoginTest {
                 email = tokenEmail,
                 memberOfCNs = listOf(DeltaConfig.DATAMART_DELTA_USER, DeltaConfig.DATAMART_DELTA_ADMIN)
             )
-        coEvery { userGUIDMapService.userGUIDIfExists(adminUser.email!!) } returns adminUser.getGUID()
+        coEvery { userGUIDMapService.userGUIDFromEmailIfExists(adminUser.email!!) } returns adminUser.getGUID()
         coEvery { ldapUserLookupServiceMock.lookupUserByGUID(adminUser.getGUID()) } returns adminUser
         coEvery {
             authorizationCodeServiceMock.generateAndStore(adminUser.getGUID(), serviceClient, any(), true)
@@ -320,8 +320,8 @@ class OAuthSSOLoginTest {
     @Before
     fun setupMocks() {
         clearAllMocks()
-        coEvery { userGUIDMapService.userGUIDIfExists(testUser.email!!) } returns testUser.getGUID()
-        coEvery { userGUIDMapService.userGUIDIfExists(domainUser.email!!) } returns domainUser.getGUID()
+        coEvery { userGUIDMapService.userGUIDFromEmailIfExists(testUser.email!!) } returns testUser.getGUID()
+        coEvery { userGUIDMapService.userGUIDFromEmailIfExists(domainUser.email!!) } returns domainUser.getGUID()
         coEvery { ldapUserLookupServiceMock.lookupUserByGUID(testUser.getGUID()) } returns testUser
         coEvery { ldapUserLookupServiceMock.lookupUserByGUID(domainUser.getGUID()) } returns domainUser
         coEvery {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/RegistrationServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/RegistrationServiceTest.kt
@@ -42,7 +42,7 @@ class RegistrationServiceTest {
 
     @Before
     fun setup() {
-        coEvery { userGUIDMapService.userGUIDIfExists(any()) } returns null
+        coEvery { userGUIDMapService.userGUIDFromEmailIfExists(any()) } returns null
         coEvery { groupService.addUserToGroup(any(), any(), any(), null) } just runs
         coEvery { userService.createUser(any(), any(), any(), any(), any()) } returns testLdapUser()
         coEvery { setPasswordTokenService.createToken(any()) } returns "token"
@@ -132,7 +132,7 @@ class RegistrationServiceTest {
 
     @Test
     fun testRegisteringExistingStandardUser() = testSuspend {
-        coEvery { userGUIDMapService.userGUIDIfExists(user.email!!) } returns user.getGUID()
+        coEvery { userGUIDMapService.userGUIDFromEmailIfExists(user.email!!) } returns user.getGUID()
         coEvery { userLookupService.lookupUserByGUID(user.getGUID()) } returns user
         val registrationResult = registrationService.register(
             Registration(user.firstName, user.lastName, user.email!!),


### PR DESCRIPTION
**Description** The current lookup is case-sensitive, which is fine for the internal API, but for SSO login and creating users means they don't match. This doesn't actually cause any issues since it always falls back to looking up in AD, but it means some extra calls and log noise.

I've added a generated column because that seems simplest to understand, but an index on `user_guid_map (LOWER(user_cn))` would presumably work just as well and use less space.

**Local testing** I've tried logging in normally and through SSO, but haven't actually tried one with a different case to reproduce it.

**Release** Auth service only, includes migration
