### PR TITLE
DT-1070: fix for Auth service errors/warnings

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/monitoring/Monitoring.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/monitoring/Monitoring.kt
@@ -4,7 +4,6 @@ import io.ktor.server.application.*
 import io.ktor.server.metrics.micrometer.*
 import io.ktor.server.plugins.callid.*
 import io.micrometer.core.instrument.MeterRegistry
-import io.micrometer.core.instrument.config.MeterFilter
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.context.Context
@@ -26,14 +25,6 @@ fun Application.configureMonitoring(meterRegistry: MeterRegistry, openTelemetry:
     install(MicrometerMetrics) {
         registry = meterRegistry
         meterBinders = emptyList()
-        registry.config()
-            .meterFilter(MeterFilter.acceptNameStartsWith("login."))
-            .meterFilter(MeterFilter.acceptNameStartsWith("registration."))
-            .meterFilter(MeterFilter.acceptNameStartsWith("setPassword."))
-            .meterFilter(MeterFilter.acceptNameStartsWith("resetPassword."))
-            .meterFilter(MeterFilter.acceptNameStartsWith("forgotPassword."))
-            .meterFilter(MeterFilter.acceptNameStartsWith("tasks."))
-            .meterFilter(MeterFilter.deny()) // Currently don't want any other metrics
     }
     // Install this before KtorServerTracing so it runs first
     install(checkOpenTelemetrySpanContext)

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/EmailService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/EmailService.kt
@@ -189,22 +189,23 @@ class EmailService(
         recipients: List<EmailRecipient>,
         accessGroupDisplayName: String,
     ) {
-        sendTemplateEmail(
-            "user-added-to-dclg-in-access-group",
-            EmailContacts(recipients, emailConfig),
-            "Delta: MHCLG user has been added to collection group '$accessGroupDisplayName'",
-            mapOf(
-                "deltaUrl" to deltaConfig.deltaWebsiteUrl,
-                "userFullName" to userName,
-                "userEmailAddress" to userEmail,
-                "actingUserEmail" to actingUserEmail,
-                "accessGroupName" to accessGroupDisplayName
+        for (recipient in recipients) {
+            sendTemplateEmail(
+                "user-added-to-dclg-in-access-group",
+                EmailContacts(listOf(recipient), emailConfig),
+                "Delta: MHCLG user has been added to collection group '$accessGroupDisplayName'",
+                mapOf(
+                    "deltaUrl" to deltaConfig.deltaWebsiteUrl,
+                    "userFullName" to userName,
+                    "userEmailAddress" to userEmail,
+                    "actingUserEmail" to actingUserEmail,
+                    "accessGroupName" to accessGroupDisplayName
+                )
             )
-        )
-
-        logger.atInfo().addKeyValue("userEmail", userEmail).addKeyValue("accessGroupName", accessGroupDisplayName)
-            .addKeyValue("emailRecipients", recipients.joinToString(";") { it.email })
-            .log("Sent user-added-to-dclg-in-access-group email")
+            logger.atInfo().addKeyValue("userEmail", userEmail).addKeyValue("accessGroupName", accessGroupDisplayName)
+                .addKeyValue("emailRecipients", recipient.email)
+                .log("Sent user-added-to-dclg-in-access-group email")
+        }
     }
 }
 


### PR DESCRIPTION
**Description** 
This PR fixes an issue where sending emails to 50+ recipients causes an error. The code has been modified to send update emails to recipients individually as opposed to collectively.
The PR also changes the way the MeterRegistry is initialised and filters set to avoid warnings in this regard. 

**Local testing** 
Tested sending emails locally.
