### PR TITLE
DT-732 Tracing follow ups

### DIFF
--- a/auth-service/build.gradle.kts
+++ b/auth-service/build.gradle.kts
@@ -91,6 +91,7 @@ dependencies {
     api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.4.0-alpha"))
     implementation("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-sdk")
+    implementation("io.opentelemetry:opentelemetry-extension-kotlin")
     implementation("io.opentelemetry:opentelemetry-exporter-otlp")
     testImplementation("io.opentelemetry:opentelemetry-exporter-logging")
     implementation("io.opentelemetry.instrumentation:opentelemetry-ktor-2.0")

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -5,6 +5,7 @@ import io.micrometer.cloudwatch2.CloudWatchMeterRegistry
 import io.micrometer.core.instrument.Clock
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.context.Context
 import org.slf4j.Logger
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
@@ -84,6 +85,7 @@ class Injection(
     private val ldapSpanFactory: SpanFactory = {
         ldapTracer.spanBuilder(it).setParent(Context.current())
             .setAttribute("peer.service", "ActiveDirectory")
+            .setSpanKind(SpanKind.CLIENT)
             .setAttribute("delta.request-to", "AD-ldap")
     }
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/Monitoring.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/Monitoring.kt
@@ -51,6 +51,10 @@ fun Application.configureMonitoring(meterRegistry: MeterRegistry, openTelemetry:
         filter { it.request.path() != "/health" }
         mdc("username") { it.principal<DeltaLdapPrincipal>(DELTA_AD_LDAP_SERVICE_USERS_AUTH_NAME)?.username }
         mdc("IPAddress") { it.request.origin.remoteAddress }
+        mdc("XRayTraceId") {
+            val context = Span.current().spanContext
+            if (context.isValid) context.traceId else null
+        }
         disableDefaultColors()
     }
     install(CallId) {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/saml/SAMLTokenService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/saml/SAMLTokenService.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.delta.auth.saml
 
+import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.Context
 import org.opensaml.core.config.InitializationService
@@ -35,6 +36,7 @@ class SAMLTokenService(private val tracer: Tracer) {
             val span = tracer.spanBuilder("generate-saml-token")
                 .setAttribute("saml-token-user-guid", user.javaUUIDObjectGuid!!)
                 .setParent(Context.current())
+                .setSpanKind(SpanKind.INTERNAL)
                 .startSpan()
             try {
                 generateInternal(credential, user, validFrom, validTo)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OrganisationService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/OrganisationService.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import uk.gov.communities.delta.auth.config.DeltaConfig
 import uk.gov.communities.delta.auth.utils.emailToDomain
 import uk.gov.communities.delta.auth.utils.timedSuspend
@@ -83,6 +84,7 @@ class OrganisationService(private val httpClient: HttpClient, private val deltaC
                         onStart {
                             attributes.put("peer.service", "MarkLogic")
                             attributes.put("delta.request-to", "marklogic-organisations")
+                            attributes.put("MDC-requestId", MDC.get("requestId"))
                         }
                     }
                 }

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/sso/MicrosoftGraphService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/sso/MicrosoftGraphService.kt
@@ -13,6 +13,7 @@ import io.opentelemetry.instrumentation.ktor.v2_0.client.KtorClientTracing
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import kotlin.time.Duration.Companion.seconds
 
 class MicrosoftGraphService(openTelemetry: OpenTelemetry) {
@@ -30,6 +31,7 @@ class MicrosoftGraphService(openTelemetry: OpenTelemetry) {
                 onStart {
                     attributes.put("peer.service", "Microsoft Graph")
                     attributes.put("delta.request-to", "microsoft-graph")
+                    attributes.put("MDC-requestId", MDC.get("requestId"))
                 }
             }
         }

--- a/terraform/modules/fargate/adot-config.yml
+++ b/terraform/modules/fargate/adot-config.yml
@@ -16,6 +16,7 @@ processors:
 exporters:
   awsxray:
     indexed_attributes: ["delta.username"]
+    aws_log_groups: ["${log_group}"]
 
 service:
   pipelines:

--- a/terraform/modules/fargate/ecs.tf
+++ b/terraform/modules/fargate/ecs.tf
@@ -91,7 +91,9 @@ resource "aws_ecs_task_definition" "main" {
       environment = [
         {
           name : "AOT_CONFIG_CONTENT"
-          value : file("${path.module}/adot-config.yml")
+          value : templatefile("${path.module}/adot-config.yml", {
+            log_group = aws_cloudwatch_log_group.ecs_logs.name
+          })
         }
       ]
       logConfiguration : {


### PR DESCRIPTION
**Description** We're getting traces through to X-Ray for test. They mostly look good though I've seen one or two which seem to include spans from other requests and I'm not sure why.

This should (in theory, I haven't tried it on test yet) link up the CloudWatch logs with X-Ray which should make it easier to jump between them and also give a way of investigating these odd traces

**Local testing** Ran locally, no real testing

**Release** Auth service release including terraform apply
