### PR TITLE
DT-1565: fixed "forgotten password" link in "already a user" email message

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/EmailService.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/services/EmailService.kt
@@ -66,6 +66,7 @@ class EmailService(
             "MHCLG Delta - Existing Account",
             mapOf(
                 "deltaUrl" to deltaConfig.deltaWebsiteUrl,
+                "authServiceUrl" to authServiceConfig.serviceUrl,
                 "userFirstName" to firstName,
             )
         )

--- a/auth-service/src/main/resources/templates/thymeleaf/emails/already-a-user.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/emails/already-a-user.html
@@ -6,6 +6,7 @@
 <body>
 
 <!--/*@thymesVar id="deltaUrl" type="java.lang.String" */-->
+<!--/*@thymesVar id="authServiceUrl" type="java.lang.String" */-->
 <!--/*@thymesVar id="userFirstName" type="java.lang.String" */-->
 
 <p>Dear <span th:text="${userFirstName}">#userFirstName#</span>,</p>
@@ -18,7 +19,7 @@
     password, you can reset it with following link.
 </p>
 <p>
-    <a href="/delta/forgot-password">Forgotten Password</a>.
+    <a th:href="@{${authServiceUrl} + '/delta/forgot-password'}">Forgotten Password</a>.
 </p>
 <p>
     When you have logged in to Delta please go to My Account to complete the set-up of your account.

--- a/auth-service/src/main/resources/templates/thymeleaf/emails/no-user-account.html
+++ b/auth-service/src/main/resources/templates/thymeleaf/emails/no-user-account.html
@@ -5,6 +5,7 @@
 </head>
 
 <!--/*@thymesVar id="deltaUrl" type="java.lang.String" */-->
+<!--/*@thymesVar id="authServiceUrl" type="java.lang.String" */-->
 
 <body>
 <p> You are receiving this email because you tried to send a reset password link to this email address for


### PR DESCRIPTION
**Description** 
Similar to https://github.com/communitiesuk/delta-auth-service/pull/199 , this change fixes a broken link in the "already a user" email users receive if they register with an email that already has an account linked to it
