### PR TITLE
DT-753: Replace GitHub Actions access keys with OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_ci }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_key_ci }}
       AWS_REGION: "eu-west-1"
-      VERSION: "11.2"
+      VERSION: "12.0"
       REPOSITORY: "delta-auth-service"
       ECR_PATH: "468442790030.dkr.ecr.eu-west-1.amazonaws.com"
     outputs:

--- a/terraform/production/ci_iam.tf
+++ b/terraform/production/ci_iam.tf
@@ -2,7 +2,7 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 resource "aws_iam_role" "github_actions_delta_auth_ci" {
-  name = "github-actions-delta-auth-ci"
+  name               = "github-actions-delta-auth-ci"
   assume_role_policy = data.aws_iam_policy_document.github_actions_delta_auth_assume_role.json
 }
 
@@ -26,8 +26,8 @@ data "aws_iam_policy_document" "github_actions_delta_auth_assume_role" {
     }
 
     condition {
-      test     = "StringLike"
-      values   = [
+      test = "StringLike"
+      values = [
         "repo:communitiesuk/delta-auth-service:*"
       ]
       variable = "token.actions.githubusercontent.com:sub"

--- a/terraform/production/ci_iam.tf
+++ b/terraform/production/ci_iam.tf
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "github_actions_delta_auth_assume_role" {
     }
 
     condition {
-      test = "StringLike"
+      test = "StringEquals"
       values = [
         "repo:communitiesuk/delta-auth-service:environment:publish"
       ]

--- a/terraform/production/ci_iam.tf
+++ b/terraform/production/ci_iam.tf
@@ -1,6 +1,10 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
+locals {
+  ecr_repo = "${data.aws_caller_identity.current.account_id}.dkr.ecr.eu-west-1.amazonaws.com/delta-auth-service"
+}
+
 resource "aws_iam_role" "github_actions_delta_auth_ci" {
   name               = "github-actions-delta-auth-ci"
   assume_role_policy = data.aws_iam_policy_document.github_actions_delta_auth_assume_role.json
@@ -28,7 +32,7 @@ data "aws_iam_policy_document" "github_actions_delta_auth_assume_role" {
     condition {
       test = "StringLike"
       values = [
-        "repo:communitiesuk/delta-auth-service:*"
+        "repo:communitiesuk/delta-auth-service:environment:publish"
       ]
       variable = "token.actions.githubusercontent.com:sub"
     }
@@ -50,7 +54,7 @@ data "aws_iam_policy_document" "ecr_push_access" {
     ]
 
     resources = [
-      "${data.aws_caller_identity.current.account_id}.dkr.ecr.eu-west-1.amazonaws.com/delta-auth-service"
+      local.ecr_repo
     ]
   }
 

--- a/terraform/production/ci_iam.tf
+++ b/terraform/production/ci_iam.tf
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "ecr_push_access" {
     ]
 
     resources = [
-      "468442790030.dkr.ecr.eu-west-1.amazonaws.com/delta-auth-service"
+      "${data.aws_caller_identity.current.account_id}.dkr.ecr.eu-west-1.amazonaws.com/delta-auth-service"
     ]
   }
 

--- a/terraform/production/ci_iam.tf
+++ b/terraform/production/ci_iam.tf
@@ -1,0 +1,78 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_iam_role" "github_actions_delta_auth_ci" {
+  name = "github-actions-delta-auth-ci"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_delta_auth_assume_role.json
+}
+
+data "aws_iam_openid_connect_provider" "github" {
+  arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com"
+}
+
+data "aws_iam_policy_document" "github_actions_delta_auth_assume_role" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [data.aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      values   = ["sts.amazonaws.com"]
+      variable = "token.actions.githubusercontent.com:aud"
+    }
+
+    condition {
+      test     = "StringLike"
+      values   = [
+        "repo:communitiesuk/delta-auth-service:*"
+      ]
+      variable = "token.actions.githubusercontent.com:sub"
+    }
+  }
+}
+
+data "aws_iam_policy_document" "ecr_push_access" {
+  statement {
+    sid    = "1"
+    effect = "Allow"
+
+    actions = [
+      "ecr:CompleteLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:DescribeImages",
+      "ecr:InitiateLayerUpload",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:PutImage"
+    ]
+
+    resources = [
+      "468442790030.dkr.ecr.eu-west-1.amazonaws.com/delta-auth-service"
+    ]
+  }
+
+  statement {
+    sid    = "2"
+    effect = "Allow"
+
+    actions = [
+      "ecr:GetAuthorizationToken"
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "github_actions_auth_service_ci_ecr_access" {
+  name        = "github-actions-auth-service-ci-ecr-access"
+  description = "Grant github-actions-auth-service-ci the ability to push to ECR"
+  policy      = data.aws_iam_policy_document.ecr_push_access.json
+}
+
+resource "aws_iam_role_policy_attachment" "github_actions_ecr_push_access" {
+  role       = aws_iam_role.github_actions_delta_auth_ci.name
+  policy_arn = aws_iam_policy.github_actions_auth_service_ci_ecr_access.arn
+}

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -41,7 +41,7 @@ module "auth_service" {
   source                         = "../modules/auth_service"
   subnet_ids                     = data.terraform_remote_state.common_infra.outputs.auth_service_private_subnet_ids
   environment                    = local.environment
-  container_image                = "468442790030.dkr.ecr.eu-west-1.amazonaws.com/delta-auth-service:${var.image_tag}"
+  container_image                = "${local.ecr_repo}:${var.image_tag}"
   vpc_id                         = data.terraform_remote_state.common_infra.outputs.vpc_id
   cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
   alarms_sns_topic_arn           = data.terraform_remote_state.common_infra.outputs.alarms_sns_topic_arn


### PR DESCRIPTION
This PR creates the roles and policies required to use OIDC instead of secrets/keys within GitHub Actions.