### PR TITLE
DT-1361: Comments not being added when performing bulk update access …

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/EditAccessGroupsController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/EditAccessGroupsController.kt
@@ -104,6 +104,8 @@ class EditAccessGroupsController(
         val targetUserGUID = userGUIDMapService.getGUIDFromCN(removeGroupRequest.userToEditCn)
         val targetUser = userLookupService.lookupUserByGUID(targetUserGUID)
 
+        val comment = removeGroupRequest.comment
+
         val targetGroupName = removeGroupRequest.accessGroupName
         validateAccessGroupExists(targetGroupName)
 
@@ -122,6 +124,12 @@ class EditAccessGroupsController(
                     )
                 }
             }
+
+            val commentModification = comment?.let { getCommentModification(targetUser, it) }
+            commentModification?.let {
+                userService.updateUser(targetUser, arrayOf(commentModification), session, call)
+            }
+
             return call.respond(mapOf("message" to "User ${targetUser.email} removed from access group ${targetGroupName}."))
         } else {
             logger.warn("User {} already not member of access group {}", targetUser.getGUID(), targetGroupADName)
@@ -432,6 +440,7 @@ class EditAccessGroupsController(
     data class DeltaUserSingleAccessGroupRequest(
         @SerialName("userToEditCn") val userToEditCn: String, // TODO DT-1022 - use GUID
         @SerialName("accessGroupName") val accessGroupName: String,
+        @SerialName("comment") val comment: String? = null,
     )
 
     @Serializable


### PR DESCRIPTION
**Description** 

Fix for a bug on the bulk update user access groups where any comments added to the file are ignored on the update when removing access groups. This fix modifies the Auth Service endpoint to take in an additional optional comment parameter, which it then uses to check against existing comments and amend as necessary.

The changes required on auth-service have been made [in this PR](https://github.com/communitiesuk/delta/pull/1784)


**Local testing** 

Have tested multiple times locally using a CSV file and comments are updating correctly. 

- Find a user to test with.

- Go to Admin>Edit user. 

- Find an access group to remove from the user and make a note of the org code/org name/access group name.

- Open a new tab onto Admin>Users>Bulk Actions>Update user access groups.

- Either create a new file to upload or use the file here. The file will need to contain the information needed to remove an access group and organisation from an existing user. Ensure the comment field is filled in. Click save and await the 'success’ message. 

- Go back to the Admin>Users>User details tab previously opened and refresh the page. The access group should have been removed from the user along with the comment from the CSV file.