### PR TITLE
DT-1502: non-prod warning text

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/DeltaConfig.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/config/DeltaConfig.kt
@@ -7,6 +7,7 @@ class DeltaConfig(
     val rateLimit: Int,
     val masterStoreBaseNoAuth: String,
     val apiOrigin: String,
+    val isProduction: Boolean,
 ) {
     companion object {
         fun fromEnv() = DeltaConfig(
@@ -16,7 +17,8 @@ class DeltaConfig(
                 "DELTA_MARKLOGIC_LDAP_AUTH_APP_SERVICE",
                 "http://localhost:8030/"
             ),
-            apiOrigin = Env.getRequiredOrDevFallback("API_ORIGIN", "localhost:8080")
+            apiOrigin = Env.getRequiredOrDevFallback("API_ORIGIN", "localhost:8080"),
+            isProduction = Env.getRequiredOrDevFallback("ENVIRONMENT", "") == "production"
         )
 
         const val DATAMART_DELTA_USER = LDAPConfig.DATAMART_DELTA_PREFIX + "user"

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaForgotPasswordController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaForgotPasswordController.kt
@@ -98,7 +98,8 @@ class DeltaForgotPasswordController(
                 "reset-password-email-sent",
                 mapOf(
                     "deltaUrl" to deltaConfig.deltaWebsiteUrl,
-                    "emailAddress" to emailAddress
+                    "emailAddress" to emailAddress,
+                    "isProduction" to deltaConfig.isProduction
                 )
             )
         )

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaForgotPasswordController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaForgotPasswordController.kt
@@ -110,7 +110,8 @@ class DeltaForgotPasswordController(
     ) {
         val mapOfValues = mutableMapOf(
             "deltaUrl" to deltaConfig.deltaWebsiteUrl,
-        )
+            "isProduction" to deltaConfig.isProduction,
+            )
         if (message != null) mapOfValues += "message" to message
         if (emailAddress != null) mapOfValues += "emailAddress" to emailAddress
         respond(

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaLoginController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaLoginController.kt
@@ -118,6 +118,7 @@ class DeltaLoginController(
                 "errorMessage" to errorMessage,
                 "errorLink" to errorLink,
                 "username" to username,
+                "isProduction" to deltaConfig.isProduction
             )
         )
     )

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaResetPasswordController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaResetPasswordController.kt
@@ -157,6 +157,7 @@ class DeltaResetPasswordController(
                 mapOf(
                     "deltaUrl" to deltaConfig.deltaWebsiteUrl,
                     "emailAddress" to userEmail,
+                    "isProduction" to deltaConfig.isProduction,
                 )
             )
         )

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSetPasswordController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSetPasswordController.kt
@@ -146,7 +146,8 @@ class DeltaSetPasswordController(
                 mapOf(
                     "deltaUrl" to deltaConfig.deltaWebsiteUrl,
                     "emailAddress" to userEmail,
-                )
+                    "isProduction" to deltaConfig.isProduction,
+                    )
             )
         )
 

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaUserRegistrationController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaUserRegistrationController.kt
@@ -244,6 +244,7 @@ class DeltaUserRegistrationController(
                     "confirmEmailErrorMessages" to confirmEmailAddressErrors,
                     "confirmEmailAddress" to confirmEmailAddress,
                     "errorSummary" to errorSummary,
+                    "isProduction" to deltaConfig.isProduction
                 )
             )
         )

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/OriginHeaderCheck.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/plugins/OriginHeaderCheck.kt
@@ -36,6 +36,7 @@ fun originHeaderCheck(serviceUrl: String, deltaConfig: DeltaConfig) = createRout
                             "heading" to "Error",
                             "message" to "Origin header check failed. If you are using Internet Explorer please try another browser",
                             "requestId" to call.callId!!,
+                            "isProduction" to deltaConfig.isProduction
                         )
                     )
                 )

--- a/auth-service/src/main/resources/templates/thymeleaf/delta-login.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/delta-login.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="govuk-template " lang="en" xmlns:th="http://www.thymeleaf.org">
 
-<head th:replace="~{fragments/template.html :: head (title='Delta | Sign in')}">
+<head th:replace="~{fragments/template.html :: head (title='Delta | Sign in', isProduction=${isProduction})}">
     <title>Delta | Sign in</title>
 </head>
 
