### PR TITLE
DT-1084: User bulk upload access groups ignores comment field

### DIFF
--- a/auth-service/README.md
+++ b/auth-service/README.md
@@ -82,6 +82,15 @@ You can also run only the migrations without starting the app:
 ./gradlew migrate
 ```
 
+### User GUID Mapping
+
+If setting up for the first time, Delta may throw an error about not finding a corresponding user for a particular a GUID when attempting to log in. This can be resolved by manually adding the user_guid and user_cn to the postgres database within Auth Service. 
+
+```shell
+INSERT INTO user_guid_map (user_guid, user_cn) VALUES ("{guid}", "{username}")
+```
+
+
 ### Scheduled tasks
 
 You can run a task locally by setting the RUN_TASK environment variable and using the "runTask" gradle task, for example

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -379,6 +379,7 @@ class Injection(
     fun editAccessGroupsController() = EditAccessGroupsController(
         userLookupService,
         userGUIDMapService,
+        userService,
         groupService,
         organisationService,
         accessGroupsService,

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/DeltaUserDetailsRequest.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/DeltaUserDetailsRequest.kt
@@ -120,4 +120,6 @@ data class DeltaUserDetailsRequest(
     @SerialName("organisations") val organisations: List<String>,
     @SerialName("comment") val comment: String? = null,
     @SerialName("classificationType") val classificationType: String? = null, //Not used anywhere yet
+    @SerialName("userObjectGuid") val userObjectGuid: String? = null,
+    @SerialName("isAdmin") val isAdmin: String? = null,
 )


### PR DESCRIPTION
**Description** Fix for a bug on the bulk update user access groups where any comments added to the file are ignored on the update. This fix modifies the Auth Service endpoint to take in an additional optional comment parameter, which it then uses to check against existing comments and amend as necessary. 

The Readme file has also been updated to add some instructions for when setting up the Auth Service to run locally. 

**Local testing** Have tested multiple times locally using a CSV file and comments are updating correctly. The relevant endpoint within the Auth Service is also used by other services such as the payments approver/reviewer service. I have tested this also and this also works correctly. 

