### PR TITLE
DT-1089 Activate notifications when enabled through set password

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSetPasswordController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSetPasswordController.kt
@@ -128,7 +128,7 @@ class DeltaSetPasswordController(
 
             is PasswordTokenService.ValidToken -> {
                 try {
-                    userService.setPasswordAndEnable(user.dn, newPassword)
+                    userService.setPasswordAndEnableAccountAndNotifications(user.dn, newPassword)
                 } catch (e: Exception) {
                     logger.atError().addKeyValue("UserDN", user.dn).log("Error setting password for user", e)
                     throw e

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminEnableDisableUserController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/AdminEnableDisableUserController.kt
@@ -43,7 +43,7 @@ class AdminEnableDisableUserController(
             if (user.isSSORequiredUser()) {
                 logger.atInfo().addKeyValue("targetUserGUID", user.getGUID())
                     .log("Setting random password and enabling SSO user")
-                userService.setPasswordAndEnable(user.dn, randomBase64(18))
+                userService.setPasswordAndEnableAccountAndNotifications(user.dn, randomBase64(18))
                 auditService.userEnableAudit(user.getGUID(), session.userGUID, call)
                 return call.respond(mapOf("message" to "User ${user.email} enabled"))
             } else {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserService.kt
@@ -249,13 +249,14 @@ class UserService(
         }
     }
 
-    suspend fun setPasswordAndEnable(userDN: String, password: String) {
+    suspend fun setPasswordAndEnableAccountAndNotifications(userDN: String, password: String) {
         val modificationItems = arrayOf(
             ModificationItem(DirContext.REPLACE_ATTRIBUTE, ADUser.getPasswordAttribute(password)),
             ModificationItem(
                 DirContext.REPLACE_ATTRIBUTE,
                 BasicAttribute("userAccountControl", ADUser.accountFlags(true))
-            )
+            ),
+            ModificationItem(DirContext.REPLACE_ATTRIBUTE, BasicAttribute("st", "active"))
         )
         ldapServiceUserBind.useServiceUserBind {
             it.modifyAttributes(userDN, modificationItems)

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEnableDisableUserControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/AdminEnableDisableUserControllerTest.kt
@@ -88,7 +88,7 @@ class AdminEnableDisableUserControllerTest {
 
         enableRequestAsAdminUser(user).apply {
             assertEquals(HttpStatusCode.OK, status)
-            coVerify(exactly = 1) { userService.setPasswordAndEnable(user.dn, any()) }
+            coVerify(exactly = 1) { userService.setPasswordAndEnableAccountAndNotifications(user.dn, any()) }
             coVerify(exactly = 1) { auditService.userEnableAudit(user.getGUID(), adminUser.getGUID(), any()) }
             confirmVerified(userService, auditService)
         }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaSetPasswordControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaSetPasswordControllerTest.kt
@@ -214,7 +214,7 @@ class DeltaSetPasswordControllerTest {
         } returns PasswordTokenService.NoSuchToken
         coEvery { setPasswordTokenService.consumeTokenIfValid("", any()) } returns PasswordTokenService.NoSuchToken
         coEvery { setPasswordTokenService.createToken(user.getGUID()) } returns "token"
-        coEvery { userService.setPasswordAndEnable(user.dn, validPassword) } just runs
+        coEvery { userService.setPasswordAndEnableAccountAndNotifications(user.dn, validPassword) } just runs
         coEvery { emailService.sendNotYetEnabledEmail(any(), any(), any()) } just runs
         coEvery { userGUIDMapService.getGUIDFromCN(user.cn) } returns user.getGUID()
         coEvery { userLookupService.lookupUserByGUID(user.getGUID()) } returns user

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/UserServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/UserServiceTest.kt
@@ -329,13 +329,16 @@ class UserServiceTest {
 
     @Test
     fun testSetUserPassword() = testSuspend {
-        userService.setPasswordAndEnable(user.dn, "TestPassword")
+        userService.setPasswordAndEnableAccountAndNotifications(user.dn, "TestPassword")
         verify(exactly = 1) { context.modifyAttributes(user.dn, any()) }
+        assertEquals(3, modificationItems.captured.size)
         // User has normal and enabled account
         assertEquals(DirContext.REPLACE_ATTRIBUTE, modificationItems.captured[1].modificationOp)
         assertEquals("512", modificationItems.captured[1].attribute.get())
         // User has a password set
         assert(modificationItems.captured[0].attribute.get() as ByteArray? != null)
+        // Notifications enabled
+        assertEquals("st", modificationItems.captured[2].attribute.id)
     }
 
     @Test


### PR DESCRIPTION
**Description** Activate notifications when a user is enabled through a set password email.

Also affects activating an SSO user that doesn't have their password set, this now matches the behaviour when a user does have a password - notifications are activated when the user is enabled.

**Local testing** Unit tests and tried with local delta

**Release** Auth service only, no extra steps