@@ -14,6 +14,7 @@
 -->
 <a class="govuk-skip-link" data-module="govuk-skip-link" href="#main-content">Skip to main content</a>
 <header th:replace="~{fragments/template.html :: header}"></header>
+<div th:replace="~{fragments/template.html :: environment-warning-message}"></div>
 
 <!--/*@thymesVar id="deltaUrl" type="java.lang.String" */-->
 <!--/*@thymesVar id="ssoClients" type="java.util.List<uk.gov.communities.delta.auth.config.AzureADSSOClient>" */-->

--- a/auth-service/src/main/resources/templates/thymeleaf/delta-login.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/delta-login.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html class="govuk-template " lang="en" xmlns:th="http://www.thymeleaf.org">
 
+<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
 <head th:replace="~{fragments/template.html :: head (title='Delta | Sign in', isProduction=${isProduction})}">
     <title>Delta | Sign in</title>
 </head>

--- a/auth-service/src/main/resources/templates/thymeleaf/delta-login.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/delta-login.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <html class="govuk-template " lang="en" xmlns:th="http://www.thymeleaf.org">
 
-<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
-<head th:replace="~{fragments/template.html :: head (title='Delta | Sign in', isProduction=${isProduction})}">
+<head th:replace="~{fragments/template.html :: head (title='Delta | Sign in')}">
     <title>Delta | Sign in</title>
 </head>
 

--- a/auth-service/src/main/resources/templates/thymeleaf/error.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/error.html
@@ -11,12 +11,6 @@
     <title>Error</title>
 </head>
 
-<p>
-    <span th:text="${isProduction}">Something went wrong</span>.
-
-    ${isProduction}
-</p>
-<p>123</p>
 <body class="govuk-template__body govuk-body">
 <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 <header th:replace="~{fragments/template.html :: header}"></header>

--- a/auth-service/src/main/resources/templates/thymeleaf/error.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/error.html
@@ -6,8 +6,7 @@
 <!--/*@thymesVar id="heading" type="java.lang.String" */-->
 <!--/*@thymesVar id="message" type="java.lang.String" */-->
 <!--/*@thymesVar id="requestId" type="java.lang.String" */-->
-<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
-<head th:replace="~{fragments/template.html :: head (title=${title}, isProduction=${isProduction})}">
+<head th:replace="~{fragments/template.html :: head (title=${title})}">
     <title>Error</title>
 </head>
 

--- a/auth-service/src/main/resources/templates/thymeleaf/error.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/error.html
@@ -11,6 +11,12 @@
     <title>Error</title>
 </head>
 
+<p>
+    <span th:text="${isProduction}">Something went wrong</span>.
+
+    ${isProduction}
+</p>
+<p>123</p>
 <body class="govuk-template__body govuk-body">
 <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 <header th:replace="~{fragments/template.html :: header}"></header>

--- a/auth-service/src/main/resources/templates/thymeleaf/error.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/error.html
@@ -6,14 +6,16 @@
 <!--/*@thymesVar id="heading" type="java.lang.String" */-->
 <!--/*@thymesVar id="message" type="java.lang.String" */-->
 <!--/*@thymesVar id="requestId" type="java.lang.String" */-->
-
-<head th:replace="~{fragments/template.html :: head (title=${title})}">
+<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
+<head th:replace="~{fragments/template.html :: head (title=${title}, isProduction=${isProduction})}">
     <title>Error</title>
 </head>
 
 <body class="govuk-template__body govuk-body">
 <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 <header th:replace="~{fragments/template.html :: header}"></header>
+
+<div th:replace="~{fragments/template.html :: environment-warning-message}"></div>
 
 <div class="govuk-width-container ">
     <main class="govuk-main-wrapper " id="main-content" role="main">

--- a/auth-service/src/main/resources/templates/thymeleaf/expired-reset-password.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/expired-reset-password.html
@@ -1,13 +1,15 @@
 <!DOCTYPE html>
 <html class="govuk-template " lang="en" xmlns:th="http://www.thymeleaf.org">
 
-<head th:replace="~{fragments/template.html :: head (title='Delta | Reset Password')}">
+<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
+<head th:replace="~{fragments/template.html :: head (title='Delta | Reset Password', isProduction=${isProduction})}">
     <title>Delta | Reset Password</title>
 </head>
 
 <body class="govuk-template__body govuk-body">
 <a class="govuk-skip-link" data-module="govuk-skip-link" href="#main-content">Skip to main content</a>
 <header th:replace="~{fragments/template.html :: header}"></header>
