### PR TITLE
DT-1374 Add welcome message for new internal users

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/Injection.kt
@@ -285,7 +285,8 @@ class Injection(
         oauthSessionService,
         accessGroupsService,
         organisationService,
-        ::MemberOfToDeltaRolesMapper
+        ::MemberOfToDeltaRolesMapper,
+        userAuditService,
     )
 
     fun externalDeltaApiTokenController(): ExternalDeltaApiTokenController {

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/RefreshUserInfoController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/internal/RefreshUserInfoController.kt
@@ -44,9 +44,9 @@ class RefreshUserInfoController(
             val roles = memberOfToDeltaRolesMapperFactory(
                 user.getGUID(), allOrganisations.await(), allAccessGroups.await()
             ).map(user.memberOfCNs)
-
+            val isNewUser = userAuditService.checkIsNewUser(user.getGUID())
             logger.info("Retrieved updated user info")
-            UserInfoResponse(user, samlToken.token, roles, samlToken.expiry.epochSecond, session.isSso)
+            UserInfoResponse(user, samlToken.token, roles, samlToken.expiry.epochSecond, session.isSso, isNewUser)
         }
     }
 
@@ -124,6 +124,7 @@ class RefreshUserInfoController(
         val delta_user_roles: MemberOfToDeltaRolesMapper.Roles,
         val expires_at_epoch_second: Long,
         val is_sso: Boolean,
+        val is_new_user: Boolean,
         var impersonatedUserCn: String? = null,
         var impersonatedUserGuid: String? = null,
     )

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/UserAuditTrailRepo.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/UserAuditTrailRepo.kt
@@ -99,6 +99,18 @@ class UserAuditTrailRepo {
     }
 
     @Blocking
+    fun checkIsNewUser(conn: Connection, userGUID: UUID): Boolean {
+        val stmt = conn.prepareStatement(
+            "SELECT COUNT(*) FROM (SELECT * FROM user_audit WHERE user_guid= ? AND action='form_login' LIMIT 2) AS a"
+        )
+        stmt.setObject(1, userGUID)
+        val resultSet = stmt.executeQuery()
+        resultSet.next()
+        resultSet.getInt(1)
+        return resultSet.getInt(1) == 1
+    }
+
+    @Blocking
     fun insertAuditRow(
         conn: Connection,
         action: AuditAction,

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/UserAuditTrailRepo.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/repositories/UserAuditTrailRepo.kt
@@ -106,7 +106,6 @@ class UserAuditTrailRepo {
         stmt.setObject(1, userGUID)
         val resultSet = stmt.executeQuery()
         resultSet.next()
-        resultSet.getInt(1)
         return resultSet.getInt(1) == 1
     }
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/UserAuditService.kt
@@ -73,6 +73,14 @@ class UserAuditService(private val userAuditTrailRepo: UserAuditTrailRepo, priva
         )
     }
 
