### PR TITLE
MSD-95778: Non-prod banner showing on prod

### DIFF
--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaResetPasswordController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaResetPasswordController.kt
@@ -163,13 +163,20 @@ class DeltaResetPasswordController(
         )
 
     private suspend fun ApplicationCall.respondSuccessPage() =
-        respond(ThymeleafContent("reset-password-success", mapOf("deltaUrl" to deltaConfig.deltaWebsiteUrl)))
+        respond(ThymeleafContent("reset-password-success",
+            mapOf(
+            "deltaUrl" to deltaConfig.deltaWebsiteUrl,
+            "isProduction" to deltaConfig.isProduction,
+            )
+        )
+    )
 
     private suspend fun ApplicationCall.respondResetPasswordPage(
         message: String? = null,
     ) {
         val mapOfValues = mutableMapOf(
             "deltaUrl" to deltaConfig.deltaWebsiteUrl,
+            "isProduction" to deltaConfig.isProduction,
         )
         if (message != null) mapOfValues += "message" to message
         respond(
@@ -191,6 +198,7 @@ class DeltaResetPasswordController(
                 "userEmail" to userEmail,
                 "userGUID" to tokenResult.userGUID,
                 "token" to tokenResult.token,
+                "isProduction" to deltaConfig.isProduction,
             )
         )
     )

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSetPasswordController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaSetPasswordController.kt
@@ -152,13 +152,19 @@ class DeltaSetPasswordController(
         )
 
     private suspend fun ApplicationCall.respondSuccessPage() =
-        respond(ThymeleafContent("set-password-success", mapOf("deltaUrl" to deltaConfig.deltaWebsiteUrl)))
+        respond(ThymeleafContent("set-password-success",
+            mapOf("deltaUrl" to deltaConfig.deltaWebsiteUrl,
+                "isProduction" to deltaConfig.isProduction,
+            )
+        )
+    )
 
     private suspend fun ApplicationCall.respondSetPasswordPage(
         message: String? = null,
     ) {
         val mapOfValues = mutableMapOf(
             "deltaUrl" to deltaConfig.deltaWebsiteUrl,
+            "isProduction" to deltaConfig.isProduction,
         )
         if (message != null) mapOfValues += "message" to message
         respond(
@@ -180,6 +186,7 @@ class DeltaSetPasswordController(
                 "userEmail" to userEmail,
                 "userGUID" to tokenResult.userGUID,
                 "token" to tokenResult.token,
+                "isProduction" to deltaConfig.isProduction,
             )
         )
     )

--- a/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaUserRegistrationController.kt
+++ b/auth-service/src/main/kotlin/uk/gov/communities/delta/auth/controllers/external/DeltaUserRegistrationController.kt
@@ -40,6 +40,7 @@ class DeltaUserRegistrationController(
                     mapOf(
                         "deltaUrl" to deltaConfig.deltaWebsiteUrl,
                         "emailAddress" to call.parameters["emailAddress"]!!,
+                        "isProduction" to deltaConfig.isProduction,
                     )
                 )
             )


### PR DESCRIPTION
**Description** 
https://mhclgdigital.atlassian.net/browse/MSD-95778
Non-prod banner is showing on the production environment on /delta/set-password, /delta/register/success, and /delta/forgot-password pages

**Local testing** 
Visually checked the following pages locally after amending the `isProduction = Env.getRequiredOrDevFallback("ENVIRONMENT", "") != "production"` in DeltaConfig.kt
http://localhost:8088/delta/set-password
http://localhost:8088/delta/register/success
http://localhost:8088/delta/forgot-password

**Release**