+<div th:replace="~{fragments/template.html :: environment-warning-message}"></div>
 
 <!--/*@thymesVar id="deltaUrl" type="java.lang.String" */-->
 <!--/*@thymesVar id="userEmail" type="java.lang.String" */-->

--- a/auth-service/src/main/resources/templates/thymeleaf/expired-reset-password.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/expired-reset-password.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <html class="govuk-template " lang="en" xmlns:th="http://www.thymeleaf.org">
 
-<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
-<head th:replace="~{fragments/template.html :: head (title='Delta | Reset Password', isProduction=${isProduction})}">
+<head th:replace="~{fragments/template.html :: head (title='Delta | Reset Password')}">
     <title>Delta | Reset Password</title>
 </head>
 

--- a/auth-service/src/main/resources/templates/thymeleaf/expired-set-password.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/expired-set-password.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html class="govuk-template " lang="en" xmlns:th="http://www.thymeleaf.org">
-<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
-<head th:replace="~{fragments/template.html :: head (title='Delta | Set Password', isProduction=${isProduction})}">
+<head th:replace="~{fragments/template.html :: head (title='Delta | Set Password')}">
     <title>Delta | Set Password</title>
 </head>
 

--- a/auth-service/src/main/resources/templates/thymeleaf/expired-set-password.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/expired-set-password.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html class="govuk-template " lang="en" xmlns:th="http://www.thymeleaf.org">
-
-<head th:replace="~{fragments/template.html :: head (title='Delta | Set Password')}">
+<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
+<head th:replace="~{fragments/template.html :: head (title='Delta | Set Password', isProduction=${isProduction})}">
     <title>Delta | Set Password</title>
 </head>
 
 <body class="govuk-template__body govuk-body">
 <a class="govuk-skip-link" data-module="govuk-skip-link" href="#main-content">Skip to main content</a>
 <header th:replace="~{fragments/template.html :: header}"></header>
+<div th:replace="~{fragments/template.html :: environment-warning-message}"></div>
 
 <!--/*@thymesVar id="deltaUrl" type="java.lang.String" */-->
 <!--/*@thymesVar id="userEmail" type="java.lang.String" */-->

--- a/auth-service/src/main/resources/templates/thymeleaf/forgot-password.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/forgot-password.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html class="govuk-template " lang="en" xmlns:th="http://www.thymeleaf.org">
-<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
-<head th:replace="~{fragments/template.html :: head (title='Delta | Forgot Password', isProduction=${isProduction})}">
+<head th:replace="~{fragments/template.html :: head (title='Delta | Forgot Password')}">
     <title>Delta | Forgot Password</title>
 </head>
 

--- a/auth-service/src/main/resources/templates/thymeleaf/forgot-password.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/forgot-password.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html class="govuk-template " lang="en" xmlns:th="http://www.thymeleaf.org">
-
-<head th:replace="~{fragments/template.html :: head (title='Delta | Forgot Password')}">
+<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
+<head th:replace="~{fragments/template.html :: head (title='Delta | Forgot Password', isProduction=${isProduction})}">
     <title>Delta | Forgot Password</title>
 </head>
 
 <body class="govuk-template__body govuk-body">
 <a class="govuk-skip-link" data-module="govuk-skip-link" href="#main-content">Skip to main content</a>
 <header th:replace="~{fragments/template.html :: header}"></header>
+<div th:replace="~{fragments/template.html :: environment-warning-message}"></div>
 
 <!--/*@thymesVar id="deltaUrl" type="java.lang.String" */-->
 <!--/*@thymesVar id="message" type="java.lang.String" */-->

--- a/auth-service/src/main/resources/templates/thymeleaf/fragments/template.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/fragments/template.html
@@ -42,7 +42,7 @@
 
 <div th:fragment="environment-warning-message" class="">
     <div th:unless="${isProduction}">
-        <div class="govuk-width-container" style="margin-top: 10px">
+        <div class="govuk-width-container govuk-!-margin-top-2">
             <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
                 <div class="govuk-notification-banner__header">
                     <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">

--- a/auth-service/src/main/resources/templates/thymeleaf/fragments/template.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/fragments/template.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="govuk-template " lang="en" xmlns:th="http://www.thymeleaf.org">
-
-<head th:fragment="head (title, isProduction)">
+<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
+<head th:fragment="head (title)">
     <meta charset="utf-8">
     <title th:text="${title}">Delta</title>
     <meta content="width=device-width, initial-scale=1, viewport-fit=cover" name="viewport">
