### PR TITLE
Otel sidecar revert

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     environment: publish
     env:
       AWS_REGION: "eu-west-1"
-      VERSION: "23.3"
+      VERSION: "23.4"
       REPOSITORY: "delta-auth-service"
       ECR_PATH: "468442790030.dkr.ecr.eu-west-1.amazonaws.com"
     outputs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
   # AWS OpenTelemetry collector for sending traces to AWS X-Ray
   # In hosted environments this runs as a sidecar in ECS
   telemetry:
-    image: amazon/aws-otel-collector:latest
+    image: amazon/aws-otel-collector:v0.43.2
     command: [ "--config=/etc/otel-agent-config.yaml" ]
     env_file:
       # Should contain AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY, or equivalent session credentials

--- a/terraform/modules/fargate/ecs.tf
+++ b/terraform/modules/fargate/ecs.tf
@@ -85,7 +85,7 @@ resource "aws_ecs_task_definition" "main" {
     var.enable_adot_sidecar ? [{
       name : "aws-otel-collector"
       # Requires a pull through cache to be configured for ecr-public
-      image : "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/ecr-public/aws-observability/aws-otel-collector:v0.43.3"
+      image : "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/ecr-public/aws-observability/aws-otel-collector:v0.43.2"
       command : [""]
       essential : true
       environment = [

--- a/terraform/modules/fargate/ecs.tf
+++ b/terraform/modules/fargate/ecs.tf
@@ -85,7 +85,7 @@ resource "aws_ecs_task_definition" "main" {
     var.enable_adot_sidecar ? [{
       name : "aws-otel-collector"
       # Requires a pull through cache to be configured for ecr-public
-      image : "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/ecr-public/aws-observability/aws-otel-collector:latest"
+      image : "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/ecr-public/aws-observability/aws-otel-collector:v0.43.3"
       command : [""]
       essential : true
       environment = [

--- a/terraform/staging/.terraform.lock.hcl
+++ b/terraform/staging/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "5.72.1"
   hashes = [
     "h1:ZSJLLwInUKiZ1fHNduFkIXJDXbLy5t4wZ6hFH1Lz1fE=",
+    "h1:jhd5O5o0CfZCNEwwN0EiDAzb7ApuFrtxJqa6HXW4EKE=",
     "zh:0dea6843836e926d33469b48b948744079023816d16a2ff7666bcfb6aa3522d4",
     "zh:195fa9513f75800a0d62797ebec75ee73e9b8c28d713fe9b63d3b1d1eec129b3",
     "zh:1ed92f3961715bf0e024bcde3c12dfbdc50b00c1f8a43cc00802cfc45a256208",
@@ -26,6 +27,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.2.3"
   hashes = [
+    "h1:I0Um8UkrMUb81Fxq/dxbr3HLP2cecTH2WMJiwKSrwQY=",
     "h1:zxoDtu918XPWJ/Y6s4aFrZydn6SfqkRc5Ax1ZLnC6Ew=",
     "zh:22d062e5278d872fe7aed834f5577ba0a5afe34a3bdac2b81f828d8d3e6706d2",
     "zh:23dead00493ad863729495dc212fd6c29b8293e707b055ce5ba21ee453ce552d",
@@ -46,6 +48,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version = "3.6.3"
   hashes = [
     "h1:+UItZOLue/moJfnI3tqZBQbXUYR4ZnqPYfJDJPgLZy0=",
+    "h1:zG9uFP8l9u+yGZZvi5Te7PV62j50azpgwPunq2vTm1E=",
     "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
     "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
     "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",


### PR DESCRIPTION
43.3 and 44 of otel-sidecar probably have malformed TLS packets, either omitting the SNI or providing the wrong one (I assume, I cannot get onto the otel-sidecar container to run a packet inspector and the AWS firewall TLS logs only log TLS if it is malformed in a way where it cannot be sent at all rather than just triggering our firewall rule), 43.2 does not so we revert to that.