+    suspend fun checkIsNewUser(userGUID: UUID): Boolean {
+        return withContext(Dispatchers.IO) {
+            dbPool.useConnectionBlocking("check_is_new_user") {
+                userAuditTrailRepo.checkIsNewUser(it,userGUID)
+            }
+        }
+    }
+
     val userFormLoginAudit = insertAnonSimpleAuditRowFun(UserAuditTrailRepo.AuditAction.FORM_LOGIN)
     val resetPasswordEmailAudit = insertAnonSimpleAuditRowFun(UserAuditTrailRepo.AuditAction.RESET_PASSWORD_EMAIL)
     val adminResetPasswordEmailAudit = insertSimpleAuditRowFun(UserAuditTrailRepo.AuditAction.RESET_PASSWORD_EMAIL)

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/OAuthTokenControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/OAuthTokenControllerTest.kt
@@ -43,6 +43,7 @@ class OAuthTokenControllerTest {
             assertEquals(session.authToken, response["access_token"].toString().trim('"'))
             assertEquals("SAML Token", response["saml_token"].toString().trim('"'))
             assertEquals("user", response["delta_ldap_user"]!!.jsonObject["cn"].toString().trim('"'))
+            assertEquals("false", response["is_new_user"].toString().trim('"'))
         }
     }
 

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/OAuthTokenControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/OAuthTokenControllerTest.kt
@@ -106,6 +106,7 @@ class OAuthTokenControllerTest {
             coEvery { userLookupService.lookupCurrentUser(session) }.returns(user)
             coEvery { accessGroupsService.getAllAccessGroups() }.returns(listOf())
             coEvery { organisationService.findAllNamesAndCodes() }.returns(listOf())
+            coEvery { userAuditService.checkIsNewUser(user.getGUID()) }.returns(false)
             every { memberOfToDeltaRolesMapper.map(any()) }.returns(
                 MemberOfToDeltaRolesMapper.Roles(
                     emptyList(),

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/OAuthTokenControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/OAuthTokenControllerTest.kt
@@ -93,6 +93,7 @@ class OAuthTokenControllerTest {
         private val oauthSessionService = mockk<OAuthSessionService>()
         private val accessGroupsService = mockk<AccessGroupsService>()
         private val organisationService = mockk<OrganisationService>()
+        private val userAuditService = mockk<UserAuditService>()
         private val memberOfToDeltaRolesMapper = mockk<MemberOfToDeltaRolesMapper>()
 
         @Suppress("MoveLambdaOutsideParentheses")
@@ -123,7 +124,7 @@ class OAuthTokenControllerTest {
             } answers { "SAML Token" }
             controller = OAuthTokenController(
                 listOf(client), authorizationCodeService, userLookupService, samlTokenService, oauthSessionService,
-                accessGroupsService, organisationService, { _, _, _ -> memberOfToDeltaRolesMapper }
+                accessGroupsService, organisationService, { _, _, _ -> memberOfToDeltaRolesMapper }, userAuditService
             )
 
             testApp = TestApplication {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/RefreshUserInfoControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/RefreshUserInfoControllerTest.kt
@@ -36,6 +36,8 @@ class RefreshUserInfoControllerTest {
 
     @Test
     fun testUserInfoEndpoint() = testSuspend {
+        coEvery { userAuditService.checkIsNewUser(user.getGUID()) }.returns(false)
+
         testClient.get("/user-info") {
             headers {
                 append("Authorization", "Bearer ${session.authToken}")
@@ -55,6 +57,7 @@ class RefreshUserInfoControllerTest {
 
     @Test
     fun testInvalidBearerToken() = testSuspend {
+
         testClient.get("/user-info") {
             headers {
                 append("Authorization", "Bearer invalid_token")
@@ -74,6 +77,7 @@ class RefreshUserInfoControllerTest {
                 any()
             )
         } just runs
+
         coEvery {
             oauthSessionService.updateWithImpersonatedGUID(adminSession.id, userToImpersonate.getGUID())
         } just runs
@@ -110,6 +114,7 @@ class RefreshUserInfoControllerTest {
                 any()
             )
         } just runs
+
         coEvery {
             oauthSessionService.updateWithImpersonatedGUID(adminSession.id, userWithPersonalDataRole.getGUID())
         } just runs
@@ -201,6 +206,7 @@ class RefreshUserInfoControllerTest {
             coEvery { userLookupService.lookupUserByGUID(userToImpersonate.getGUID()) } returns userToImpersonate
             coEvery { userGUIDMapService.getGUIDFromCN(userWithPersonalDataRole.cn) } returns userWithPersonalDataRole.getGUID()
             coEvery { userLookupService.lookupUserByGUID(userWithPersonalDataRole.getGUID()) } returns userWithPersonalDataRole
+            coEvery { userAuditService.checkIsNewUser(adminUser.getGUID()) }.returns(false)
             every {
                 samlTokenService.generate(
                     client.samlCredential,

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/RefreshUserInfoControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/RefreshUserInfoControllerTest.kt
@@ -52,6 +52,7 @@ class RefreshUserInfoControllerTest {
                 "dclg",
                 response["delta_user_roles"]!!.jsonObject["organisations"]!!.jsonArray.single().jsonObject["code"]!!.jsonPrimitive.content
             )
+            assertEquals("false", response["is_new_user"].toString().trim('"'))
         }
     }
 

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditServiceTest.kt
@@ -7,6 +7,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import org.junit.AfterClass
 import org.junit.BeforeClass
 import org.junit.Test
 import uk.gov.communities.delta.auth.config.AzureADSSOClient
@@ -111,6 +112,16 @@ class UserAuditServiceTest {
             service = UserAuditService(repo, testDbPool)
             userGUIDMapRepo = UserGUIDMapRepo()
             every { call.callId } returns "request-id-1234"
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun teardown() {
+            testDbPool.useConnectionBlocking("test_data_removal") {
+                it.createStatement().execute("DELETE FROM user_audit")
+                it.createStatement().execute("DELETE FROM user_guid_map")
+                it.commit()
+            }
         }
     }
 }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditTrailRepoTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserAuditTrailRepoTest.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.delta.dbintegration
 
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import org.junit.AfterClass
 import org.junit.BeforeClass
 import org.junit.Test
 import uk.gov.communities.delta.auth.repositories.UserAuditTrailRepo
@@ -112,7 +113,7 @@ class UserAuditTrailRepoTest {
                     UserAuditTrailRepo.AuditAction.FORM_LOGIN,
                     oldUser.getGUID(),
                     null,
-                    "requestId",
+                    "requestId2",
                     "{\"key\": \"value\"}"
                 )
                 it.commit()// So that the next row has a different timestamp, and we can check ordering (newest first)
@@ -122,7 +123,7 @@ class UserAuditTrailRepoTest {
                     UserAuditTrailRepo.AuditAction.RESET_PASSWORD_EMAIL,
                     user.getGUID(),
                     null,
-                    "requestId2",
+                    "requestId3",
                     "{}"
                 )
                 repo.insertAuditRow(
@@ -130,12 +131,23 @@ class UserAuditTrailRepoTest {
                     UserAuditTrailRepo.AuditAction.FORM_LOGIN,
                     oldUser.getGUID(),
                     null,
-                    "requestId",
+                    "requestId3",
                     "{\"key\": \"value\"}"
                 )
                 userGUIDMapRepo.newUser(it, user)
                 userGUIDMapRepo.newUser(it, otherUser)
                 userGUIDMapRepo.newUser(it, oldUser)
+                it.commit()
+            }
+        }
+
+
+        @AfterClass
+        @JvmStatic
+        fun teardown() {
+            testDbPool.useConnectionBlocking("test_data_removal") {
+                it.createStatement().execute("DELETE FROM user_audit")
+                it.createStatement().execute("DELETE FROM user_guid_map")
                 it.commit()
             }
         }

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserGUIDMapTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/dbintegration/UserGUIDMapTest.kt
@@ -4,10 +4,7 @@ import io.ktor.server.application.*
 import io.ktor.test.dispatcher.*
 import io.mockk.*
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Test
+import org.junit.*
 import uk.gov.communities.delta.auth.plugins.NoUserException
 import uk.gov.communities.delta.auth.repositories.UserGUIDMapRepo
 import uk.gov.communities.delta.auth.services.UserGUIDMapService
@@ -96,6 +93,15 @@ class UserGUIDMapTest {
         fun setup() {
             val repo = UserGUIDMapRepo()
             service = UserGUIDMapService(repo, userLookupService, testDbPool)
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun teardown() {
+            testDbPool.useConnectionBlocking("test_data_removal") {
+                it.createStatement().execute("DELETE FROM user_guid_map")
+                it.commit()
+            }
         }
     }
 


### PR DESCRIPTION
**Description**
Added check to see if a user is new by check the audit logs to see how many times they have logged in. This is then passed to Delta

**Local testing** 
Tested locally
Added unit tests (also added clean up to some pre-existing tests - only for user-audit and user_guid_map tables)

**Release**
Also requires Delta release