@@ -40,7 +40,7 @@
     </div>
 </header>
 
-<div th:fragment="environment-warning-message" class="">
+<div th:fragment="environment-warning-message">
     <div th:unless="${isProduction}">
         <div class="govuk-width-container govuk-!-margin-top-2">
             <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">

--- a/auth-service/src/main/resources/templates/thymeleaf/fragments/template.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/fragments/template.html
@@ -54,7 +54,7 @@
                         This is a staging site, used for internal testing.<br>Do not enter data.
                     </p>
                     <p class="govuk-body">
-                        To enter data, go to the <a class="govuk-notification-banner__link" href="https://delta.gov.uk">main Delta site</a>.
+                        To enter data, go to the <a class="govuk-notification-banner__link" href="https://delta.communities.gov.uk/">main Delta site</a>.
                     </p>
                 </div>
             </div>

--- a/auth-service/src/main/resources/templates/thymeleaf/fragments/template.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/fragments/template.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html class="govuk-template " lang="en" xmlns:th="http://www.thymeleaf.org">
 
-<head th:fragment="head (title)">
+<head th:fragment="head (title, isProduction)">
     <meta charset="utf-8">
     <title th:text="${title}">Delta</title>
     <meta content="width=device-width, initial-scale=1, viewport-fit=cover" name="viewport">
     <meta content="#0b0c0c" name="theme-color">
     <meta content="IE=edge" http-equiv="X-UA-Compatible">
+    <meta th:unless="${isProduction}" name="robots" content="noindex">
     <link href="/static/assets/images/favicon.ico" rel="shortcut icon" sizes="16x16 32x32 48x48"
           type="image/x-icon">
     <link color="#0b0c0c" href="/static/assets/images/govuk-mask-icon.svg" rel="mask-icon">
@@ -38,6 +39,28 @@
         </div>
     </div>
 </header>
+
+<div th:fragment="environment-warning-message" class="">
+    <div th:unless="${isProduction}">
+        <div class="govuk-width-container" style="margin-top: 10px">
+            <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+                <div class="govuk-notification-banner__header">
+                    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                        Important
+                    </h2>
+                </div>
+                <div class="govuk-notification-banner__content">
+                    <p class="govuk-notification-banner__heading">
+                        This is a staging site, used for internal testing.<br>Do not enter data.
+                    </p>
+                    <p class="govuk-body">
+                        To enter data, go to the <a class="govuk-notification-banner__link" href="https://delta.gov.uk">main Delta site</a>.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
 
 <div class="govuk-width-container ">
     <main class="govuk-main-wrapper " id="main-content" role="main">

--- a/auth-service/src/main/resources/templates/thymeleaf/password-form.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/password-form.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html class="govuk-template " lang="en" xmlns:th="http://www.thymeleaf.org">
-<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
-<head th:replace="~{fragments/template.html :: head (title='Delta | Password', isProduction=${isProduction})}">
+<head th:replace="~{fragments/template.html :: head (title='Delta | Password')}">
     <title>Delta | Password</title>
 </head>
 

--- a/auth-service/src/main/resources/templates/thymeleaf/password-form.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/password-form.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html class="govuk-template " lang="en" xmlns:th="http://www.thymeleaf.org">
-
-<head th:replace="~{fragments/template.html :: head (title='Delta | Password')}">
+<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
+<head th:replace="~{fragments/template.html :: head (title='Delta | Password', isProduction=${isProduction})}">
     <title>Delta | Password</title>
 </head>
 
 <body class="govuk-template__body govuk-body">
 <a class="govuk-skip-link" data-module="govuk-skip-link" href="#main-content">Skip to main content</a>
 <header th:replace="~{fragments/template.html :: header}"></header>
+<div th:replace="~{fragments/template.html :: environment-warning-message}"></div>
 
 <!--/*@thymesVar id="deltaUrl" type="java.lang.String" */-->
 <!--/*@thymesVar id="message" type="java.lang.String" */-->

