### PR TITLE
DT-1558: Broken hyperlink in the No User Account email

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/EmailService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/EmailService.kt
@@ -111,7 +111,10 @@ class EmailService(
                 emailConfig
             ),
             "MHCLG Delta - No User Account",
-            mapOf("deltaUrl" to deltaConfig.deltaWebsiteUrl)
+            mapOf(
+                "deltaUrl" to deltaConfig.deltaWebsiteUrl,
+                "authServiceUrl" to authServiceConfig.serviceUrl
+            )
         )
         logger.atInfo().addKeyValue("emailAddress", emailAddress).log("Sent no-user-account email")
     }

--- a/auth-service/src/main/resources/templates/thymeleaf/emails/no-user-account.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/emails/no-user-account.html
@@ -17,7 +17,7 @@
 <p>If this was you please check this is the email address linked to your account or click the link below to create an
     account.</p>
 <p>
-    <a th:href="@{${deltaUrl}+'/delta/register'}">Create an account</a>.
+    <a th:href="@{${authServiceUrl}+'/delta/register'}">Create an account</a>.
 </p>
 <p>If this wasn't you, no action is required.</p>
 <p>


### PR DESCRIPTION
**Description** 

[DT-1558](https://mhclgdigital.atlassian.net/browse/DT-1558) - Fixes a broken URL in an email template


**Local testing** 

Tested locally and the new link works fine



[DT-1558]: https://mhclgdigital.atlassian.net/browse/DT-1558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