--- a/auth-service/src/main/resources/templates/thymeleaf/register-user-form.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/register-user-form.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template " xmlns:th="http://www.thymeleaf.org">
-
-<head th:replace="~{fragments/template.html :: head (title='Delta | Register')}">
+<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
+<head th:replace="~{fragments/template.html :: head (title='Delta | Register', isProduction=${isProduction})}">
     <title>Delta | Register</title>
 </head>
 
 <body class="govuk-template__body govuk-body">
 <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 <header th:replace="~{fragments/template.html :: header}"></header>
+<div th:replace="~{fragments/template.html :: environment-warning-message}"></div>
 
 <!--/*@thymesVar id="deltaUrl" type="java.lang.String" */-->
 <!-- List of errors paired with error links -->

--- a/auth-service/src/main/resources/templates/thymeleaf/register-user-form.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/register-user-form.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template " xmlns:th="http://www.thymeleaf.org">
-<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
-<head th:replace="~{fragments/template.html :: head (title='Delta | Register', isProduction=${isProduction})}">
+<head th:replace="~{fragments/template.html :: head (title='Delta | Register')}">
     <title>Delta | Register</title>
 </head>
 

--- a/auth-service/src/main/resources/templates/thymeleaf/registration-success.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/registration-success.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template " xmlns:th="http://www.thymeleaf.org">
-
-<head th:replace="~{fragments/template.html :: head (title='Delta | Register')}">
+<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
+<head th:replace="~{fragments/template.html :: head (title='Delta | Register', isProduction=${isProduction})}">
     <title>Delta | Register</title>
 </head>
 
 <body class="govuk-template__body govuk-body">
 <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 <header th:replace="~{fragments/template.html :: header}"></header>
+<div th:replace="~{fragments/template.html :: environment-warning-message}"></div>
 
 <!--/*@thymesVar id="deltaUrl" type="java.lang.String" */-->
 <!--/*@thymesVar id="emailAddress" type="java.lang.String" */-->

--- a/auth-service/src/main/resources/templates/thymeleaf/registration-success.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/registration-success.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template " xmlns:th="http://www.thymeleaf.org">
-<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
-<head th:replace="~{fragments/template.html :: head (title='Delta | Register', isProduction=${isProduction})}">
+<head th:replace="~{fragments/template.html :: head (title='Delta | Register')}">
     <title>Delta | Register</title>
 </head>
 

--- a/auth-service/src/main/resources/templates/thymeleaf/reset-password-email-sent.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/reset-password-email-sent.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html class="govuk-template " lang="en" xmlns:th="http://www.thymeleaf.org">
-<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
-<head th:replace="~{fragments/template.html :: head (title='Delta | Reset Password', isProduction=${isProduction})}">
+<head th:replace="~{fragments/template.html :: head (title='Delta | Reset Password')}">
     <title>Delta | Reset Password</title>
 </head>
 

--- a/auth-service/src/main/resources/templates/thymeleaf/reset-password-email-sent.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/reset-password-email-sent.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html class="govuk-template " lang="en" xmlns:th="http://www.thymeleaf.org">
-
-<head th:replace="~{fragments/template.html :: head (title='Delta | Reset Password')}">
+<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
+<head th:replace="~{fragments/template.html :: head (title='Delta | Reset Password', isProduction=${isProduction})}">
     <title>Delta | Reset Password</title>
 </head>
 
 <body class="govuk-template__body govuk-body">
 <a class="govuk-skip-link" data-module="govuk-skip-link" href="#main-content">Skip to main content</a>
 <header th:replace="~{fragments/template.html :: header}"></header>
+<div th:replace="~{fragments/template.html :: environment-warning-message}"></div>
 
 <!--/*@thymesVar id="deltaUrl" type="java.lang.String" */-->
 <!--/*@thymesVar id="emailAddress" type="java.lang.String" */-->

--- a/auth-service/src/main/resources/templates/thymeleaf/reset-password-success.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/reset-password-success.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html class="govuk-template " lang="en" xmlns:th="http://www.thymeleaf.org">
-<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
-<head th:replace="~{fragments/template.html :: head (title='Delta | Reset Password', isProduction=${isProduction})}">
+<head th:replace="~{fragments/template.html :: head (title='Delta | Reset Password')}">
     <title>Delta | Reset Password</title>
 </head>
 

--- a/auth-service/src/main/resources/templates/thymeleaf/reset-password-success.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/reset-password-success.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html class="govuk-template " lang="en" xmlns:th="http://www.thymeleaf.org">
-
-<head th:replace="~{fragments/template.html :: head (title='Delta | Reset Password')}">
+<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
+<head th:replace="~{fragments/template.html :: head (title='Delta | Reset Password', isProduction=${isProduction})}">
     <title>Delta | Reset Password</title>
 </head>
 
 <body class="govuk-template__body govuk-body">
 <a class="govuk-skip-link" data-module="govuk-skip-link" href="#main-content">Skip to main content</a>
 <header th:replace="~{fragments/template.html :: header}"></header>
+<div th:replace="~{fragments/template.html :: environment-warning-message}"></div>
 
 <!--/*@thymesVar id="deltaUrl" type="java.lang.String" */-->
 

--- a/auth-service/src/main/resources/templates/thymeleaf/set-password-success.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/set-password-success.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html class="govuk-template " lang="en" xmlns:th="http://www.thymeleaf.org">
-<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
-<head th:replace="~{fragments/template.html :: head (title='Delta | Set Password', isProduction=${isProduction})}">
+<head th:replace="~{fragments/template.html :: head (title='Delta | Set Password')}">
     <title>Delta | Set Password</title>
 </head>
 

--- a/auth-service/src/main/resources/templates/thymeleaf/set-password-success.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/set-password-success.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html class="govuk-template " lang="en" xmlns:th="http://www.thymeleaf.org">
-
-<head th:replace="~{fragments/template.html :: head (title='Delta | Set Password')}">
+<!--/*@thymesVar id="isProduction" type="java.lang.Boolean" */-->
+<head th:replace="~{fragments/template.html :: head (title='Delta | Set Password', isProduction=${isProduction})}">
     <title>Delta | Set Password</title>
 </head>
 
 <body class="govuk-template__body govuk-body">
 <a class="govuk-skip-link" data-module="govuk-skip-link" href="#main-content">Skip to main content</a>
 <header th:replace="~{fragments/template.html :: header}"></header>
+<div th:replace="~{fragments/template.html :: environment-warning-message}"></div>
 
 <!--/*@thymesVar id="deltaUrl" type="java.lang.String" */-->
 

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaLoginControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaLoginControllerTest.kt
@@ -35,6 +35,7 @@ import uk.gov.communities.delta.helper.testServiceClient
 import java.time.Instant
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.hours
 
@@ -45,6 +46,23 @@ class DeltaLoginControllerTest {
         testClient.get("/login?response_type=code&client_id=delta-website&state=1234").apply {
             assertEquals(HttpStatusCode.OK, status)
             assertContains(bodyAsText(), "Sign in to Delta")
+        }
+    }
+
+    @Test
+    fun testLoginPageNotDisplaysNonProdWarning() = testSuspend {
+        testClient.get("/login?response_type=code&client_id=delta-website&state=1234").apply {
+            assertEquals(HttpStatusCode.OK, status)
+            assertContains(bodyAsText(), "This is a staging site, used for internal testing.")
+        }
+    }
+
+    @Test
+    fun testLoginPageDisplaysNonProdWarning() = testSuspend {
+        every { deltaConfig.isProduction }  returns true
+        testClient.get("/login?response_type=code&client_id=delta-website&state=1234").apply {
+            assertEquals(HttpStatusCode.OK, status)
+            assertFalse(bodyAsText().contains( "This is a staging site, used for internal testing."))
         }
     }
 
@@ -219,6 +237,9 @@ class DeltaLoginControllerTest {
     @Before
     fun resetMocks() {
         clearAllMocks()
+        every { deltaConfig.deltaWebsiteUrl }  returns "http://localhost:8080"
+        every { deltaConfig.isProduction }  returns false
+        every { deltaConfig.rateLimit }  returns 100
         every { failedLoginCounter.increment(1.0) } returns Unit
         every { successfulLoginCounter.increment(1.0) } returns Unit
         coEvery { userAuditService.userFormLoginAudit(any(), any()) } returns Unit
@@ -231,7 +252,7 @@ class DeltaLoginControllerTest {
         private lateinit var testApp: TestApplication
         private lateinit var testClient: HttpClient
         private lateinit var loginResult: IADLdapLoginService.LdapLoginResult
-        private val deltaConfig = DeltaConfig.fromEnv()
+        val deltaConfig = mockk<DeltaConfig>()
         val user = testLdapUser(cn = "user")
         val client = testServiceClient()
         val failedLoginCounter = mockk<Counter>()
@@ -242,6 +263,7 @@ class DeltaLoginControllerTest {
         @BeforeClass
         @JvmStatic
         fun setup() {
+
             val controller = DeltaLoginController(
                 listOf(client),
                 AzureADSSOConfig(listOf(AzureADSSOClient("dev", "", "", "", "@sso.domain", required = true))),

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaLoginControllerTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/DeltaLoginControllerTest.kt
@@ -50,7 +50,7 @@ class DeltaLoginControllerTest {
     }
 
     @Test
-    fun testLoginPageNotDisplaysNonProdWarning() = testSuspend {
+    fun testLoginPageDoesNotDisplayNonProdWarning() = testSuspend {
         testClient.get("/login?response_type=code&client_id=delta-website&state=1234").apply {
             assertEquals(HttpStatusCode.OK, status)
             assertContains(bodyAsText(), "This is a staging site, used for internal testing.")
@@ -63,6 +63,23 @@ class DeltaLoginControllerTest {
         testClient.get("/login?response_type=code&client_id=delta-website&state=1234").apply {
             assertEquals(HttpStatusCode.OK, status)
             assertFalse(bodyAsText().contains( "This is a staging site, used for internal testing."))
+        }
+    }
+
+    @Test
+    fun testLoginPageHasNoIndexWarning() = testSuspend {
+        testClient.get("/login?response_type=code&client_id=delta-website&state=1234").apply {
+            assertEquals(HttpStatusCode.OK, status)
+            assertContains(bodyAsText(), "<meta name=\"robots\" content=\"noindex\">")
+        }
+    }
+
+    @Test
+    fun testLoginPageDoesNotHaveNoIndexWarning() = testSuspend {
+        every { deltaConfig.isProduction }  returns true
+        testClient.get("/login?response_type=code&client_id=delta-website&state=1234").apply {
+            assertEquals(HttpStatusCode.OK, status)
+            assertFalse(bodyAsText().contains( "<meta name=\"robots\" content=\"noindex\">"))
         }
     }
 

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/StatusPagesTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/controllers/StatusPagesTest.kt
@@ -19,7 +19,7 @@ class StatusPagesTest {
         val app = TestApplication {
             application {
                 configureTemplating(false)
-                configureStatusPages("http://delta", AzureADSSOConfig(emptyList()), DeltaConfig("url", 10, "", "localhost"))
+                configureStatusPages("http://delta", AzureADSSOConfig(emptyList()), DeltaConfig("url", 10, "", "localhost", false))
                 routing {
                     get("/userVisibleError") {
                         throw UserVisibleServerError("code", "internal message", "user message")

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/security/RateLimitingTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/security/RateLimitingTest.kt
@@ -196,7 +196,7 @@ class RateLimitingTest {
                     configureStatusPages(
                         "test.url",
                         AzureADSSOConfig(emptyList()),
-                        DeltaConfig("url", rateLimitValue, "", "localhost")
+                        DeltaConfig("url", rateLimitValue, "", "localhost", false)
                     )
                     routing {
                         rateLimit(RateLimitName(loginRateLimitName)) {

--- a/auth-service/src/test/kotlin/uk/gov/communities/delta/service/EmailServiceTest.kt
+++ b/auth-service/src/test/kotlin/uk/gov/communities/delta/service/EmailServiceTest.kt
@@ -41,7 +41,7 @@ class EmailServiceTest {
     )
     private val emailService = EmailService(
         emailConfig,
-        DeltaConfig("http://delta", 10, "", "localhost"),
+        DeltaConfig("http://delta", 10, "", "localhost", false),
         AuthServiceConfig("http://authservice", null),
         userAuditService,
         emailRepository,

--- a/terraform/modules/auth_service/main.tf
+++ b/terraform/modules/auth_service/main.tf
@@ -142,6 +142,10 @@ module "fargate" {
       name  = "API_ORIGIN"
       value = var.api_origin
     },
+    {
+      name  = "ENVIRONMENT",
+      value = var.environment
+    },
     var.enable_telemetry ? {
       name  = "AUTH_TELEMETRY_PREFIX"
       value = var.environment


### PR DESCRIPTION
**Description** 
Added warning that should only appear in non-prod environments
Added noindex to `<head>` that should apply in non-prod environments (feel like we should have this for prod, too?)

**Local testing** 
- Locally tested with switching variable manually
- Unit test coverage

**Release** 
Auth service release
